### PR TITLE
Add Csr device view

### DIFF
--- a/benchmark/sparse_blas/operations.cpp
+++ b/benchmark/sparse_blas/operations.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -575,7 +575,8 @@ bool validate_symbolic_factorization(const Mtx* input, const Mtx* factors)
     const auto exec = factors->get_executor();
     bool valid = false;
     exec->run(make_symbolic_validate(
-        input, factors, gko::matrix::csr::build_lookup(factors), valid));
+        input->get_const_device_view(), factors->get_const_device_view(),
+        gko::matrix::csr::build_lookup(factors), valid));
     return valid;
 }
 

--- a/common/cuda_hip/factorization/cholesky_kernels.cpp
+++ b/common/cuda_hip/factorization/cholesky_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -235,24 +235,24 @@ __global__ __launch_bounds__(default_block_size) void factorize(
 template <typename ValueType, typename IndexType>
 void symbolic_factorize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
     const factorization::elimination_forest<IndexType>& forest,
-    matrix::Csr<ValueType, IndexType>* l_factor,
+    matrix::view::csr<ValueType, IndexType> l_factor,
     const array<IndexType>& tmp_storage)
 {
-    const auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
+    const auto num_rows = static_cast<IndexType>(mtx.size[0]);
     if (num_rows == 0) {
         return;
     }
-    const auto mtx_nnz = static_cast<IndexType>(mtx->get_num_stored_elements());
+    const auto mtx_nnz = static_cast<IndexType>(mtx.num_stored_elements);
     const auto postorder_cols = tmp_storage.get_const_data();
     const auto lower_ends = postorder_cols + mtx_nnz;
-    const auto row_ptrs = mtx->get_const_row_ptrs();
+    const auto row_ptrs = mtx.row_ptrs;
     const auto postorder = forest.postorder.get_const_data();
     const auto inv_postorder = forest.inv_postorder.get_const_data();
     const auto postorder_parent = forest.postorder_parents.get_const_data();
-    const auto out_row_ptrs = l_factor->get_const_row_ptrs();
-    const auto out_cols = l_factor->get_col_idxs();
+    const auto out_row_ptrs = l_factor.row_ptrs;
+    const auto out_cols = l_factor.col_idxs;
     const auto num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     kernel::symbolic_factorize<config::warp_size>
@@ -267,25 +267,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
+                matrix::view::csr<const ValueType, const IndexType> mtx,
                 const IndexType* factor_lookup_offsets,
                 const int64* factor_lookup_descs,
                 const int32* factor_lookup_storage, IndexType* diag_idxs,
                 IndexType* transpose_idxs,
-                matrix::Csr<ValueType, IndexType>* factors)
+                matrix::view::csr<ValueType, IndexType> factors)
 {
     lu_factorization::initialize(exec, mtx, factor_lookup_offsets,
                                  factor_lookup_descs, factor_lookup_storage,
                                  diag_idxs, factors);
     // convert to COO
-    const auto nnz = factors->get_num_stored_elements();
+    const auto nnz = factors.num_stored_elements;
     array<IndexType> row_idx_array{exec, nnz};
     array<IndexType> col_idx_array{exec, nnz};
     const auto row_idxs = row_idx_array.get_data();
     const auto col_idxs = col_idx_array.get_data();
-    exec->copy(nnz, factors->get_const_col_idxs(), col_idxs);
-    components::convert_ptrs_to_idxs(exec, factors->get_const_row_ptrs(),
-                                     factors->get_size()[0], row_idxs);
+    exec->copy(nnz, factors.col_idxs, col_idxs);
+    components::convert_ptrs_to_idxs(exec, factors.row_ptrs, factors.size[0],
+                                     row_idxs);
     components::fill_seq_array(exec, transpose_idxs, nnz);
     // compute nonzero permutation for sparse transpose
     // to profit from cub/rocPRIM's fast radix sort, we do it in two steps
@@ -304,10 +304,10 @@ void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const int32* lookup_storage, const IndexType* diag_idxs,
                const IndexType* transpose_idxs,
                const factorization::elimination_forest<IndexType>& forest,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage)
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage)
 {
-    const auto num_rows = factors->get_size()[0];
+    const auto num_rows = factors.size[0];
     if (num_rows > 0) {
         syncfree_storage storage(exec, tmp_storage, num_rows);
         const auto num_blocks =
@@ -315,17 +315,15 @@ void factorize(std::shared_ptr<const DefaultExecutor> exec,
         if (!full_fillin) {
             kernel::factorize<false>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    factors->get_const_row_ptrs(),
-                    factors->get_const_col_idxs(), lookup_offsets,
+                    factors.row_ptrs, factors.col_idxs, lookup_offsets,
                     lookup_storage, lookup_descs, diag_idxs, transpose_idxs,
-                    as_device_type(factors->get_values()), storage, num_rows);
+                    as_device_type(factors.values), storage, num_rows);
         } else {
             kernel::factorize<true>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    factors->get_const_row_ptrs(),
-                    factors->get_const_col_idxs(), lookup_offsets,
+                    factors.row_ptrs, factors.col_idxs, lookup_offsets,
                     lookup_storage, lookup_descs, diag_idxs, transpose_idxs,
-                    as_device_type(factors->get_values()), storage, num_rows);
+                    as_device_type(factors.values), storage, num_rows);
         }
     }
 }
@@ -335,20 +333,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CHOLESKY_FACTORIZE);
 
 template <typename ValueType, typename IndexType>
 void symbolic_count(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* mtx,
+                    matrix::view::csr<const ValueType, const IndexType> mtx,
                     const factorization::elimination_forest<IndexType>& forest,
                     IndexType* row_nnz, array<IndexType>& tmp_storage)
 {
-    const auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
+    const auto num_rows = static_cast<IndexType>(mtx.size[0]);
     if (num_rows == 0) {
         return;
     }
-    const auto mtx_nnz = static_cast<IndexType>(mtx->get_num_stored_elements());
+    const auto mtx_nnz = static_cast<IndexType>(mtx.num_stored_elements);
     tmp_storage.resize_and_reset(mtx_nnz + num_rows);
     const auto postorder_cols = tmp_storage.get_data();
     const auto lower_ends = postorder_cols + mtx_nnz;
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto cols = mtx->get_const_col_idxs();
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto cols = mtx.col_idxs;
     const auto inv_postorder = forest.inv_postorder.get_const_data();
     const auto postorder_parent = forest.postorder_parents.get_const_data();
     // transform col indices to postorder indices

--- a/common/cuda_hip/factorization/elimination_forest_kernels.cpp
+++ b/common/cuda_hip/factorization/elimination_forest_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -334,15 +334,14 @@ void build_children_from_parents(
 
 template <typename ValueType, typename IndexType>
 void from_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* factors,
+                 matrix::view::csr<const ValueType, const IndexType> factors,
                  gko::factorization::elimination_forest<IndexType>& forest)
 {
-    const auto num_rows = factors->get_size()[0];
+    const auto num_rows = factors.size[0];
     const auto it = thrust::make_counting_iterator(IndexType{});
     thrust::transform(
         thrust_policy(exec), it, it + num_rows, forest.parents.get_data(),
-        [row_ptrs = factors->get_const_row_ptrs(),
-         col_idxs = factors->get_const_col_idxs(),
+        [row_ptrs = factors.row_ptrs, col_idxs = factors.col_idxs,
          num_rows] __device__(IndexType l_col) {
             const auto llt_row_begin = row_ptrs[l_col];
             const auto llt_row_end = row_ptrs[l_col + 1];

--- a/common/cuda_hip/factorization/factorization_kernels.cpp
+++ b/common/cuda_hip/factorization/factorization_kernels.cpp
@@ -434,10 +434,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const auto block_size = default_block_size;
     const uint32 number_blocks =
@@ -447,10 +447,8 @@ void initialize_row_ptrs_l_u(
     if (grid_dim > 0) {
         kernel::count_nnz_per_l_u_row<<<grid_dim, block_size, 0,
                                         exec->get_stream()>>>(
-            num_rows, system_matrix->get_const_row_ptrs(),
-            system_matrix->get_const_col_idxs(),
-            as_device_type(system_matrix->get_const_values()), l_row_ptrs,
-            u_row_ptrs);
+            num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+            as_device_type(system_matrix.values), l_row_ptrs, u_row_ptrs);
     }
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
@@ -462,12 +460,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const auto block_size = helpers::default_block_size;
     const auto grid_dim = static_cast<uint32>(
         ceildiv(num_rows, static_cast<size_type>(block_size)));
@@ -480,13 +479,11 @@ void initialize_l_u(std::shared_ptr<const DefaultExecutor> exec,
         auto u_closure = triangular_mtx_closure(identity{}, identity{});
         helpers::
             initialize_l_u<<<grid_dim, block_size, 0, exec->get_stream()>>>(
-                num_rows, system_matrix->get_const_row_ptrs(),
-                system_matrix->get_const_col_idxs(),
-                as_device_type(system_matrix->get_const_values()),
-                csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-                as_device_type(csr_l->get_values()),
-                csr_u->get_const_row_ptrs(), csr_u->get_col_idxs(),
-                as_device_type(csr_u->get_values()), l_closure, u_closure);
+                num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+                as_device_type(system_matrix.values), csr_l.row_ptrs,
+                csr_l.col_idxs, as_device_type(csr_l.values), csr_u.row_ptrs,
+                csr_u.col_idxs, as_device_type(csr_u.values), l_closure,
+                u_closure);
     }
 }
 
@@ -497,10 +494,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const auto block_size = default_block_size;
     const uint32 number_blocks =
@@ -510,9 +507,8 @@ void initialize_row_ptrs_l(
     if (grid_dim > 0) {
         kernel::count_nnz_per_l_row<<<grid_dim, block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, system_matrix->get_const_row_ptrs(),
-            system_matrix->get_const_col_idxs(),
-            as_device_type(system_matrix->get_const_values()), l_row_ptrs);
+            num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+            as_device_type(system_matrix.values), l_row_ptrs);
     }
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
@@ -523,11 +519,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const auto block_size = helpers::default_block_size;
     const auto grid_dim = static_cast<uint32>(
         ceildiv(num_rows, static_cast<size_type>(block_size)));
@@ -536,11 +533,9 @@ void initialize_l(std::shared_ptr<const DefaultExecutor> exec,
         using namespace gko::factorization;
 
         helpers::initialize_l<<<grid_dim, block_size, 0, exec->get_stream()>>>(
-            num_rows, system_matrix->get_const_row_ptrs(),
-            system_matrix->get_const_col_idxs(),
-            as_device_type(system_matrix->get_const_values()),
-            csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-            as_device_type(csr_l->get_values()),
+            num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+            as_device_type(system_matrix.values), csr_l.row_ptrs,
+            csr_l.col_idxs, as_device_type(csr_l.values),
             triangular_mtx_closure(
                 [diag_sqrt] __device__(auto val) {
                     if (diag_sqrt) {
@@ -562,18 +557,18 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup, bool& valid)
 {
-    const auto size = system_matrix->get_size()[0];
-    const auto row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto factor_col_idxs = factors->get_const_col_idxs();
+    const auto size = system_matrix.size[0];
+    const auto row_ptrs = system_matrix.row_ptrs;
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto factor_col_idxs = factors.col_idxs;
     // this stores for each factor nonzero whether it occurred as part of the
     // factorization.
-    array<bool> found(exec, factors->get_num_stored_elements());
+    array<bool> found(exec, factors.num_stored_elements);
     components::fill_array(exec, found.get_data(), found.get_size(), false);
     // this stores for each row whether there were any elements missing
     array<bool> missing(exec, size);

--- a/common/cuda_hip/factorization/factorization_kernels.cpp
+++ b/common/cuda_hip/factorization/factorization_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -434,10 +434,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const auto block_size = default_block_size;
     const uint32 number_blocks =
@@ -447,10 +447,8 @@ void initialize_row_ptrs_l_u(
     if (grid_dim > 0) {
         kernel::count_nnz_per_l_u_row<<<grid_dim, block_size, 0,
                                         exec->get_stream()>>>(
-            num_rows, system_matrix->get_const_row_ptrs(),
-            system_matrix->get_const_col_idxs(),
-            as_device_type(system_matrix->get_const_values()), l_row_ptrs,
-            u_row_ptrs);
+            num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+            as_device_type(system_matrix.values), l_row_ptrs, u_row_ptrs);
     }
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
@@ -462,12 +460,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const auto block_size = helpers::default_block_size;
     const auto grid_dim = static_cast<uint32>(
         ceildiv(num_rows, static_cast<size_type>(block_size)));
@@ -480,13 +479,11 @@ void initialize_l_u(std::shared_ptr<const DefaultExecutor> exec,
         auto u_closure = triangular_mtx_closure(identity{}, identity{});
         helpers::
             initialize_l_u<<<grid_dim, block_size, 0, exec->get_stream()>>>(
-                num_rows, system_matrix->get_const_row_ptrs(),
-                system_matrix->get_const_col_idxs(),
-                as_device_type(system_matrix->get_const_values()),
-                csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-                as_device_type(csr_l->get_values()),
-                csr_u->get_const_row_ptrs(), csr_u->get_col_idxs(),
-                as_device_type(csr_u->get_values()), l_closure, u_closure);
+                num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+                as_device_type(system_matrix.values), csr_l.row_ptrs,
+                csr_l.col_idxs, as_device_type(csr_l.values), csr_u.row_ptrs,
+                csr_u.col_idxs, as_device_type(csr_u.values), l_closure,
+                u_closure);
     }
 }
 
@@ -497,10 +494,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const auto block_size = default_block_size;
     const uint32 number_blocks =
@@ -510,9 +507,8 @@ void initialize_row_ptrs_l(
     if (grid_dim > 0) {
         kernel::count_nnz_per_l_row<<<grid_dim, block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, system_matrix->get_const_row_ptrs(),
-            system_matrix->get_const_col_idxs(),
-            as_device_type(system_matrix->get_const_values()), l_row_ptrs);
+            num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+            as_device_type(system_matrix.values), l_row_ptrs);
     }
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
@@ -523,11 +519,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const auto block_size = helpers::default_block_size;
     const auto grid_dim = static_cast<uint32>(
         ceildiv(num_rows, static_cast<size_type>(block_size)));
@@ -536,11 +533,9 @@ void initialize_l(std::shared_ptr<const DefaultExecutor> exec,
         using namespace gko::factorization;
 
         helpers::initialize_l<<<grid_dim, block_size, 0, exec->get_stream()>>>(
-            num_rows, system_matrix->get_const_row_ptrs(),
-            system_matrix->get_const_col_idxs(),
-            as_device_type(system_matrix->get_const_values()),
-            csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-            as_device_type(csr_l->get_values()),
+            num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+            as_device_type(system_matrix.values), csr_l.row_ptrs,
+            csr_l.col_idxs, as_device_type(csr_l.values),
             triangular_mtx_closure(
                 [diag_sqrt] __device__(auto val) {
                     if (diag_sqrt) {
@@ -562,18 +557,18 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup, bool& valid)
 {
-    const auto size = system_matrix->get_size()[0];
-    const auto row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto factor_col_idxs = factors->get_const_col_idxs();
+    const auto size = system_matrix.size[0];
+    const auto row_ptrs = system_matrix.row_ptrs;
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto factor_col_idxs = factors.col_idxs;
     // this stores for each factor nonzero whether it occurred as part of the
     // factorization.
-    array<bool> found(exec, factors->get_num_stored_elements());
+    array<bool> found(exec, factors.num_stored_elements);
     components::fill_array(exec, found.get_data(), found.get_size(), false);
     // this stores for each row whether there were any elements missing
     array<bool> missing(exec, size);

--- a/common/cuda_hip/factorization/ic_kernels.cpp
+++ b/common/cuda_hip/factorization/ic_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,7 +18,7 @@ namespace ic_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ic(std::shared_ptr<const DefaultExecutor> exec,
-                  matrix::Csr<ValueType, IndexType>* m)
+                  matrix::view::csr<ValueType, IndexType> m)
 {
     const auto id = exec->get_device_id();
     auto handle = exec->get_sparselib_handle();
@@ -26,24 +26,22 @@ void sparselib_ic(std::shared_ptr<const DefaultExecutor> exec,
     auto info = sparselib::create_ic0_info();
 
     // get buffer size for IC
-    IndexType num_rows = m->get_size()[0];
-    IndexType nnz = m->get_num_stored_elements();
+    IndexType num_rows = m.size[0];
+    IndexType nnz = m.num_stored_elements;
     size_type buffer_size{};
-    sparselib::ic0_buffer_size(handle, num_rows, nnz, desc,
-                               m->get_const_values(), m->get_const_row_ptrs(),
-                               m->get_const_col_idxs(), info, buffer_size);
+    sparselib::ic0_buffer_size(handle, num_rows, nnz, desc, m.values,
+                               m.row_ptrs, m.col_idxs, info, buffer_size);
 
     array<char> buffer{exec, buffer_size};
 
     // set up IC(0)
-    sparselib::ic0_analysis(handle, num_rows, nnz, desc, m->get_const_values(),
-                            m->get_const_row_ptrs(), m->get_const_col_idxs(),
-                            info, SPARSELIB_SOLVE_POLICY_USE_LEVEL,
+    sparselib::ic0_analysis(handle, num_rows, nnz, desc, m.values, m.row_ptrs,
+                            m.col_idxs, info, SPARSELIB_SOLVE_POLICY_USE_LEVEL,
                             buffer.get_data());
 
-    sparselib::ic0(handle, num_rows, nnz, desc, m->get_values(),
-                   m->get_const_row_ptrs(), m->get_const_col_idxs(), info,
-                   SPARSELIB_SOLVE_POLICY_USE_LEVEL, buffer.get_data());
+    sparselib::ic0(handle, num_rows, nnz, desc, m.values, m.row_ptrs,
+                   m.col_idxs, info, SPARSELIB_SOLVE_POLICY_USE_LEVEL,
+                   buffer.get_data());
 
     // CUDA 11.4 has a use-after-free bug on Turing
 #if defined(GKO_COMPILING_CUDA) && (CUDA_VERSION >= 11040)

--- a/common/cuda_hip/factorization/ilu_kernels.cpp
+++ b/common/cuda_hip/factorization/ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,7 +18,7 @@ namespace ilu_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ilu(std::shared_ptr<const DefaultExecutor> exec,
-                   matrix::Csr<ValueType, IndexType>* m)
+                   matrix::view::csr<ValueType, IndexType> m)
 {
     const auto id = exec->get_device_id();
     auto handle = exec->get_sparselib_handle();
@@ -26,24 +26,22 @@ void sparselib_ilu(std::shared_ptr<const DefaultExecutor> exec,
     auto info = sparselib::create_ilu0_info();
 
     // get buffer size for ILU
-    IndexType num_rows = m->get_size()[0];
-    IndexType nnz = m->get_num_stored_elements();
+    IndexType num_rows = m.size[0];
+    IndexType nnz = m.num_stored_elements;
     size_type buffer_size{};
-    sparselib::ilu0_buffer_size(handle, num_rows, nnz, desc,
-                                m->get_const_values(), m->get_const_row_ptrs(),
-                                m->get_const_col_idxs(), info, buffer_size);
+    sparselib::ilu0_buffer_size(handle, num_rows, nnz, desc, m.values,
+                                m.row_ptrs, m.col_idxs, info, buffer_size);
 
     array<char> buffer{exec, buffer_size};
 
     // set up ILU(0)
-    sparselib::ilu0_analysis(handle, num_rows, nnz, desc, m->get_const_values(),
-                             m->get_const_row_ptrs(), m->get_const_col_idxs(),
-                             info, SPARSELIB_SOLVE_POLICY_USE_LEVEL,
+    sparselib::ilu0_analysis(handle, num_rows, nnz, desc, m.values, m.row_ptrs,
+                             m.col_idxs, info, SPARSELIB_SOLVE_POLICY_USE_LEVEL,
                              buffer.get_data());
 
-    sparselib::ilu0(handle, num_rows, nnz, desc, m->get_values(),
-                    m->get_const_row_ptrs(), m->get_const_col_idxs(), info,
-                    SPARSELIB_SOLVE_POLICY_USE_LEVEL, buffer.get_data());
+    sparselib::ilu0(handle, num_rows, nnz, desc, m.values, m.row_ptrs,
+                    m.col_idxs, info, SPARSELIB_SOLVE_POLICY_USE_LEVEL,
+                    buffer.get_data());
 
     // CUDA 11.4 has a use-after-free bug on Turing
 #if defined(GKO_COMPILING_CUDA) && (CUDA_VERSION >= 11040)

--- a/common/cuda_hip/factorization/lu_kernels.cpp
+++ b/common/cuda_hip/factorization/lu_kernels.cpp
@@ -239,23 +239,22 @@ __global__ __launch_bounds__(default_block_size) void symbolic_factorize_simple(
 
 template <typename ValueType, typename IndexType>
 void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
+                matrix::view::csr<const ValueType, const IndexType> mtx,
                 const IndexType* factor_lookup_offsets,
                 const int64* factor_lookup_descs,
                 const int32* factor_lookup_storage, IndexType* diag_idxs,
-                matrix::Csr<ValueType, IndexType>* factors)
+                matrix::view::csr<ValueType, IndexType> factors)
 {
-    const auto num_rows = mtx->get_size()[0];
+    const auto num_rows = mtx.size[0];
     if (num_rows > 0) {
         const auto num_blocks =
             ceildiv(num_rows, default_block_size / config::warp_size);
         kernel::initialize<<<num_blocks, default_block_size, 0,
                              exec->get_stream()>>>(
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            as_device_type(mtx->get_const_values()),
-            factors->get_const_row_ptrs(), factors->get_const_col_idxs(),
-            factor_lookup_offsets, factor_lookup_storage, factor_lookup_descs,
-            as_device_type(factors->get_values()), diag_idxs, num_rows);
+            mtx.row_ptrs, mtx.col_idxs, as_device_type(mtx.values),
+            factors.row_ptrs, factors.col_idxs, factor_lookup_offsets,
+            factor_lookup_storage, factor_lookup_descs,
+            as_device_type(factors.values), diag_idxs, num_rows);
     }
 }
 
@@ -266,10 +265,10 @@ template <typename ValueType, typename IndexType>
 void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const IndexType* lookup_offsets, const int64* lookup_descs,
                const int32* lookup_storage, const IndexType* diag_idxs,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage)
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage)
 {
-    const auto num_rows = factors->get_size()[0];
+    const auto num_rows = factors.size[0];
     if (num_rows > 0) {
         syncfree_storage storage(exec, tmp_storage, num_rows);
         const auto num_blocks =
@@ -277,17 +276,15 @@ void factorize(std::shared_ptr<const DefaultExecutor> exec,
         if (full_fillin) {
             kernel::factorize<true>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    factors->get_const_row_ptrs(),
-                    factors->get_const_col_idxs(), lookup_offsets,
+                    factors.row_ptrs, factors.col_idxs, lookup_offsets,
                     lookup_storage, lookup_descs, diag_idxs,
-                    as_device_type(factors->get_values()), storage, num_rows);
+                    as_device_type(factors.values), storage, num_rows);
         } else {
             kernel::factorize<false>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    factors->get_const_row_ptrs(),
-                    factors->get_const_col_idxs(), lookup_offsets,
+                    factors.row_ptrs, factors.col_idxs, lookup_offsets,
                     lookup_storage, lookup_descs, diag_idxs,
-                    as_device_type(factors->get_values()), storage, num_rows);
+                    as_device_type(factors.values), storage, num_rows);
         }
     }
 }
@@ -300,12 +297,12 @@ void symbolic_factorize_simple(
     std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_ptrs,
     const IndexType* col_idxs, const IndexType* lookup_offsets,
     const int64* lookup_descs, const int32* lookup_storage,
-    matrix::Csr<float, IndexType>* factors, IndexType* out_row_nnz)
+    matrix::view::csr<float, IndexType> factors, IndexType* out_row_nnz)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto factor_cols = factors->get_const_col_idxs();
-    const auto factor_vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto factor_cols = factors.col_idxs;
+    const auto factor_vals = factors.values;
     array<IndexType> diag_idx_array{exec, num_rows};
     array<int> tmp_storage{exec};
     const auto diag_idxs = diag_idx_array.get_data();
@@ -345,16 +342,17 @@ struct return_second_functor {
 template <typename IndexType>
 void symbolic_factorize_simple_finalize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<float, IndexType>* factors, IndexType* out_col_idxs)
+    matrix::view::csr<const float, const IndexType> factors,
+    IndexType* out_col_idxs)
 {
-    const auto col_idxs = factors->get_const_col_idxs();
-    const auto vals = factors->get_const_values();
+    const auto col_idxs = factors.col_idxs;
+    const auto vals = factors.values;
     const auto input_it =
         thrust::make_zip_iterator(thrust::make_tuple(vals, col_idxs));
     const auto output_it = thrust::make_transform_output_iterator(
         out_col_idxs, return_second_functor{});
     thrust::copy_if(thrust_policy(exec), input_it,
-                    input_it + factors->get_num_stored_elements(), output_it,
+                    input_it + factors.num_stored_elements, output_it,
                     first_eq_one_functor{});
 }
 

--- a/common/cuda_hip/factorization/lu_kernels.cpp
+++ b/common/cuda_hip/factorization/lu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -238,23 +238,22 @@ __global__ __launch_bounds__(default_block_size) void symbolic_factorize_simple(
 
 template <typename ValueType, typename IndexType>
 void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
+                matrix::view::csr<const ValueType, const IndexType> mtx,
                 const IndexType* factor_lookup_offsets,
                 const int64* factor_lookup_descs,
                 const int32* factor_lookup_storage, IndexType* diag_idxs,
-                matrix::Csr<ValueType, IndexType>* factors)
+                matrix::view::csr<ValueType, IndexType> factors)
 {
-    const auto num_rows = mtx->get_size()[0];
+    const auto num_rows = mtx.size[0];
     if (num_rows > 0) {
         const auto num_blocks =
             ceildiv(num_rows, default_block_size / config::warp_size);
         kernel::initialize<<<num_blocks, default_block_size, 0,
                              exec->get_stream()>>>(
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            as_device_type(mtx->get_const_values()),
-            factors->get_const_row_ptrs(), factors->get_const_col_idxs(),
-            factor_lookup_offsets, factor_lookup_storage, factor_lookup_descs,
-            as_device_type(factors->get_values()), diag_idxs, num_rows);
+            mtx.row_ptrs, mtx.col_idxs, as_device_type(mtx.values),
+            factors.row_ptrs, factors.col_idxs, factor_lookup_offsets,
+            factor_lookup_storage, factor_lookup_descs,
+            as_device_type(factors.values), diag_idxs, num_rows);
     }
 }
 
@@ -265,10 +264,10 @@ template <typename ValueType, typename IndexType>
 void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const IndexType* lookup_offsets, const int64* lookup_descs,
                const int32* lookup_storage, const IndexType* diag_idxs,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage)
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage)
 {
-    const auto num_rows = factors->get_size()[0];
+    const auto num_rows = factors.size[0];
     if (num_rows > 0) {
         syncfree_storage storage(exec, tmp_storage, num_rows);
         const auto num_blocks =
@@ -276,17 +275,15 @@ void factorize(std::shared_ptr<const DefaultExecutor> exec,
         if (full_fillin) {
             kernel::factorize<true>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    factors->get_const_row_ptrs(),
-                    factors->get_const_col_idxs(), lookup_offsets,
+                    factors.row_ptrs, factors.col_idxs, lookup_offsets,
                     lookup_storage, lookup_descs, diag_idxs,
-                    as_device_type(factors->get_values()), storage, num_rows);
+                    as_device_type(factors.values), storage, num_rows);
         } else {
             kernel::factorize<false>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    factors->get_const_row_ptrs(),
-                    factors->get_const_col_idxs(), lookup_offsets,
+                    factors.row_ptrs, factors.col_idxs, lookup_offsets,
                     lookup_storage, lookup_descs, diag_idxs,
-                    as_device_type(factors->get_values()), storage, num_rows);
+                    as_device_type(factors.values), storage, num_rows);
         }
     }
 }
@@ -299,12 +296,12 @@ void symbolic_factorize_simple(
     std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_ptrs,
     const IndexType* col_idxs, const IndexType* lookup_offsets,
     const int64* lookup_descs, const int32* lookup_storage,
-    matrix::Csr<float, IndexType>* factors, IndexType* out_row_nnz)
+    matrix::view::csr<float, IndexType> factors, IndexType* out_row_nnz)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto factor_cols = factors->get_const_col_idxs();
-    const auto factor_vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto factor_cols = factors.col_idxs;
+    const auto factor_vals = factors.values;
     array<IndexType> diag_idx_array{exec, num_rows};
     array<int> tmp_storage{exec};
     const auto diag_idxs = diag_idx_array.get_data();
@@ -344,16 +341,17 @@ struct return_second_functor {
 template <typename IndexType>
 void symbolic_factorize_simple_finalize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<float, IndexType>* factors, IndexType* out_col_idxs)
+    matrix::view::csr<const float, const IndexType> factors,
+    IndexType* out_col_idxs)
 {
-    const auto col_idxs = factors->get_const_col_idxs();
-    const auto vals = factors->get_const_values();
+    const auto col_idxs = factors.col_idxs;
+    const auto vals = factors.values;
     const auto input_it =
         thrust::make_zip_iterator(thrust::make_tuple(vals, col_idxs));
     const auto output_it = thrust::make_transform_output_iterator(
         out_col_idxs, return_second_functor{});
     thrust::copy_if(thrust_policy(exec), input_it,
-                    input_it + factors->get_num_stored_elements(), output_it,
+                    input_it + factors.num_stored_elements, output_it,
                     first_eq_one_functor{});
 }
 

--- a/common/cuda_hip/factorization/par_ic_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ic_kernels.cpp
@@ -96,12 +96,12 @@ __global__ __launch_bounds__(default_block_size) void ic_sweep(
 
 template <typename ValueType, typename IndexType>
 void init_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 matrix::Csr<ValueType, IndexType>* l)
+                 matrix::view::csr<ValueType, IndexType> l)
 {
-    auto num_rows = l->get_size()[0];
+    auto num_rows = l.size[0];
     auto num_blocks = ceildiv(num_rows, default_block_size);
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_vals = l->get_values();
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_vals = l.values;
     if (num_blocks > 0) {
         kernel::
             ic_init<<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
@@ -117,9 +117,9 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type iterations,
                     matrix::view::coo<const ValueType, const IndexType> a_lower,
-                    matrix::Csr<ValueType, IndexType>* l)
+                    matrix::view::csr<ValueType, IndexType> l)
 {
-    auto nnz = l->get_num_stored_elements();
+    auto nnz = l.num_stored_elements;
     auto num_blocks = ceildiv(nnz, default_block_size);
     if (num_blocks > 0) {
 #ifdef GKO_COMPILING_HIP
@@ -133,9 +133,9 @@ void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                 kernel::ic_sweep<<<num_blocks, default_block_size, 0,
                                    exec->get_stream()>>>(
                     a_lower.row_idxs, a_lower.col_idxs,
-                    as_device_type(a_lower.values), l->get_const_row_ptrs(),
-                    l->get_const_col_idxs(), as_device_type(l->get_values()),
-                    static_cast<IndexType>(l->get_num_stored_elements()));
+                    as_device_type(a_lower.values), l.row_ptrs, l.col_idxs,
+                    as_device_type(l.values),
+                    static_cast<IndexType>(l.num_stored_elements));
             }
         }
     }

--- a/common/cuda_hip/factorization/par_ict_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ict_kernels.cpp
@@ -328,24 +328,24 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
-    auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(llh.size[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     auto l_new = l_new_builder->get_matrix();
-    auto llh_row_ptrs = llh->get_const_row_ptrs();
-    auto llh_col_idxs = llh->get_const_col_idxs();
-    auto llh_vals = llh->get_const_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
+    auto llh_row_ptrs = llh.row_ptrs;
+    auto llh_col_idxs = llh.col_idxs;
+    auto llh_vals = llh.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     // count non-zeros per row
     if (num_blocks > 0) {
@@ -384,11 +384,11 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 template <int subwarp_size, typename ValueType, typename IndexType>
 void compute_factor(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements());
+    auto total_nnz = static_cast<IndexType>(l.num_stored_elements);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(total_nnz, block_size);
     if (num_blocks > 0) {
@@ -401,11 +401,10 @@ void compute_factor(syn::value_list<int, subwarp_size>,
         {
             kernel::ict_sweep<subwarp_size>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    a->get_const_row_ptrs(), a->get_const_col_idxs(),
-                    as_device_type(a->get_const_values()),
-                    l->get_const_row_ptrs(), l_coo.row_idxs,
-                    l->get_const_col_idxs(), as_device_type(l->get_values()),
-                    static_cast<IndexType>(l->get_num_stored_elements()));
+                    a.row_ptrs, a.col_idxs, as_device_type(a.values),
+                    l.row_ptrs, l_coo.row_idxs, l.col_idxs,
+                    as_device_type(l.values),
+                    static_cast<IndexType>(l.num_stored_elements));
         }
     }
 }
@@ -419,14 +418,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_factor, compute_factor);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        llh->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = llh.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),
@@ -444,12 +442,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = 2 * l->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = 2 * l.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_compute_factor(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ict_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ict_kernels.cpp
@@ -328,21 +328,21 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> llh,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* llh,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = static_cast<IndexType>(llh.size[0]);
+    auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
-    auto llh_row_ptrs = llh.row_ptrs;
-    auto llh_col_idxs = llh.col_idxs;
-    auto llh_vals = llh.values;
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto a_vals = a.values;
+    auto llh_row_ptrs = llh->get_const_row_ptrs();
+    auto llh_col_idxs = llh->get_const_col_idxs();
+    auto llh_vals = llh->get_const_values();
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto a_vals = a->get_const_values();
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = l.values;
@@ -418,13 +418,14 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_factor, compute_factor);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> llh,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* llh,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a.size[0];
-    auto total_nnz = llh.num_stored_elements + a.num_stored_elements;
+    auto num_rows = a->get_size()[0];
+    auto total_nnz =
+        llh->get_num_stored_elements() + a->get_num_stored_elements();
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ict_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ict_kernels.cpp
@@ -328,24 +328,24 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(llh.size[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
-    auto llh_row_ptrs = llh->get_const_row_ptrs();
-    auto llh_col_idxs = llh->get_const_col_idxs();
-    auto llh_vals = llh->get_const_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
+    auto llh_row_ptrs = llh.row_ptrs;
+    auto llh_col_idxs = llh.col_idxs;
+    auto llh_vals = llh.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     // count non-zeros per row
     if (num_blocks > 0) {
@@ -384,11 +384,11 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 template <int subwarp_size, typename ValueType, typename IndexType>
 void compute_factor(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements());
+    auto total_nnz = static_cast<IndexType>(l.num_stored_elements);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(total_nnz, block_size);
     if (num_blocks > 0) {
@@ -401,11 +401,10 @@ void compute_factor(syn::value_list<int, subwarp_size>,
         {
             kernel::ict_sweep<subwarp_size>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    a->get_const_row_ptrs(), a->get_const_col_idxs(),
-                    as_device_type(a->get_const_values()),
-                    l->get_const_row_ptrs(), l_coo.row_idxs,
-                    l->get_const_col_idxs(), as_device_type(l->get_values()),
-                    static_cast<IndexType>(l->get_num_stored_elements()));
+                    a.row_ptrs, a.col_idxs, as_device_type(a.values),
+                    l.row_ptrs, l_coo.row_idxs, l.col_idxs,
+                    as_device_type(l.values),
+                    static_cast<IndexType>(l.num_stored_elements));
         }
     }
 }
@@ -419,14 +418,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_factor, compute_factor);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        llh->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = llh.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),
@@ -443,12 +441,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = 2 * l->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = 2 * l.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_compute_factor(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilu_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilu_kernels.cpp
@@ -83,8 +83,8 @@ template <typename ValueType, typename IndexType>
 void compute_l_u_factors(
     std::shared_ptr<const DefaultExecutor> exec, size_type iterations,
     matrix::view::coo<const ValueType, const IndexType> system_matrix,
-    matrix::Csr<ValueType, IndexType>* l_factor,
-    matrix::Csr<ValueType, IndexType>* u_factor)
+    matrix::view::csr<ValueType, IndexType> l_factor,
+    matrix::view::csr<ValueType, IndexType> u_factor)
 {
     iterations = (iterations == 0) ? 10 : iterations;
     const auto num_elements = system_matrix.num_stored_elements;
@@ -104,13 +104,10 @@ void compute_l_u_factors(
                                               exec->get_stream()>>>(
                     num_elements, system_matrix.row_idxs,
                     system_matrix.col_idxs,
-                    as_device_type(system_matrix.values),
-                    l_factor->get_const_row_ptrs(),
-                    l_factor->get_const_col_idxs(),
-                    as_device_type(l_factor->get_values()),
-                    u_factor->get_const_row_ptrs(),
-                    u_factor->get_const_col_idxs(),
-                    as_device_type(u_factor->get_values()));
+                    as_device_type(system_matrix.values), l_factor.row_ptrs,
+                    l_factor.col_idxs, as_device_type(l_factor.values),
+                    u_factor.row_ptrs, u_factor.col_idxs,
+                    as_device_type(u_factor.values));
             }
         }
     }

--- a/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
@@ -51,13 +51,13 @@ template <int subwarp_size, typename ValueType, typename IndexType>
 void threshold_filter_approx(
     syn::value_list<int, subwarp_size>,
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>* tmp, remove_complex<ValueType>* threshold,
     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
     matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     using AbsType = remove_complex<ValueType>;
     constexpr auto bucket_count = kernel::searchtree_width;
     auto max_num_threads = ceildiv(size, items_per_thread);
@@ -98,11 +98,11 @@ void threshold_filter_approx(
     }
 
     // filter the elements
-    auto old_row_ptrs = m->get_const_row_ptrs();
-    auto old_col_idxs = m->get_const_col_idxs();
-    auto old_vals = m->get_const_values();
+    auto old_row_ptrs = m.row_ptrs;
+    auto old_col_idxs = m.col_idxs;
+    auto old_vals = m.values;
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(m->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(m.size[0]);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto m_out = m_out_builder->get_matrix();
@@ -150,13 +150,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter_approx,
 template <typename ValueType, typename IndexType>
 void threshold_filter_approx(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
     matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto num_rows = m->get_size()[0];
-    auto total_nnz = m->get_num_stored_elements();
+    auto num_rows = m.size[0];
+    auto total_nnz = m.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter_approx(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
@@ -48,16 +48,16 @@ using compiled_kernels =
 
 
 template <int subwarp_size, typename ValueType, typename IndexType>
-void threshold_filter_approx(syn::value_list<int, subwarp_size>,
-                             std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>* tmp,
-                             remove_complex<ValueType>* threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    syn::value_list<int, subwarp_size>,
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
+    array<ValueType>* tmp, remove_complex<ValueType>* threshold,
+    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     using AbsType = remove_complex<ValueType>;
     constexpr auto bucket_count = kernel::searchtree_width;
     auto max_num_threads = ceildiv(size, items_per_thread);
@@ -98,11 +98,11 @@ void threshold_filter_approx(syn::value_list<int, subwarp_size>,
     }
 
     // filter the elements
-    auto old_row_ptrs = m->get_const_row_ptrs();
-    auto old_col_idxs = m->get_const_col_idxs();
-    auto old_vals = m->get_const_values();
+    auto old_row_ptrs = m.row_ptrs;
+    auto old_col_idxs = m.col_idxs;
+    auto old_vals = m.values;
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(m->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(m.size[0]);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto new_row_ptrs = m_out->get_row_ptrs();
@@ -148,15 +148,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter_approx,
 
 
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto num_rows = m->get_size()[0];
-    auto total_nnz = m->get_num_stored_elements();
+    auto num_rows = m.size[0];
+    auto total_nnz = m.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter_approx(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
@@ -47,16 +47,16 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void threshold_filter(syn::value_list<int, subwarp_size>,
                       std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto old_row_ptrs = a->get_const_row_ptrs();
-    auto old_col_idxs = a->get_const_col_idxs();
-    auto old_vals = a->get_const_values();
+    auto old_row_ptrs = a.row_ptrs;
+    auto old_col_idxs = a.col_idxs;
+    auto old_vals = a.values;
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(a->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(a.size[0]);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto m_out = m_out_builder->get_matrix();
@@ -105,13 +105,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter, threshold_filter);
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
@@ -47,16 +47,16 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void threshold_filter(syn::value_list<int, subwarp_size>,
                       std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto old_row_ptrs = a->get_const_row_ptrs();
-    auto old_col_idxs = a->get_const_col_idxs();
-    auto old_vals = a->get_const_values();
+    auto old_row_ptrs = a.row_ptrs;
+    auto old_col_idxs = a.col_idxs;
+    auto old_vals = a.values;
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(a->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(a.size[0]);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto new_row_ptrs = m_out->get_row_ptrs();
@@ -105,13 +105,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter, threshold_filter);
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilut_select_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_select_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -55,13 +55,13 @@ void sampleselect_filter(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp1,
                       array<remove_complex<ValueType>>& tmp2,
                       remove_complex<ValueType>& threshold)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     using AbsType = remove_complex<ValueType>;
     constexpr auto bucket_count = kernel::searchtree_width;
     auto max_num_threads = ceildiv(size, items_per_thread);

--- a/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
@@ -296,30 +296,30 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
                     matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
-    auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(lu.size[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     auto l_new = l_new_builder->get_matrix();
     auto u_new = u_new_builder->get_matrix();
-    auto lu_row_ptrs = lu->get_const_row_ptrs();
-    auto lu_col_idxs = lu->get_const_col_idxs();
-    auto lu_vals = lu->get_const_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_const_values();
+    auto lu_row_ptrs = lu.row_ptrs;
+    auto lu_col_idxs = lu.col_idxs;
+    auto lu_vals = lu.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     if (num_blocks > 0) {
@@ -369,16 +369,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
                     matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        lu->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = lu.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -296,30 +296,30 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(lu.size[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
     matrix::CsrBuilder<ValueType, IndexType> u_new_builder(u_new);
-    auto lu_row_ptrs = lu->get_const_row_ptrs();
-    auto lu_col_idxs = lu->get_const_col_idxs();
-    auto lu_vals = lu->get_const_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_const_values();
+    auto lu_row_ptrs = lu.row_ptrs;
+    auto lu_col_idxs = lu.col_idxs;
+    auto lu_vals = lu.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     if (num_blocks > 0) {
@@ -369,16 +369,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        lu->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = lu.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
@@ -296,24 +296,24 @@ namespace {
 template <int subwarp_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subwarp_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> lu,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* lu,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = static_cast<IndexType>(lu.size[0]);
+    auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
     matrix::CsrBuilder<ValueType, IndexType> u_new_builder(u_new);
-    auto lu_row_ptrs = lu.row_ptrs;
-    auto lu_col_idxs = lu.col_idxs;
-    auto lu_vals = lu.values;
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto a_vals = a.values;
+    auto lu_row_ptrs = lu->get_const_row_ptrs();
+    auto lu_col_idxs = lu->get_const_col_idxs();
+    auto lu_vals = lu->get_const_values();
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto a_vals = a->get_const_values();
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = l.values;
@@ -369,15 +369,16 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> lu,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* lu,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a.size[0];
-    auto total_nnz = lu.num_stored_elements + a.num_stored_elements;
+    auto num_rows = a->get_size()[0];
+    auto total_nnz =
+        lu->get_num_stored_elements() + a->get_num_stored_elements();
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/common/cuda_hip/factorization/par_ilut_sweep_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_sweep_kernels.cpp
@@ -144,15 +144,15 @@ template <int subwarp_size, typename ValueType, typename IndexType>
 void compute_l_u_factors(
     syn::value_list<int, subwarp_size>,
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
-    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<ValueType, IndexType> l,
     matrix::view::coo<const ValueType, const IndexType> l_coo,
-    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::csr<ValueType, IndexType> u,
     matrix::view::coo<const ValueType, const IndexType> u_coo,
-    matrix::Csr<ValueType, IndexType>* u_csc)
+    matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements() +
-                                            u->get_num_stored_elements());
+    auto total_nnz =
+        static_cast<IndexType>(l.num_stored_elements + u.num_stored_elements);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(total_nnz, block_size);
     if (num_blocks > 0) {
@@ -165,16 +165,14 @@ void compute_l_u_factors(
         {
             kernel::sweep<subwarp_size>
                 <<<num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                    a->get_const_row_ptrs(), a->get_const_col_idxs(),
-                    as_device_type(a->get_const_values()),
-                    l->get_const_row_ptrs(), l_coo.row_idxs,
-                    l->get_const_col_idxs(), as_device_type(l->get_values()),
-                    static_cast<IndexType>(l->get_num_stored_elements()),
-                    u_coo.row_idxs, u_coo.col_idxs,
-                    as_device_type(u->get_values()),
-                    u_csc->get_const_row_ptrs(), u_csc->get_const_col_idxs(),
-                    as_device_type(u_csc->get_values()),
-                    static_cast<IndexType>(u->get_num_stored_elements()));
+                    a.row_ptrs, a.col_idxs, as_device_type(a.values),
+                    l.row_ptrs, l_coo.row_idxs, l.col_idxs,
+                    as_device_type(l.values),
+                    static_cast<IndexType>(l.num_stored_elements),
+                    u_coo.row_idxs, u_coo.col_idxs, as_device_type(u.values),
+                    u_csc.row_ptrs, u_csc.col_idxs,
+                    as_device_type(u_csc.values),
+                    static_cast<IndexType>(u.num_stored_elements));
         }
     }
 }
@@ -189,16 +187,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_l_u_factors,
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
-    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<ValueType, IndexType> l,
     matrix::view::coo<const ValueType, const IndexType> l_coo,
-    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::csr<ValueType, IndexType> u,
     matrix::view::coo<const ValueType, const IndexType> u_coo,
-    matrix::Csr<ValueType, IndexType>* u_csc)
+    matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        l->get_num_stored_elements() + u->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = l.num_stored_elements + u.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_compute_l_u_factors(
         compiled_kernels(),

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -1399,14 +1399,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_spgeam, spgeam);
 template <typename ValueType, typename IndexType>
 void spgeam(std::shared_ptr<const DefaultExecutor> exec,
             matrix::view::dense<const ValueType> alpha,
-            const matrix::Csr<ValueType, IndexType>* a,
+            matrix::view::csr<const ValueType, const IndexType> a,
             matrix::view::dense<const ValueType> beta,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto total_nnz =
-        a->get_num_stored_elements() + b->get_num_stored_elements();
-    auto nnz_per_row = a->get_size()[0] ? total_nnz / a->get_size()[0] : 0;
+    auto total_nnz = a.num_stored_elements + b.num_stored_elements;
+    auto nnz_per_row = a.size[0] ? total_nnz / a.size[0] : 0;
     select_spgeam(
         spgeam_kernels(),
         [&](int compiled_subwarp_size) {
@@ -1414,9 +1413,8 @@ void spgeam(std::shared_ptr<const DefaultExecutor> exec,
                    compiled_subwarp_size == config::warp_size;
         },
         syn::value_list<int>(), syn::type_list<>(), exec, alpha.values,
-        a->get_const_row_ptrs(), a->get_const_col_idxs(), a->get_const_values(),
-        beta.values, b->get_const_row_ptrs(), b->get_const_col_idxs(),
-        b->get_const_values(), c_builder);
+        a.row_ptrs, a.col_idxs, a.values, beta.values, b.row_ptrs, b.col_idxs,
+        b.values, c_builder);
 }
 
 
@@ -1927,7 +1925,7 @@ template <int items_per_thread, typename MatrixValueType,
 void merge_path_spmv(
     syn::value_list<int, items_per_thread>,
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1939,7 +1937,7 @@ void merge_path_spmv(
 {
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
-    const IndexType total = a->get_size()[0] + a->get_num_stored_elements();
+    const IndexType total = a.size[0] + a.num_stored_elements;
     const IndexType grid_num =
         ceildiv(total, spmv_block_size * items_per_thread);
     const auto grid = grid_num;
@@ -1949,8 +1947,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -1965,10 +1963,9 @@ void merge_path_spmv(
             if (grid_num > 0) {
                 kernel::abstract_merge_path_spmv<items_per_thread>
                     <<<grid, block, 0, exec->get_stream()>>>(
-                        static_cast<IndexType>(a->get_size()[0]),
-                        acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                        as_device_type(a->get_const_row_ptrs()),
-                        as_device_type(a->get_const_srow()),
+                        static_cast<IndexType>(a.size[0]),
+                        acc::as_device_range(a_vals), a.col_idxs,
+                        as_device_type(a.row_ptrs), as_device_type(a.srow),
                         acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals),
                         as_device_type(row_out.get_data()),
@@ -1984,11 +1981,10 @@ void merge_path_spmv(
             if (grid_num > 0) {
                 kernel::abstract_merge_path_spmv<items_per_thread>
                     <<<grid, block, 0, exec->get_stream()>>>(
-                        static_cast<IndexType>(a->get_size()[0]),
+                        static_cast<IndexType>(a.size[0]),
                         as_device_type(alpha->values),
-                        acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                        as_device_type(a->get_const_row_ptrs()),
-                        as_device_type(a->get_const_srow()),
+                        acc::as_device_range(a_vals), a.col_idxs,
+                        as_device_type(a.row_ptrs), as_device_type(a.srow),
                         acc::as_device_range(b_vals),
                         as_device_type(beta->values),
                         acc::as_device_range(c_vals),
@@ -2126,7 +2122,7 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 bool load_balance_spmv(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -2160,13 +2156,12 @@ bool load_balance_spmv(
         } else {
             dense::fill(exec, c, zero<OutputValueType>());
         }
-        const IndexType nwarps = a->get_num_srow_elements();
+        const IndexType nwarps = a.num_srow_elements;
         if (nwarps > 0) {
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(
-                    a->get_const_device_view());
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -2174,11 +2169,10 @@ bool load_balance_spmv(
                 if (csr_grid.x > 0 && csr_grid.y > 0) {
                     kernel::abstract_spmv<<<csr_grid, csr_block, 0,
                                             exec->get_stream()>>>(
-                        nwarps, static_cast<IndexType>(a->get_size()[0]),
+                        nwarps, static_cast<IndexType>(a.size[0]),
                         as_device_type(alpha->values),
-                        acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                        as_device_type(a->get_const_row_ptrs()),
-                        as_device_type(a->get_const_srow()),
+                        acc::as_device_range(a_vals), a.col_idxs,
+                        as_device_type(a.row_ptrs), as_device_type(a.srow),
                         acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
@@ -2186,10 +2180,9 @@ bool load_balance_spmv(
                 if (csr_grid.x > 0 && csr_grid.y > 0) {
                     kernel::abstract_spmv<<<csr_grid, csr_block, 0,
                                             exec->get_stream()>>>(
-                        nwarps, static_cast<IndexType>(a->get_size()[0]),
-                        acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                        as_device_type(a->get_const_row_ptrs()),
-                        as_device_type(a->get_const_srow()),
+                        nwarps, static_cast<IndexType>(a.size[0]),
+                        acc::as_device_range(a_vals), a.col_idxs,
+                        as_device_type(a.row_ptrs), as_device_type(a.srow),
                         acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
@@ -2341,7 +2334,7 @@ template <typename MatrixValueType, typename InputValueType,
 void spmv(std::shared_ptr<const DefaultExecutor> exec,
           const matrix::csr::spmv_strategy strategy,
           const IndexType max_nnz_per_row,
-          const matrix::Csr<MatrixValueType, IndexType>* a,
+          matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
 {
@@ -2349,7 +2342,7 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
         // empty output: nothing to do
         return;
     }
-    if (b.size[0] == 0 || a->get_num_stored_elements() == 0) {
+    if (b.size[0] == 0 || a.num_stored_elements == 0) {
         // empty input: zero output
         dense::fill(exec, c, zero<OutputValueType>());
         return;
@@ -2371,8 +2364,7 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -2380,8 +2372,7 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
         }
     }
 }
@@ -2393,7 +2384,7 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                    const matrix::csr::spmv_strategy strategy,
                    const IndexType max_nnz_per_row,
                    matrix::view::dense<const MatrixValueType> alpha,
-                   const matrix::Csr<MatrixValueType, IndexType>* a,
+                   matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,
                    matrix::view::dense<const OutputValueType> beta,
                    matrix::view::dense<OutputValueType> c)
@@ -2402,7 +2393,7 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
         // empty output: nothing to do
         return;
     }
-    if (b.size[0] == 0 || a->get_num_stored_elements() == 0) {
+    if (b.size[0] == 0 || a.num_stored_elements == 0) {
         // empty input: scale output
         dense::scale(exec, beta, c);
         return;
@@ -2426,8 +2417,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c, alpha, beta);
+            use_classical =
+                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -2435,8 +2426,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c, alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
+                alpha, beta);
         }
     }
 }
@@ -2444,8 +2435,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const DefaultExecutor> exec,
-            const matrix::Csr<ValueType, IndexType>* a,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> a,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto c = c_builder->get_matrix();
@@ -2460,20 +2451,20 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
         auto info = sparselib::create_spgemm_info();
 
         auto alpha = one<ValueType>();
-        auto a_nnz = static_cast<IndexType>(a->get_num_stored_elements());
-        auto a_vals = a->get_const_values();
-        auto a_row_ptrs = a->get_const_row_ptrs();
-        auto a_col_idxs = a->get_const_col_idxs();
-        auto b_nnz = static_cast<IndexType>(b->get_num_stored_elements());
-        auto b_vals = b->get_const_values();
-        auto b_row_ptrs = b->get_const_row_ptrs();
-        auto b_col_idxs = b->get_const_col_idxs();
+        auto a_nnz = static_cast<IndexType>(a.num_stored_elements);
+        auto a_vals = a.values;
+        auto a_row_ptrs = a.row_ptrs;
+        auto a_col_idxs = a.col_idxs;
+        auto b_nnz = static_cast<IndexType>(b.num_stored_elements);
+        auto b_vals = b.values;
+        auto b_row_ptrs = b.row_ptrs;
+        auto b_col_idxs = b.col_idxs;
         auto null_value = static_cast<ValueType*>(nullptr);
         auto null_index = static_cast<IndexType*>(nullptr);
         auto zero_nnz = IndexType{};
-        auto m = static_cast<IndexType>(a->get_size()[0]);
-        auto n = static_cast<IndexType>(b->get_size()[1]);
-        auto k = static_cast<IndexType>(a->get_size()[1]);
+        auto m = static_cast<IndexType>(a.size[0]);
+        auto n = static_cast<IndexType>(b.size[1]);
+        auto k = static_cast<IndexType>(a.size[1]);
         auto c_row_ptrs = c->get_row_ptrs();
         auto& c_col_idxs_array = c_builder->get_col_idx_array();
         auto& c_vals_array = c_builder->get_value_array();
@@ -2514,26 +2505,26 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
         GKO_NOT_IMPLEMENTED;
     }
 #else   // GKO_COMPILING_CUDA
-    auto a_vals = a->get_const_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto b_vals = b->get_const_values();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
+    auto a_vals = a.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto b_vals = b.values;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
     auto c_row_ptrs = c->get_row_ptrs();
 
     auto handle = exec->get_sparselib_handle();
     sparselib::pointer_mode_guard pm_guard(handle);
 
     auto alpha = one<ValueType>();
-    auto a_nnz = static_cast<IndexType>(a->get_num_stored_elements());
-    auto b_nnz = static_cast<IndexType>(b->get_num_stored_elements());
+    auto a_nnz = static_cast<IndexType>(a.num_stored_elements);
+    auto b_nnz = static_cast<IndexType>(b.num_stored_elements);
     auto null_value = static_cast<ValueType*>(nullptr);
     auto null_index = static_cast<IndexType*>(nullptr);
     auto zero_nnz = IndexType{};
-    auto m = IndexType(a->get_size()[0]);
-    auto n = IndexType(b->get_size()[1]);
-    auto k = IndexType(a->get_size()[1]);
+    auto m = IndexType(a.size[0]);
+    auto n = IndexType(b.size[1]);
+    auto k = IndexType(a.size[1]);
     auto& c_col_idxs_array = c_builder->get_col_idx_array();
     auto& c_vals_array = c_builder->get_value_array();
 
@@ -2591,10 +2582,10 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
                      matrix::view::dense<const ValueType> alpha,
-                     const matrix::Csr<ValueType, IndexType>* a,
-                     const matrix::Csr<ValueType, IndexType>* b,
+                     matrix::view::csr<const ValueType, const IndexType> a,
+                     matrix::view::csr<const ValueType, const IndexType> b,
                      matrix::view::dense<const ValueType> beta,
-                     const matrix::Csr<ValueType, IndexType>* d,
+                     matrix::view::csr<const ValueType, const IndexType> d,
                      matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto c = c_builder->get_matrix();
@@ -2608,23 +2599,23 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
         auto d_descr = sparselib::create_mat_descr();
         auto info = sparselib::create_spgemm_info();
 
-        auto a_nnz = static_cast<IndexType>(a->get_num_stored_elements());
-        auto a_vals = a->get_const_values();
-        auto a_row_ptrs = a->get_const_row_ptrs();
-        auto a_col_idxs = a->get_const_col_idxs();
-        auto b_nnz = static_cast<IndexType>(b->get_num_stored_elements());
-        auto b_vals = b->get_const_values();
-        auto b_row_ptrs = b->get_const_row_ptrs();
-        auto b_col_idxs = b->get_const_col_idxs();
-        auto d_vals = d->get_const_values();
-        auto d_row_ptrs = d->get_const_row_ptrs();
-        auto d_col_idxs = d->get_const_col_idxs();
+        auto a_nnz = static_cast<IndexType>(a.num_stored_elements);
+        auto a_vals = a.values;
+        auto a_row_ptrs = a.row_ptrs;
+        auto a_col_idxs = a.col_idxs;
+        auto b_nnz = static_cast<IndexType>(b.num_stored_elements);
+        auto b_vals = b.values;
+        auto b_row_ptrs = b.row_ptrs;
+        auto b_col_idxs = b.col_idxs;
+        auto d_vals = d.values;
+        auto d_row_ptrs = d.row_ptrs;
+        auto d_col_idxs = d.col_idxs;
         auto null_value = static_cast<ValueType*>(nullptr);
         auto null_index = static_cast<IndexType*>(nullptr);
         auto one_value = one<ValueType>();
-        auto m = static_cast<IndexType>(a->get_size()[0]);
-        auto n = static_cast<IndexType>(b->get_size()[1]);
-        auto k = static_cast<IndexType>(a->get_size()[1]);
+        auto m = static_cast<IndexType>(a.size[0]);
+        auto n = static_cast<IndexType>(b.size[1]);
+        auto k = static_cast<IndexType>(a.size[1]);
 
         // allocate buffer
         size_type buffer_size{};
@@ -2663,7 +2654,7 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
         sparselib::destroy(b_descr);
         sparselib::destroy(a_descr);
 
-        auto total_nnz = c_nnz + d->get_num_stored_elements();
+        auto total_nnz = c_nnz + d.num_stored_elements;
         auto nnz_per_row = total_nnz / m;
         select_spgeam(
             spgeam_kernels(),
@@ -2682,22 +2673,22 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
     sparselib::pointer_mode_guard pm_guard(handle);
 
     auto valpha = exec->copy_val_to_host(alpha.values);
-    auto a_nnz = IndexType(a->get_num_stored_elements());
-    auto a_vals = a->get_const_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto b_nnz = IndexType(b->get_num_stored_elements());
-    auto b_vals = b->get_const_values();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
+    auto a_nnz = IndexType(a.num_stored_elements);
+    auto a_vals = a.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto b_nnz = IndexType(b.num_stored_elements);
+    auto b_vals = b.values;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
     auto vbeta = exec->copy_val_to_host(beta.values);
-    auto d_nnz = IndexType(d->get_num_stored_elements());
-    auto d_vals = d->get_const_values();
-    auto d_row_ptrs = d->get_const_row_ptrs();
-    auto d_col_idxs = d->get_const_col_idxs();
-    auto m = IndexType(a->get_size()[0]);
-    auto n = IndexType(b->get_size()[1]);
-    auto k = IndexType(a->get_size()[1]);
+    auto d_nnz = IndexType(d.num_stored_elements);
+    auto d_vals = d.values;
+    auto d_row_ptrs = d.row_ptrs;
+    auto d_col_idxs = d.col_idxs;
+    auto m = IndexType(a.size[0]);
+    auto n = IndexType(b.size[1]);
+    auto k = IndexType(a.size[1]);
 
     auto null_value = static_cast<ValueType*>(nullptr);
     auto null_index = static_cast<IndexType*>(nullptr);
@@ -2753,7 +2744,7 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
     sparselib::destroy(a_descr);
     sparselib::destroy(spgemm_descr);
 
-    auto spgeam_total_nnz = c_tmp_nnz + d->get_num_stored_elements();
+    auto spgeam_total_nnz = c_tmp_nnz + d.num_stored_elements;
     auto nnz_per_row = spgeam_total_nnz / m;
     select_spgeam(
         spgeam_kernels(),

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -1069,21 +1069,20 @@ __global__ __launch_bounds__(default_block_size) void add_scaled_identity(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& block_row_ptr_array,
-                      array<IndexType>& block_col_idx_array,
-                      array<ValueType>& block_value_array)
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& block_row_ptr_array,
+    array<IndexType>& block_col_idx_array, array<ValueType>& block_value_array)
 {
     using tuple_type = thrust::tuple<IndexType, IndexType>;
-    const auto nnz = source->get_num_stored_elements();
+    const auto nnz = source.num_stored_elements;
     array<IndexType> in_row_idxs{exec, nnz};
     array<IndexType> in_col_idxs{exec, nnz};
     array<ValueType> in_values{exec, nnz};
-    exec->copy(nnz, source->get_const_col_idxs(), in_col_idxs.get_data());
-    exec->copy(nnz, source->get_const_values(), in_values.get_data());
-    components::convert_ptrs_to_idxs(exec, source->get_const_row_ptrs(),
-                                     source->get_size()[0],
+    exec->copy(nnz, source.col_idxs, in_col_idxs.get_data());
+    exec->copy(nnz, source.values, in_values.get_data());
+    components::convert_ptrs_to_idxs(exec, source.row_ptrs, source.size[0],
                                      in_row_idxs.get_data());
     auto block_row_ptrs = block_row_ptr_array.get_data();
     auto num_block_rows = block_row_ptr_array.get_size() - 1;
@@ -1456,14 +1455,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_spgeam_numeric, spgeam_numeric);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
-    auto total_nnz =
-        a->get_num_stored_elements() + b->get_num_stored_elements();
-    auto nnz_per_row = a->get_size()[0] ? total_nnz / a->get_size()[0] : 0;
+    auto total_nnz = a.num_stored_elements + b.num_stored_elements;
+    auto nnz_per_row = a.size[0] ? total_nnz / a.size[0] : 0;
     select_spgeam_numeric(
         spgeam_kernels(),
         [&](int compiled_subwarp_size) {
@@ -1471,24 +1469,22 @@ void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,
                    compiled_subwarp_size == config::warp_size;
         },
         syn::value_list<int>(), syn::type_list<>(), exec, alpha.values,
-        a->get_const_row_ptrs(), a->get_const_col_idxs(), a->get_const_values(),
-        beta.values, b->get_const_row_ptrs(), b->get_const_col_idxs(),
-        b->get_const_values(), c->get_const_row_ptrs(), c->get_values(),
-        a->get_size()[0]);
+        a.row_ptrs, a.col_idxs, a.values, beta.values, b.row_ptrs, b.col_idxs,
+        b.values, c.row_ptrs, c.values, a.size[0]);
 }
 
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
     const auto num_rows = result.size[0];
     const auto num_cols = result.size[1];
     const auto stride = result.stride;
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto vals = source->get_const_values();
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
+    const auto vals = source.values;
 
     auto grid_dim = ceildiv(num_rows, default_block_size);
     if (grid_dim > 0) {
@@ -1503,59 +1499,52 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const DefaultExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_symm_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                num_rows, perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,
-                         const IndexType* row_perm, const IndexType* col_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_perm,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, row_perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, row_perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_nonsymm_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, row_perm, col_perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                num_rows, row_perm, col_perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
@@ -1563,29 +1552,26 @@ void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const DefaultExecutor> exec,
                  const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                   exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::row_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), row_permuted.row_ptrs,
+                row_permuted.col_idxs, as_device_type(row_permuted.values));
     }
 }
 
@@ -1593,93 +1579,82 @@ void row_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const DefaultExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_row_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), row_permuted.row_ptrs,
+                row_permuted.col_idxs, as_device_type(row_permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_symm_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, as_device_type(scale), perm,
-                orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                num_rows, as_device_type(scale), perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, row_perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, row_perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_nonsymm_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
                 num_rows, as_device_type(row_scale), row_perm,
-                as_device_type(col_scale), col_perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                as_device_type(col_scale), col_perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
@@ -1687,59 +1662,56 @@ void inv_nonsymm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                   exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::row_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, as_device_type(scale), perm,
-                orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, as_device_type(scale), perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values),
+                row_permuted.row_ptrs, row_permuted.col_idxs,
+                as_device_type(row_permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_row_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, as_device_type(scale), perm,
-                orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, as_device_type(scale), perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values),
+                row_permuted.row_ptrs, row_permuted.col_idxs,
+                as_device_type(row_permuted.values));
     }
 }
 
@@ -1747,12 +1719,12 @@ void inv_row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
-    const auto num_rows = source->get_size()[0];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
+    const auto num_rows = source.size[0];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
     auto grid_dim = ceildiv(row_span.length(), default_block_size);
     if (grid_dim > 0) {
         kernel::calculate_nnz_per_row_in_span<<<grid_dim, default_block_size, 0,
@@ -1764,27 +1736,25 @@ void calculate_nonzeros_per_row_in_span(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     auto row_offset = row_span.begin;
     auto col_offset = col_span.begin;
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto row_ptrs = source->get_const_row_ptrs();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto row_ptrs = source.row_ptrs;
     auto grid_dim = ceildiv(num_rows, default_block_size);
     if (grid_dim > 0) {
         kernel::compute_submatrix_idxs_and_vals<<<grid_dim, default_block_size,
                                                   0, exec->get_stream()>>>(
             num_rows, num_cols, row_offset, col_offset,
-            as_device_type(source->get_const_row_ptrs()),
-            as_device_type(source->get_const_col_idxs()),
-            as_device_type(source->get_const_values()),
-            as_device_type(result->get_const_row_ptrs()),
-            as_device_type(result->get_col_idxs()),
-            as_device_type(result->get_values()));
+            as_device_type(source.row_ptrs), as_device_type(source.col_idxs),
+            as_device_type(source.values), as_device_type(result.row_ptrs),
+            as_device_type(result.col_idxs), as_device_type(result.values));
     }
 }
 
@@ -1792,7 +1762,7 @@ void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
     IndexType* row_nnz) GKO_NOT_IMPLEMENTED;
@@ -1801,26 +1771,27 @@ void calculate_nonzeros_per_row_in_index_set(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result) GKO_NOT_IMPLEMENTED;
+    matrix::view::csr<ValueType, IndexType> result) GKO_NOT_IMPLEMENTED;
 
 
 template <typename ValueType, typename IndexType>
-void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
-                        const matrix::Csr<ValueType, IndexType>* input,
-                        matrix::Csr<ValueType, IndexType>* output)
+void fallback_transpose(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> output)
 {
-    const auto in_num_rows = input->get_size()[0];
-    const auto out_num_rows = output->get_size()[0];
-    const auto nnz = output->get_num_stored_elements();
-    const auto in_row_ptrs = input->get_const_row_ptrs();
-    const auto in_col_idxs = input->get_const_col_idxs();
-    const auto in_vals = as_device_type(input->get_const_values());
-    const auto out_row_ptrs = output->get_row_ptrs();
-    const auto out_col_idxs = output->get_col_idxs();
-    const auto out_vals = as_device_type(output->get_values());
+    const auto in_num_rows = input.size[0];
+    const auto out_num_rows = output.size[0];
+    const auto nnz = output.num_stored_elements;
+    const auto in_row_ptrs = input.row_ptrs;
+    const auto in_col_idxs = input.col_idxs;
+    const auto in_vals = as_device_type(input.values);
+    const auto out_row_ptrs = output.row_ptrs;
+    const auto out_col_idxs = output.col_idxs;
+    const auto out_vals = as_device_type(output.values);
     array<IndexType> out_row_idxs{exec, nnz};
     components::convert_ptrs_to_idxs(exec, in_row_ptrs, in_num_rows,
                                      out_col_idxs);
@@ -1836,13 +1807,13 @@ void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void fallback_sort(std::shared_ptr<const DefaultExecutor> exec,
-                   matrix::Csr<ValueType, IndexType>* to_sort)
+                   matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    const auto row_ptrs = to_sort->get_const_row_ptrs();
-    const auto col_idxs = to_sort->get_col_idxs();
-    const auto vals = as_device_type(to_sort->get_values());
-    const auto nnz = to_sort->get_num_stored_elements();
-    const auto num_rows = to_sort->get_size()[0];
+    const auto row_ptrs = to_sort.row_ptrs;
+    const auto col_idxs = to_sort.col_idxs;
+    const auto vals = as_device_type(to_sort.values);
+    const auto nnz = to_sort.num_stored_elements;
+    const auto num_rows = to_sort.size[0];
     array<IndexType> row_idx_array(exec, nnz);
     const auto row_idxs = row_idx_array.get_data();
     components::convert_ptrs_to_idxs(exec, row_ptrs, num_rows, row_idxs);
@@ -1861,20 +1832,21 @@ void fallback_sort(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
     is_sorted = true;
     auto gpu_array = array<bool>{exec, 1};
     // need to initialize the GPU value to true
     exec->copy_from(exec->get_master(), 1, &is_sorted, gpu_array.get_data());
     auto block_size = default_block_size;
-    auto num_rows = static_cast<IndexType>(to_check->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(to_check.size[0]);
     auto num_blocks = ceildiv(num_rows, block_size);
     if (num_blocks > 0) {
         kernel::
             check_unsorted<<<num_blocks, block_size, 0, exec->get_stream()>>>(
-                to_check->get_const_row_ptrs(), to_check->get_const_col_idxs(),
-                num_rows, gpu_array.get_data());
+                to_check.row_ptrs, to_check.col_idxs, num_rows,
+                gpu_array.get_data());
     }
     is_sorted = get_element(gpu_array, 0);
 }
@@ -1882,17 +1854,17 @@ void is_sorted_by_column_index(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto nnz = orig->get_num_stored_elements();
+    const auto nnz = orig.num_stored_elements;
     const auto diag_size = diag->get_size()[0];
     const auto num_blocks =
         ceildiv(config::warp_size * diag_size, default_block_size);
 
-    const auto orig_values = orig->get_const_values();
-    const auto orig_row_ptrs = orig->get_const_row_ptrs();
-    const auto orig_col_idxs = orig->get_const_col_idxs();
+    const auto orig_values = orig.values;
+    const auto orig_row_ptrs = orig.row_ptrs;
+    const auto orig_col_idxs = orig.col_idxs;
     auto diag_values = diag->get_values();
     if (num_blocks > 0) {
         kernel::extract_diagonal<<<num_blocks, default_block_size, 0,
@@ -1905,20 +1877,20 @@ void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const DefaultExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
-    const auto num_diag = static_cast<IndexType>(
-        std::min(mtx->get_size()[0], mtx->get_size()[1]));
+    const auto num_diag =
+        static_cast<IndexType>(std::min(mtx.size[0], mtx.size[1]));
     if (num_diag > 0) {
         const IndexType num_blocks =
             ceildiv(num_diag, default_block_size / config::warp_size);
         array<bool> has_diags(exec, {true});
         kernel::check_diagonal_entries<<<num_blocks, default_block_size, 0,
                                          exec->get_stream()>>>(
-            num_diag, mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            has_diags.get_data());
+            num_diag, mtx.row_ptrs, mtx.col_idxs, has_diags.get_data());
         has_all_diags = get_element(has_diags, 0);
     } else {
         has_all_diags = true;
@@ -1930,9 +1902,9 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const DefaultExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = mtx->get_size()[0];
+    const auto nrows = mtx.size[0];
     if (nrows == 0) {
         return;
     }
@@ -1941,8 +1913,8 @@ void add_scaled_identity(std::shared_ptr<const DefaultExecutor> exec,
     kernel::add_scaled_identity<<<nblocks, default_block_size, 0,
                                   exec->get_stream()>>>(
         as_device_type(alpha.values), as_device_type(beta.values),
-        static_cast<IndexType>(nrows), mtx->get_const_row_ptrs(),
-        mtx->get_const_col_idxs(), as_device_type(mtx->get_values()));
+        static_cast<IndexType>(nrows), mtx.row_ptrs, mtx.col_idxs,
+        as_device_type(mtx.values));
 }
 
 
@@ -1977,8 +1949,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -2098,7 +2070,7 @@ template <int subwarp_size, typename MatrixValueType, typename InputValueType,
 void classical_spmv(
     syn::value_list<int, subwarp_size>,
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -2115,7 +2087,7 @@ void classical_spmv(
                         exec->get_num_multiprocessor() *
                         classical_oversubscription;
     const auto gridx =
-        std::min(ceildiv(a->get_size()[0], spmv_block_size / subwarp_size),
+        std::min(ceildiv(a.size[0], spmv_block_size / subwarp_size),
                  int64(nwarps / warps_in_block));
     const dim3 grid(gridx, b.size[1]);
     const auto block = spmv_block_size;
@@ -2129,20 +2101,18 @@ void classical_spmv(
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subwarp_size>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    a->get_size()[0], acc::as_device_range(a_vals),
-                    a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_ptrs()),
-                    acc::as_device_range(b_vals), acc::as_device_range(c_vals));
+                    a.size[0], acc::as_device_range(a_vals), a.col_idxs,
+                    as_device_type(a.row_ptrs), acc::as_device_range(b_vals),
+                    acc::as_device_range(c_vals));
         }
     } else if (alpha && beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subwarp_size>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    a->get_size()[0], as_device_type(alpha->values),
-                    acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_ptrs()),
-                    acc::as_device_range(b_vals), as_device_type(beta->values),
-                    acc::as_device_range(c_vals));
+                    a.size[0], as_device_type(alpha->values),
+                    acc::as_device_range(a_vals), a.col_idxs,
+                    as_device_type(a.row_ptrs), acc::as_device_range(b_vals),
+                    as_device_type(beta->values), acc::as_device_range(c_vals));
         }
     } else {
         GKO_KERNEL_NOT_FOUND;
@@ -2195,7 +2165,8 @@ bool load_balance_spmv(
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(
+                    a->get_const_device_view());
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -2230,29 +2201,27 @@ bool load_balance_spmv(
 
 
 template <typename ValueType, typename IndexType>
-bool try_general_sparselib_spmv(std::shared_ptr<const DefaultExecutor> exec,
-                                const ValueType* alpha,
-                                const matrix::Csr<ValueType, IndexType>* a,
-                                matrix::view::dense<const ValueType> b,
-                                const ValueType* beta,
-                                matrix::view::dense<ValueType> c)
+bool try_general_sparselib_spmv(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::dense<const ValueType> b, const ValueType* beta,
+    matrix::view::dense<ValueType> c)
 {
 #ifdef GKO_COMPILING_HIP
     bool try_sparselib = sparselib::is_supported<ValueType, IndexType>::value;
     try_sparselib = try_sparselib && b.stride == 1 && c.stride == 1;
     // rocSPARSE has issues with zero matrices
-    try_sparselib = try_sparselib && a->get_num_stored_elements() > 0;
+    try_sparselib = try_sparselib && a.num_stored_elements > 0;
     if (try_sparselib) {
         auto descr = sparselib::create_mat_descr();
 
-        auto row_ptrs = a->get_const_row_ptrs();
-        auto col_idxs = a->get_const_col_idxs();
+        auto row_ptrs = a.row_ptrs;
+        auto col_idxs = a.col_idxs;
 
         sparselib::spmv(exec->get_sparselib_handle(),
-                        SPARSELIB_OPERATION_NON_TRANSPOSE, a->get_size()[0],
-                        a->get_size()[1], a->get_num_stored_elements(), alpha,
-                        descr, a->get_const_values(), row_ptrs, col_idxs,
-                        b.values, beta, c.values);
+                        SPARSELIB_OPERATION_NON_TRANSPOSE, a.size[0], a.size[1],
+                        a.num_stored_elements, alpha, descr, a.values, row_ptrs,
+                        col_idxs, b.values, beta, c.values);
 
         sparselib::destroy(descr);
     }
@@ -2260,16 +2229,16 @@ bool try_general_sparselib_spmv(std::shared_ptr<const DefaultExecutor> exec,
 #else  // GKO_COMPILING_CUDA
     auto handle = exec->get_sparselib_handle();
     // workaround for a division by zero in cuSPARSE 11.?
-    if (a->get_size()[1] == 0) {
+    if (a.size[1] == 0) {
         return false;
     }
     cusparseOperation_t trans = SPARSELIB_OPERATION_NON_TRANSPOSE;
-    auto row_ptrs = const_cast<IndexType*>(a->get_const_row_ptrs());
-    auto col_idxs = const_cast<IndexType*>(a->get_const_col_idxs());
-    auto values = const_cast<ValueType*>(a->get_const_values());
-    auto mat = sparselib::create_csr(a->get_size()[0], a->get_size()[1],
-                                     a->get_num_stored_elements(), row_ptrs,
-                                     col_idxs, values);
+    auto row_ptrs = const_cast<IndexType*>(a.row_ptrs);
+    auto col_idxs = const_cast<IndexType*>(a.col_idxs);
+    auto values = const_cast<ValueType*>(a.values);
+    auto mat =
+        sparselib::create_csr(a.size[0], a.size[1], a.num_stored_elements,
+                              row_ptrs, col_idxs, values);
     auto b_val = const_cast<ValueType*>(b.values);
     auto c_val = c.values;
     if (b.stride == 1 && c.stride == 1) {
@@ -2326,7 +2295,7 @@ template <typename MatrixValueType, typename InputValueType,
               !std::is_same<MatrixValueType, OutputValueType>::value>>
 bool try_sparselib_spmv(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -2343,7 +2312,7 @@ bool try_sparselib_spmv(
 template <typename ValueType, typename IndexType>
 bool try_sparselib_spmv(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::view::csr<const ValueType, const IndexType> a,
     matrix::view::dense<const ValueType> b, matrix::view::dense<ValueType> c,
     xstd::type_identity_t<std::optional<matrix::view::dense<const ValueType>>>
         alpha = {},
@@ -2402,7 +2371,8 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -2410,7 +2380,8 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c);
         }
     }
 }
@@ -2455,8 +2426,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical =
-                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c, alpha, beta);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -2464,8 +2435,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
-                alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c, alpha, beta);
         }
     }
 }
@@ -2921,21 +2892,21 @@ __global__ __launch_bounds__(default_block_size) void advanced_spgemm_reuse(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -2953,28 +2924,29 @@ void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
-    const auto d_vals = as_device_type(d->get_const_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
+    const auto d_vals = as_device_type(d.values);
     const auto palpha = as_device_type(alpha.values);
     const auto pbeta = as_device_type(beta.values);
     const auto lookup_storage_offsets =
@@ -2995,10 +2967,10 @@ void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const DefaultExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
-    if (orig->get_size()[0] == 0) {
+    if (orig.size[0] == 0) {
         return;
     }
     if (sparselib::is_supported<ValueType, IndexType>::value) {
@@ -3007,11 +2979,9 @@ void transpose(std::shared_ptr<const DefaultExecutor> exec,
         hipsparseIndexBase_t idxBase = HIPSPARSE_INDEX_BASE_ZERO;
 
         sparselib::transpose(
-            exec->get_sparselib_handle(), orig->get_size()[0],
-            orig->get_size()[1], orig->get_num_stored_elements(),
-            orig->get_const_values(), orig->get_const_row_ptrs(),
-            orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_row_ptrs(), trans->get_col_idxs(), copyValues, idxBase);
+            exec->get_sparselib_handle(), orig.size[0], orig.size[1],
+            orig.num_stored_elements, orig.values, orig.row_ptrs, orig.col_idxs,
+            trans.values, trans.row_ptrs, trans.col_idxs, copyValues, idxBase);
 #else   // GKO_COMPILING_CUDA
         cudaDataType_t cu_value =
             gko::kernels::cuda::cuda_data_type<ValueType>();
@@ -3020,21 +2990,17 @@ void transpose(std::shared_ptr<const DefaultExecutor> exec,
         cusparseCsr2CscAlg_t alg = CUSPARSE_CSR2CSC_ALG1;
         size_type buffer_size = 0;
         sparselib::transpose_buffersize(
-            exec->get_sparselib_handle(), orig->get_size()[0],
-            orig->get_size()[1], orig->get_num_stored_elements(),
-            orig->get_const_values(), orig->get_const_row_ptrs(),
-            orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
+            exec->get_sparselib_handle(), orig.size[0], orig.size[1],
+            orig.num_stored_elements, orig.values, orig.row_ptrs, orig.col_idxs,
+            trans.values, trans.row_ptrs, trans.col_idxs, cu_value, copyValues,
             idxBase, alg, &buffer_size);
         array<char> buffer_array(exec, buffer_size);
         auto buffer = buffer_array.get_data();
-        sparselib::transpose(
-            exec->get_sparselib_handle(), orig->get_size()[0],
-            orig->get_size()[1], orig->get_num_stored_elements(),
-            orig->get_const_values(), orig->get_const_row_ptrs(),
-            orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
-            idxBase, alg, buffer);
+        sparselib::transpose(exec->get_sparselib_handle(), orig.size[0],
+                             orig.size[1], orig.num_stored_elements,
+                             orig.values, orig.row_ptrs, orig.col_idxs,
+                             trans.values, trans.row_ptrs, trans.col_idxs,
+                             cu_value, copyValues, idxBase, alg, buffer);
 #endif  // GKO_COMPILING_CUDA
     } else {
         fallback_transpose(exec, orig, trans);
@@ -3044,37 +3010,35 @@ void transpose(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
-    if (orig->get_size()[0] == 0) {
+    if (orig.size[0] == 0) {
         return;
     }
     const auto block_size = default_block_size;
-    const auto grid_size =
-        ceildiv(trans->get_num_stored_elements(), block_size);
+    const auto grid_size = ceildiv(trans.num_stored_elements, block_size);
     transpose(exec, orig, trans);
     if (grid_size > 0 && is_complex<ValueType>()) {
         kernel::conjugate<<<grid_size, block_size, 0, exec->get_stream()>>>(
-            trans->get_num_stored_elements(),
-            as_device_type(trans->get_values()));
+            trans.num_stored_elements, as_device_type(trans.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const DefaultExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
     if (sparselib::is_supported<ValueType, IndexType>::value) {
         auto handle = exec->get_sparselib_handle();
         auto descr = sparselib::create_mat_descr();
-        auto m = IndexType(to_sort->get_size()[0]);
-        auto n = IndexType(to_sort->get_size()[1]);
-        auto nnz = IndexType(to_sort->get_num_stored_elements());
-        auto row_ptrs = to_sort->get_const_row_ptrs();
-        auto col_idxs = to_sort->get_col_idxs();
-        auto vals = to_sort->get_values();
+        auto m = IndexType(to_sort.size[0]);
+        auto n = IndexType(to_sort.size[1]);
+        auto nnz = IndexType(to_sort.num_stored_elements);
+        auto row_ptrs = to_sort.row_ptrs;
+        auto col_idxs = to_sort.col_idxs;
+        auto vals = to_sort.values;
 
         // copy values
         array<ValueType> tmp_vals_array(exec, nnz);

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -361,9 +361,8 @@ template <int items_per_thread, typename matrix_accessor,
 __device__ void merge_path_spmv(
     const IndexType num_rows, acc::range<matrix_accessor> val,
     const IndexType* __restrict__ col_idxs,
-    const IndexType* __restrict__ row_ptrs, const IndexType* __restrict__ srow,
-    acc::range<input_accessor> b, acc::range<output_accessor> c,
-    IndexType* __restrict__ row_out,
+    const IndexType* __restrict__ row_ptrs, acc::range<input_accessor> b,
+    acc::range<output_accessor> c, IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out,
     Alpha_op alpha_op, Beta_op beta_op)
 {
@@ -438,14 +437,13 @@ template <int items_per_thread, typename matrix_accessor,
 __global__ __launch_bounds__(spmv_block_size) void abstract_merge_path_spmv(
     const IndexType num_rows, acc::range<matrix_accessor> val,
     const IndexType* __restrict__ col_idxs,
-    const IndexType* __restrict__ row_ptrs, const IndexType* __restrict__ srow,
-    acc::range<input_accessor> b, acc::range<output_accessor> c,
-    IndexType* __restrict__ row_out,
+    const IndexType* __restrict__ row_ptrs, acc::range<input_accessor> b,
+    acc::range<output_accessor> c, IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out)
 {
     using type = typename output_accessor::arithmetic_type;
     merge_path_spmv<items_per_thread>(
-        num_rows, val, col_idxs, row_ptrs, srow, b, c, row_out, val_out,
+        num_rows, val, col_idxs, row_ptrs, b, c, row_out, val_out,
         [](const type& x) { return x; },
         [](const type& x) { return zero<type>(); });
 }
@@ -457,8 +455,7 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_merge_path_spmv(
     const IndexType num_rows,
     const typename matrix_accessor::storage_type* __restrict__ alpha,
     acc::range<matrix_accessor> val, const IndexType* __restrict__ col_idxs,
-    const IndexType* __restrict__ row_ptrs, const IndexType* __restrict__ srow,
-    acc::range<input_accessor> b,
+    const IndexType* __restrict__ row_ptrs, acc::range<input_accessor> b,
     const typename output_accessor::storage_type* __restrict__ beta,
     acc::range<output_accessor> c, IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out)
@@ -468,12 +465,12 @@ __global__ __launch_bounds__(spmv_block_size) void abstract_merge_path_spmv(
     const type beta_val = beta[0];
     if (is_zero(beta_val)) {
         merge_path_spmv<items_per_thread>(
-            num_rows, val, col_idxs, row_ptrs, srow, b, c, row_out, val_out,
+            num_rows, val, col_idxs, row_ptrs, b, c, row_out, val_out,
             [&alpha_val](const type& x) { return alpha_val * x; },
             [](const type& x) { return zero<type>(); });
     } else {
         merge_path_spmv<items_per_thread>(
-            num_rows, val, col_idxs, row_ptrs, srow, b, c, row_out, val_out,
+            num_rows, val, col_idxs, row_ptrs, b, c, row_out, val_out,
             [&alpha_val](const type& x) { return alpha_val * x; },
             [&beta_val](const type& x) { return beta_val * x; });
     }
@@ -1965,7 +1962,7 @@ void merge_path_spmv(
                     <<<grid, block, 0, exec->get_stream()>>>(
                         static_cast<IndexType>(a.size[0]),
                         acc::as_device_range(a_vals), a.col_idxs,
-                        as_device_type(a.row_ptrs), as_device_type(a.srow),
+                        as_device_type(a.row_ptrs),
                         acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals),
                         as_device_type(row_out.get_data()),
@@ -1984,7 +1981,7 @@ void merge_path_spmv(
                         static_cast<IndexType>(a.size[0]),
                         as_device_type(alpha->values),
                         acc::as_device_range(a_vals), a.col_idxs,
-                        as_device_type(a.row_ptrs), as_device_type(a.srow),
+                        as_device_type(a.row_ptrs),
                         acc::as_device_range(b_vals),
                         as_device_type(beta->values),
                         acc::as_device_range(c_vals),
@@ -2121,7 +2118,8 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_classical_spmv, classical_spmv);
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 bool load_balance_spmv(
-    std::shared_ptr<const DefaultExecutor> exec,
+    std::shared_ptr<const DefaultExecutor> exec, size_type num_srow_elements,
+    const IndexType* srow,
     matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
@@ -2156,7 +2154,7 @@ bool load_balance_spmv(
         } else {
             dense::fill(exec, c, zero<OutputValueType>());
         }
-        const IndexType nwarps = a.num_srow_elements;
+        const IndexType nwarps = num_srow_elements;
         if (nwarps > 0) {
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
@@ -2172,7 +2170,7 @@ bool load_balance_spmv(
                         nwarps, static_cast<IndexType>(a.size[0]),
                         as_device_type(alpha->values),
                         acc::as_device_range(a_vals), a.col_idxs,
-                        as_device_type(a.row_ptrs), as_device_type(a.srow),
+                        as_device_type(a.row_ptrs), as_device_type(srow),
                         acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
@@ -2182,7 +2180,7 @@ bool load_balance_spmv(
                                             exec->get_stream()>>>(
                         nwarps, static_cast<IndexType>(a.size[0]),
                         acc::as_device_range(a_vals), a.col_idxs,
-                        as_device_type(a.row_ptrs), as_device_type(a.srow),
+                        as_device_type(a.row_ptrs), as_device_type(srow),
                         acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
@@ -2333,7 +2331,8 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const DefaultExecutor> exec,
           const matrix::csr::spmv_strategy strategy,
-          const IndexType max_nnz_per_row,
+          const IndexType max_nnz_per_row, size_type num_srow_elements,
+          const IndexType* srow,
           matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
@@ -2362,7 +2361,8 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
     } else {
         bool use_classical = true;
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
-            use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
+            use_classical = !host_kernel::load_balance_spmv(
+                exec, num_srow_elements, srow, a, b, c);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
@@ -2382,7 +2382,8 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                    const matrix::csr::spmv_strategy strategy,
-                   const IndexType max_nnz_per_row,
+                   const IndexType max_nnz_per_row, size_type num_srow_elements,
+                   const IndexType* srow,
                    matrix::view::dense<const MatrixValueType> alpha,
                    matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,
@@ -2414,8 +2415,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
     } else {
         bool use_classical = true;
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
-            use_classical =
-                !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
+            use_classical = !host_kernel::load_balance_spmv(
+                exec, num_srow_elements, srow, a, b, c, alpha, beta);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical =
                 !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -1454,13 +1454,14 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_spgeam_numeric, spgeam_numeric);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::dense<const ValueType> beta,
-                    matrix::view::csr<const ValueType, const IndexType> b,
+                    const matrix::Csr<ValueType, IndexType>* b,
                     matrix::view::csr<ValueType, IndexType> c)
 {
-    auto total_nnz = a.num_stored_elements + b.num_stored_elements;
-    auto nnz_per_row = a.size[0] ? total_nnz / a.size[0] : 0;
+    auto total_nnz =
+        a->get_num_stored_elements() + b->get_num_stored_elements();
+    auto nnz_per_row = a->get_size()[0] ? total_nnz / a->get_size()[0] : 0;
     select_spgeam_numeric(
         spgeam_kernels(),
         [&](int compiled_subwarp_size) {
@@ -1468,8 +1469,9 @@ void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,
                    compiled_subwarp_size == config::warp_size;
         },
         syn::value_list<int>(), syn::type_list<>(), exec, alpha.values,
-        a.row_ptrs, a.col_idxs, a.values, beta.values, b.row_ptrs, b.col_idxs,
-        b.values, c.row_ptrs, c.values, a.size[0]);
+        a->get_const_row_ptrs(), a->get_const_col_idxs(), a->get_const_values(),
+        beta.values, b->get_const_row_ptrs(), b->get_const_col_idxs(),
+        b->get_const_values(), c.row_ptrs, c.values, a->get_size()[0]);
 }
 
 
@@ -1948,8 +1950,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -2069,7 +2071,7 @@ template <int subwarp_size, typename MatrixValueType, typename InputValueType,
 void classical_spmv(
     syn::value_list<int, subwarp_size>,
     std::shared_ptr<const DefaultExecutor> exec,
-    matrix::view::csr<const MatrixValueType, const IndexType> a,
+    const matrix::Csr<MatrixValueType, IndexType>* a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -2086,7 +2088,7 @@ void classical_spmv(
                         exec->get_num_multiprocessor() *
                         classical_oversubscription;
     const auto gridx =
-        std::min(ceildiv(a.size[0], spmv_block_size / subwarp_size),
+        std::min(ceildiv(a->get_size()[0], spmv_block_size / subwarp_size),
                  int64(nwarps / warps_in_block));
     const dim3 grid(gridx, b.size[1]);
     const auto block = spmv_block_size;
@@ -2100,18 +2102,20 @@ void classical_spmv(
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subwarp_size>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    a.size[0], acc::as_device_range(a_vals), a.col_idxs,
-                    as_device_type(a.row_ptrs), acc::as_device_range(b_vals),
-                    acc::as_device_range(c_vals));
+                    a->get_size()[0], acc::as_device_range(a_vals),
+                    a->get_const_col_idxs(),
+                    as_device_type(a->get_const_row_ptrs()),
+                    acc::as_device_range(b_vals), acc::as_device_range(c_vals));
         }
     } else if (alpha && beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subwarp_size>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    a.size[0], as_device_type(alpha->values),
-                    acc::as_device_range(a_vals), a.col_idxs,
-                    as_device_type(a.row_ptrs), acc::as_device_range(b_vals),
-                    as_device_type(beta->values), acc::as_device_range(c_vals));
+                    a->get_size()[0], as_device_type(alpha->values),
+                    acc::as_device_range(a_vals), a->get_const_col_idxs(),
+                    as_device_type(a->get_const_row_ptrs()),
+                    acc::as_device_range(b_vals), as_device_type(beta->values),
+                    acc::as_device_range(c_vals));
         }
     } else {
         GKO_KERNEL_NOT_FOUND;
@@ -2164,8 +2168,7 @@ bool load_balance_spmv(
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(
-                    a->get_const_device_view());
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -2200,27 +2203,29 @@ bool load_balance_spmv(
 
 
 template <typename ValueType, typename IndexType>
-bool try_general_sparselib_spmv(
-    std::shared_ptr<const DefaultExecutor> exec, const ValueType* alpha,
-    matrix::view::csr<const ValueType, const IndexType> a,
-    matrix::view::dense<const ValueType> b, const ValueType* beta,
-    matrix::view::dense<ValueType> c)
+bool try_general_sparselib_spmv(std::shared_ptr<const DefaultExecutor> exec,
+                                const ValueType* alpha,
+                                const matrix::Csr<ValueType, IndexType>* a,
+                                matrix::view::dense<const ValueType> b,
+                                const ValueType* beta,
+                                matrix::view::dense<ValueType> c)
 {
 #ifdef GKO_COMPILING_HIP
     bool try_sparselib = sparselib::is_supported<ValueType, IndexType>::value;
     try_sparselib = try_sparselib && b.stride == 1 && c.stride == 1;
     // rocSPARSE has issues with zero matrices
-    try_sparselib = try_sparselib && a.num_stored_elements > 0;
+    try_sparselib = try_sparselib && a->get_num_stored_elements() > 0;
     if (try_sparselib) {
         auto descr = sparselib::create_mat_descr();
 
-        auto row_ptrs = a.row_ptrs;
-        auto col_idxs = a.col_idxs;
+        auto row_ptrs = a->get_const_row_ptrs();
+        auto col_idxs = a->get_const_col_idxs();
 
         sparselib::spmv(exec->get_sparselib_handle(),
-                        SPARSELIB_OPERATION_NON_TRANSPOSE, a.size[0], a.size[1],
-                        a.num_stored_elements, alpha, descr, a.values, row_ptrs,
-                        col_idxs, b.values, beta, c.values);
+                        SPARSELIB_OPERATION_NON_TRANSPOSE, a->get_size()[0],
+                        a->get_size()[1], a->get_num_stored_elements(), alpha,
+                        descr, a->get_const_values(), row_ptrs, col_idxs,
+                        b.values, beta, c.values);
 
         sparselib::destroy(descr);
     }
@@ -2228,16 +2233,16 @@ bool try_general_sparselib_spmv(
 #else  // GKO_COMPILING_CUDA
     auto handle = exec->get_sparselib_handle();
     // workaround for a division by zero in cuSPARSE 11.?
-    if (a.size[1] == 0) {
+    if (a->get_size()[1] == 0) {
         return false;
     }
     cusparseOperation_t trans = SPARSELIB_OPERATION_NON_TRANSPOSE;
-    auto row_ptrs = const_cast<IndexType*>(a.row_ptrs);
-    auto col_idxs = const_cast<IndexType*>(a.col_idxs);
-    auto values = const_cast<ValueType*>(a.values);
-    auto mat =
-        sparselib::create_csr(a.size[0], a.size[1], a.num_stored_elements,
-                              row_ptrs, col_idxs, values);
+    auto row_ptrs = const_cast<IndexType*>(a->get_const_row_ptrs());
+    auto col_idxs = const_cast<IndexType*>(a->get_const_col_idxs());
+    auto values = const_cast<ValueType*>(a->get_const_values());
+    auto mat = sparselib::create_csr(a->get_size()[0], a->get_size()[1],
+                                     a->get_num_stored_elements(), row_ptrs,
+                                     col_idxs, values);
     auto b_val = const_cast<ValueType*>(b.values);
     auto c_val = c.values;
     if (b.stride == 1 && c.stride == 1) {
@@ -2294,7 +2299,7 @@ template <typename MatrixValueType, typename InputValueType,
               !std::is_same<MatrixValueType, OutputValueType>::value>>
 bool try_sparselib_spmv(
     std::shared_ptr<const DefaultExecutor> exec,
-    matrix::view::csr<const MatrixValueType, const IndexType> a,
+    const matrix::Csr<MatrixValueType, IndexType>* a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -2311,7 +2316,7 @@ bool try_sparselib_spmv(
 template <typename ValueType, typename IndexType>
 bool try_sparselib_spmv(
     std::shared_ptr<const DefaultExecutor> exec,
-    matrix::view::csr<const ValueType, const IndexType> a,
+    const matrix::Csr<ValueType, IndexType>* a,
     matrix::view::dense<const ValueType> b, matrix::view::dense<ValueType> c,
     xstd::type_identity_t<std::optional<matrix::view::dense<const ValueType>>>
         alpha = {},
@@ -2362,8 +2367,7 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -2387,8 +2391,7 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
         }
     }
 }
@@ -2425,8 +2428,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c, alpha, beta);
+            use_classical =
+                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -2450,8 +2453,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c, alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
+                alpha, beta);
         }
     }
 }

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -1069,21 +1069,20 @@ __global__ __launch_bounds__(default_block_size) void add_scaled_identity(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& block_row_ptr_array,
-                      array<IndexType>& block_col_idx_array,
-                      array<ValueType>& block_value_array)
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& block_row_ptr_array,
+    array<IndexType>& block_col_idx_array, array<ValueType>& block_value_array)
 {
     using tuple_type = thrust::tuple<IndexType, IndexType>;
-    const auto nnz = source->get_num_stored_elements();
+    const auto nnz = source.num_stored_elements;
     array<IndexType> in_row_idxs{exec, nnz};
     array<IndexType> in_col_idxs{exec, nnz};
     array<ValueType> in_values{exec, nnz};
-    exec->copy(nnz, source->get_const_col_idxs(), in_col_idxs.get_data());
-    exec->copy(nnz, source->get_const_values(), in_values.get_data());
-    components::convert_ptrs_to_idxs(exec, source->get_const_row_ptrs(),
-                                     source->get_size()[0],
+    exec->copy(nnz, source.col_idxs, in_col_idxs.get_data());
+    exec->copy(nnz, source.values, in_values.get_data());
+    components::convert_ptrs_to_idxs(exec, source.row_ptrs, source.size[0],
                                      in_row_idxs.get_data());
     auto block_row_ptrs = block_row_ptr_array.get_data();
     auto num_block_rows = block_row_ptr_array.get_size() - 1;
@@ -1455,14 +1454,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_spgeam_numeric, spgeam_numeric);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
-    auto total_nnz =
-        a->get_num_stored_elements() + b->get_num_stored_elements();
-    auto nnz_per_row = a->get_size()[0] ? total_nnz / a->get_size()[0] : 0;
+    auto total_nnz = a.num_stored_elements + b.num_stored_elements;
+    auto nnz_per_row = a.size[0] ? total_nnz / a.size[0] : 0;
     select_spgeam_numeric(
         spgeam_kernels(),
         [&](int compiled_subwarp_size) {
@@ -1470,24 +1468,22 @@ void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,
                    compiled_subwarp_size == config::warp_size;
         },
         syn::value_list<int>(), syn::type_list<>(), exec, alpha.values,
-        a->get_const_row_ptrs(), a->get_const_col_idxs(), a->get_const_values(),
-        beta.values, b->get_const_row_ptrs(), b->get_const_col_idxs(),
-        b->get_const_values(), c->get_const_row_ptrs(), c->get_values(),
-        a->get_size()[0]);
+        a.row_ptrs, a.col_idxs, a.values, beta.values, b.row_ptrs, b.col_idxs,
+        b.values, c.row_ptrs, c.values, a.size[0]);
 }
 
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
     const auto num_rows = result.size[0];
     const auto num_cols = result.size[1];
     const auto stride = result.stride;
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto vals = source->get_const_values();
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
+    const auto vals = source.values;
 
     auto grid_dim = ceildiv(num_rows, default_block_size);
     if (grid_dim > 0) {
@@ -1502,59 +1498,52 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const DefaultExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_symm_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                num_rows, perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,
-                         const IndexType* row_perm, const IndexType* col_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_perm,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, row_perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, row_perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_nonsymm_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, row_perm, col_perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                num_rows, row_perm, col_perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
@@ -1562,29 +1551,26 @@ void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const DefaultExecutor> exec,
                  const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                   exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::row_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), row_permuted.row_ptrs,
+                row_permuted.col_idxs, as_device_type(row_permuted.values));
     }
 }
 
@@ -1592,93 +1578,82 @@ void row_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const DefaultExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_row_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, perm, orig.row_ptrs, orig.col_idxs,
+                as_device_type(orig.values), row_permuted.row_ptrs,
+                row_permuted.col_idxs, as_device_type(row_permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_symm_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, as_device_type(scale), perm,
-                orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                num_rows, as_device_type(scale), perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, row_perm, orig->get_const_row_ptrs(),
-            permuted->get_row_ptrs());
+            num_rows, row_perm, orig.row_ptrs, permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_nonsymm_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
                 num_rows, as_device_type(row_scale), row_perm,
-                as_device_type(col_scale), col_perm, orig->get_const_row_ptrs(),
-                orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                permuted->get_row_ptrs(), permuted->get_col_idxs(),
-                as_device_type(permuted->get_values()));
+                as_device_type(col_scale), col_perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values), permuted.row_ptrs,
+                permuted.col_idxs, as_device_type(permuted.values));
     }
 }
 
@@ -1686,59 +1661,56 @@ void inv_nonsymm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                   exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::row_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, as_device_type(scale), perm,
-                orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, as_device_type(scale), perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values),
+                row_permuted.row_ptrs, row_permuted.col_idxs,
+                as_device_type(row_permuted.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
     if (count_num_blocks > 0) {
         kernel::inv_row_ptr_permute<<<count_num_blocks, default_block_size, 0,
                                       exec->get_stream()>>>(
-            num_rows, perm, orig->get_const_row_ptrs(),
-            row_permuted->get_row_ptrs());
+            num_rows, perm, orig.row_ptrs, row_permuted.row_ptrs);
     }
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     if (copy_num_blocks > 0) {
         kernel::inv_row_scale_permute<config::warp_size>
             <<<copy_num_blocks, default_block_size, 0, exec->get_stream()>>>(
-                num_rows, as_device_type(scale), perm,
-                orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-                as_device_type(orig->get_const_values()),
-                row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-                as_device_type(row_permuted->get_values()));
+                num_rows, as_device_type(scale), perm, orig.row_ptrs,
+                orig.col_idxs, as_device_type(orig.values),
+                row_permuted.row_ptrs, row_permuted.col_idxs,
+                as_device_type(row_permuted.values));
     }
 }
 
@@ -1746,12 +1718,12 @@ void inv_row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
-    const auto num_rows = source->get_size()[0];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
+    const auto num_rows = source.size[0];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
     auto grid_dim = ceildiv(row_span.length(), default_block_size);
     if (grid_dim > 0) {
         kernel::calculate_nnz_per_row_in_span<<<grid_dim, default_block_size, 0,
@@ -1763,27 +1735,25 @@ void calculate_nonzeros_per_row_in_span(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     auto row_offset = row_span.begin;
     auto col_offset = col_span.begin;
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto row_ptrs = source->get_const_row_ptrs();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto row_ptrs = source.row_ptrs;
     auto grid_dim = ceildiv(num_rows, default_block_size);
     if (grid_dim > 0) {
         kernel::compute_submatrix_idxs_and_vals<<<grid_dim, default_block_size,
                                                   0, exec->get_stream()>>>(
             num_rows, num_cols, row_offset, col_offset,
-            as_device_type(source->get_const_row_ptrs()),
-            as_device_type(source->get_const_col_idxs()),
-            as_device_type(source->get_const_values()),
-            as_device_type(result->get_const_row_ptrs()),
-            as_device_type(result->get_col_idxs()),
-            as_device_type(result->get_values()));
+            as_device_type(source.row_ptrs), as_device_type(source.col_idxs),
+            as_device_type(source.values), as_device_type(result.row_ptrs),
+            as_device_type(result.col_idxs), as_device_type(result.values));
     }
 }
 
@@ -1791,7 +1761,7 @@ void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
     IndexType* row_nnz) GKO_NOT_IMPLEMENTED;
@@ -1800,26 +1770,27 @@ void calculate_nonzeros_per_row_in_index_set(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result) GKO_NOT_IMPLEMENTED;
+    matrix::view::csr<ValueType, IndexType> result) GKO_NOT_IMPLEMENTED;
 
 
 template <typename ValueType, typename IndexType>
-void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
-                        const matrix::Csr<ValueType, IndexType>* input,
-                        matrix::Csr<ValueType, IndexType>* output)
+void fallback_transpose(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> output)
 {
-    const auto in_num_rows = input->get_size()[0];
-    const auto out_num_rows = output->get_size()[0];
-    const auto nnz = output->get_num_stored_elements();
-    const auto in_row_ptrs = input->get_const_row_ptrs();
-    const auto in_col_idxs = input->get_const_col_idxs();
-    const auto in_vals = as_device_type(input->get_const_values());
-    const auto out_row_ptrs = output->get_row_ptrs();
-    const auto out_col_idxs = output->get_col_idxs();
-    const auto out_vals = as_device_type(output->get_values());
+    const auto in_num_rows = input.size[0];
+    const auto out_num_rows = output.size[0];
+    const auto nnz = output.num_stored_elements;
+    const auto in_row_ptrs = input.row_ptrs;
+    const auto in_col_idxs = input.col_idxs;
+    const auto in_vals = as_device_type(input.values);
+    const auto out_row_ptrs = output.row_ptrs;
+    const auto out_col_idxs = output.col_idxs;
+    const auto out_vals = as_device_type(output.values);
     array<IndexType> out_row_idxs{exec, nnz};
     components::convert_ptrs_to_idxs(exec, in_row_ptrs, in_num_rows,
                                      out_col_idxs);
@@ -1835,13 +1806,13 @@ void fallback_transpose(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void fallback_sort(std::shared_ptr<const DefaultExecutor> exec,
-                   matrix::Csr<ValueType, IndexType>* to_sort)
+                   matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    const auto row_ptrs = to_sort->get_const_row_ptrs();
-    const auto col_idxs = to_sort->get_col_idxs();
-    const auto vals = as_device_type(to_sort->get_values());
-    const auto nnz = to_sort->get_num_stored_elements();
-    const auto num_rows = to_sort->get_size()[0];
+    const auto row_ptrs = to_sort.row_ptrs;
+    const auto col_idxs = to_sort.col_idxs;
+    const auto vals = as_device_type(to_sort.values);
+    const auto nnz = to_sort.num_stored_elements;
+    const auto num_rows = to_sort.size[0];
     array<IndexType> row_idx_array(exec, nnz);
     const auto row_idxs = row_idx_array.get_data();
     components::convert_ptrs_to_idxs(exec, row_ptrs, num_rows, row_idxs);
@@ -1860,20 +1831,21 @@ void fallback_sort(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
     is_sorted = true;
     auto gpu_array = array<bool>{exec, 1};
     // need to initialize the GPU value to true
     exec->copy_from(exec->get_master(), 1, &is_sorted, gpu_array.get_data());
     auto block_size = default_block_size;
-    auto num_rows = static_cast<IndexType>(to_check->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(to_check.size[0]);
     auto num_blocks = ceildiv(num_rows, block_size);
     if (num_blocks > 0) {
         kernel::
             check_unsorted<<<num_blocks, block_size, 0, exec->get_stream()>>>(
-                to_check->get_const_row_ptrs(), to_check->get_const_col_idxs(),
-                num_rows, gpu_array.get_data());
+                to_check.row_ptrs, to_check.col_idxs, num_rows,
+                gpu_array.get_data());
     }
     is_sorted = get_element(gpu_array, 0);
 }
@@ -1881,17 +1853,17 @@ void is_sorted_by_column_index(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto nnz = orig->get_num_stored_elements();
+    const auto nnz = orig.num_stored_elements;
     const auto diag_size = diag->get_size()[0];
     const auto num_blocks =
         ceildiv(config::warp_size * diag_size, default_block_size);
 
-    const auto orig_values = orig->get_const_values();
-    const auto orig_row_ptrs = orig->get_const_row_ptrs();
-    const auto orig_col_idxs = orig->get_const_col_idxs();
+    const auto orig_values = orig.values;
+    const auto orig_row_ptrs = orig.row_ptrs;
+    const auto orig_col_idxs = orig.col_idxs;
     auto diag_values = diag->get_values();
     if (num_blocks > 0) {
         kernel::extract_diagonal<<<num_blocks, default_block_size, 0,
@@ -1904,20 +1876,20 @@ void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const DefaultExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
-    const auto num_diag = static_cast<IndexType>(
-        std::min(mtx->get_size()[0], mtx->get_size()[1]));
+    const auto num_diag =
+        static_cast<IndexType>(std::min(mtx.size[0], mtx.size[1]));
     if (num_diag > 0) {
         const IndexType num_blocks =
             ceildiv(num_diag, default_block_size / config::warp_size);
         array<bool> has_diags(exec, {true});
         kernel::check_diagonal_entries<<<num_blocks, default_block_size, 0,
                                          exec->get_stream()>>>(
-            num_diag, mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            has_diags.get_data());
+            num_diag, mtx.row_ptrs, mtx.col_idxs, has_diags.get_data());
         has_all_diags = get_element(has_diags, 0);
     } else {
         has_all_diags = true;
@@ -1929,9 +1901,9 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const DefaultExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = mtx->get_size()[0];
+    const auto nrows = mtx.size[0];
     if (nrows == 0) {
         return;
     }
@@ -1940,8 +1912,8 @@ void add_scaled_identity(std::shared_ptr<const DefaultExecutor> exec,
     kernel::add_scaled_identity<<<nblocks, default_block_size, 0,
                                   exec->get_stream()>>>(
         as_device_type(alpha.values), as_device_type(beta.values),
-        static_cast<IndexType>(nrows), mtx->get_const_row_ptrs(),
-        mtx->get_const_col_idxs(), as_device_type(mtx->get_values()));
+        static_cast<IndexType>(nrows), mtx.row_ptrs, mtx.col_idxs,
+        as_device_type(mtx.values));
 }
 
 
@@ -1976,8 +1948,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -2097,7 +2069,7 @@ template <int subwarp_size, typename MatrixValueType, typename InputValueType,
 void classical_spmv(
     syn::value_list<int, subwarp_size>,
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -2114,7 +2086,7 @@ void classical_spmv(
                         exec->get_num_multiprocessor() *
                         classical_oversubscription;
     const auto gridx =
-        std::min(ceildiv(a->get_size()[0], spmv_block_size / subwarp_size),
+        std::min(ceildiv(a.size[0], spmv_block_size / subwarp_size),
                  int64(nwarps / warps_in_block));
     const dim3 grid(gridx, b.size[1]);
     const auto block = spmv_block_size;
@@ -2128,20 +2100,18 @@ void classical_spmv(
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subwarp_size>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    a->get_size()[0], acc::as_device_range(a_vals),
-                    a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_ptrs()),
-                    acc::as_device_range(b_vals), acc::as_device_range(c_vals));
+                    a.size[0], acc::as_device_range(a_vals), a.col_idxs,
+                    as_device_type(a.row_ptrs), acc::as_device_range(b_vals),
+                    acc::as_device_range(c_vals));
         }
     } else if (alpha && beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subwarp_size>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    a->get_size()[0], as_device_type(alpha->values),
-                    acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                    as_device_type(a->get_const_row_ptrs()),
-                    acc::as_device_range(b_vals), as_device_type(beta->values),
-                    acc::as_device_range(c_vals));
+                    a.size[0], as_device_type(alpha->values),
+                    acc::as_device_range(a_vals), a.col_idxs,
+                    as_device_type(a.row_ptrs), acc::as_device_range(b_vals),
+                    as_device_type(beta->values), acc::as_device_range(c_vals));
         }
     } else {
         GKO_KERNEL_NOT_FOUND;
@@ -2194,7 +2164,8 @@ bool load_balance_spmv(
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(
+                    a->get_const_device_view());
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -2229,29 +2200,27 @@ bool load_balance_spmv(
 
 
 template <typename ValueType, typename IndexType>
-bool try_general_sparselib_spmv(std::shared_ptr<const DefaultExecutor> exec,
-                                const ValueType* alpha,
-                                const matrix::Csr<ValueType, IndexType>* a,
-                                matrix::view::dense<const ValueType> b,
-                                const ValueType* beta,
-                                matrix::view::dense<ValueType> c)
+bool try_general_sparselib_spmv(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::dense<const ValueType> b, const ValueType* beta,
+    matrix::view::dense<ValueType> c)
 {
 #ifdef GKO_COMPILING_HIP
     bool try_sparselib = sparselib::is_supported<ValueType, IndexType>::value;
     try_sparselib = try_sparselib && b.stride == 1 && c.stride == 1;
     // rocSPARSE has issues with zero matrices
-    try_sparselib = try_sparselib && a->get_num_stored_elements() > 0;
+    try_sparselib = try_sparselib && a.num_stored_elements > 0;
     if (try_sparselib) {
         auto descr = sparselib::create_mat_descr();
 
-        auto row_ptrs = a->get_const_row_ptrs();
-        auto col_idxs = a->get_const_col_idxs();
+        auto row_ptrs = a.row_ptrs;
+        auto col_idxs = a.col_idxs;
 
         sparselib::spmv(exec->get_sparselib_handle(),
-                        SPARSELIB_OPERATION_NON_TRANSPOSE, a->get_size()[0],
-                        a->get_size()[1], a->get_num_stored_elements(), alpha,
-                        descr, a->get_const_values(), row_ptrs, col_idxs,
-                        b.values, beta, c.values);
+                        SPARSELIB_OPERATION_NON_TRANSPOSE, a.size[0], a.size[1],
+                        a.num_stored_elements, alpha, descr, a.values, row_ptrs,
+                        col_idxs, b.values, beta, c.values);
 
         sparselib::destroy(descr);
     }
@@ -2259,16 +2228,16 @@ bool try_general_sparselib_spmv(std::shared_ptr<const DefaultExecutor> exec,
 #else  // GKO_COMPILING_CUDA
     auto handle = exec->get_sparselib_handle();
     // workaround for a division by zero in cuSPARSE 11.?
-    if (a->get_size()[1] == 0) {
+    if (a.size[1] == 0) {
         return false;
     }
     cusparseOperation_t trans = SPARSELIB_OPERATION_NON_TRANSPOSE;
-    auto row_ptrs = const_cast<IndexType*>(a->get_const_row_ptrs());
-    auto col_idxs = const_cast<IndexType*>(a->get_const_col_idxs());
-    auto values = const_cast<ValueType*>(a->get_const_values());
-    auto mat = sparselib::create_csr(a->get_size()[0], a->get_size()[1],
-                                     a->get_num_stored_elements(), row_ptrs,
-                                     col_idxs, values);
+    auto row_ptrs = const_cast<IndexType*>(a.row_ptrs);
+    auto col_idxs = const_cast<IndexType*>(a.col_idxs);
+    auto values = const_cast<ValueType*>(a.values);
+    auto mat =
+        sparselib::create_csr(a.size[0], a.size[1], a.num_stored_elements,
+                              row_ptrs, col_idxs, values);
     auto b_val = const_cast<ValueType*>(b.values);
     auto c_val = c.values;
     if (b.stride == 1 && c.stride == 1) {
@@ -2325,7 +2294,7 @@ template <typename MatrixValueType, typename InputValueType,
               !std::is_same<MatrixValueType, OutputValueType>::value>>
 bool try_sparselib_spmv(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -2342,7 +2311,7 @@ bool try_sparselib_spmv(
 template <typename ValueType, typename IndexType>
 bool try_sparselib_spmv(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::view::csr<const ValueType, const IndexType> a,
     matrix::view::dense<const ValueType> b, matrix::view::dense<ValueType> c,
     xstd::type_identity_t<std::optional<matrix::view::dense<const ValueType>>>
         alpha = {},
@@ -2393,7 +2362,8 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -2417,7 +2387,8 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c);
         }
     }
 }
@@ -2454,8 +2425,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical =
-                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c, alpha, beta);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -2479,8 +2450,8 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
-                alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c, alpha, beta);
         }
     }
 }
@@ -2936,21 +2907,21 @@ __global__ __launch_bounds__(default_block_size) void advanced_spgemm_reuse(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -2968,28 +2939,29 @@ void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
-    const auto d_vals = as_device_type(d->get_const_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
+    const auto d_vals = as_device_type(d.values);
     const auto palpha = as_device_type(alpha.values);
     const auto pbeta = as_device_type(beta.values);
     const auto lookup_storage_offsets =
@@ -3010,10 +2982,10 @@ void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const DefaultExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
-    if (orig->get_size()[0] == 0) {
+    if (orig.size[0] == 0) {
         return;
     }
     if (sparselib::is_supported<ValueType, IndexType>::value) {
@@ -3022,11 +2994,9 @@ void transpose(std::shared_ptr<const DefaultExecutor> exec,
         hipsparseIndexBase_t idxBase = HIPSPARSE_INDEX_BASE_ZERO;
 
         sparselib::transpose(
-            exec->get_sparselib_handle(), orig->get_size()[0],
-            orig->get_size()[1], orig->get_num_stored_elements(),
-            orig->get_const_values(), orig->get_const_row_ptrs(),
-            orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_row_ptrs(), trans->get_col_idxs(), copyValues, idxBase);
+            exec->get_sparselib_handle(), orig.size[0], orig.size[1],
+            orig.num_stored_elements, orig.values, orig.row_ptrs, orig.col_idxs,
+            trans.values, trans.row_ptrs, trans.col_idxs, copyValues, idxBase);
 #else   // GKO_COMPILING_CUDA
         cudaDataType_t cu_value =
             gko::kernels::cuda::cuda_data_type<ValueType>();
@@ -3035,21 +3005,17 @@ void transpose(std::shared_ptr<const DefaultExecutor> exec,
         cusparseCsr2CscAlg_t alg = CUSPARSE_CSR2CSC_ALG1;
         size_type buffer_size = 0;
         sparselib::transpose_buffersize(
-            exec->get_sparselib_handle(), orig->get_size()[0],
-            orig->get_size()[1], orig->get_num_stored_elements(),
-            orig->get_const_values(), orig->get_const_row_ptrs(),
-            orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
+            exec->get_sparselib_handle(), orig.size[0], orig.size[1],
+            orig.num_stored_elements, orig.values, orig.row_ptrs, orig.col_idxs,
+            trans.values, trans.row_ptrs, trans.col_idxs, cu_value, copyValues,
             idxBase, alg, &buffer_size);
         array<char> buffer_array(exec, buffer_size);
         auto buffer = buffer_array.get_data();
-        sparselib::transpose(
-            exec->get_sparselib_handle(), orig->get_size()[0],
-            orig->get_size()[1], orig->get_num_stored_elements(),
-            orig->get_const_values(), orig->get_const_row_ptrs(),
-            orig->get_const_col_idxs(), trans->get_values(),
-            trans->get_row_ptrs(), trans->get_col_idxs(), cu_value, copyValues,
-            idxBase, alg, buffer);
+        sparselib::transpose(exec->get_sparselib_handle(), orig.size[0],
+                             orig.size[1], orig.num_stored_elements,
+                             orig.values, orig.row_ptrs, orig.col_idxs,
+                             trans.values, trans.row_ptrs, trans.col_idxs,
+                             cu_value, copyValues, idxBase, alg, buffer);
 #endif  // GKO_COMPILING_CUDA
     } else {
         fallback_transpose(exec, orig, trans);
@@ -3059,37 +3025,35 @@ void transpose(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
-    if (orig->get_size()[0] == 0) {
+    if (orig.size[0] == 0) {
         return;
     }
     const auto block_size = default_block_size;
-    const auto grid_size =
-        ceildiv(trans->get_num_stored_elements(), block_size);
+    const auto grid_size = ceildiv(trans.num_stored_elements, block_size);
     transpose(exec, orig, trans);
     if (grid_size > 0 && is_complex<ValueType>()) {
         kernel::conjugate<<<grid_size, block_size, 0, exec->get_stream()>>>(
-            trans->get_num_stored_elements(),
-            as_device_type(trans->get_values()));
+            trans.num_stored_elements, as_device_type(trans.values));
     }
 }
 
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const DefaultExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
     if (sparselib::is_supported<ValueType, IndexType>::value) {
         auto handle = exec->get_sparselib_handle();
         auto descr = sparselib::create_mat_descr();
-        auto m = IndexType(to_sort->get_size()[0]);
-        auto n = IndexType(to_sort->get_size()[1]);
-        auto nnz = IndexType(to_sort->get_num_stored_elements());
-        auto row_ptrs = to_sort->get_const_row_ptrs();
-        auto col_idxs = to_sort->get_col_idxs();
-        auto vals = to_sort->get_values();
+        auto m = IndexType(to_sort.size[0]);
+        auto n = IndexType(to_sort.size[1]);
+        auto nnz = IndexType(to_sort.num_stored_elements);
+        auto row_ptrs = to_sort.row_ptrs;
+        auto col_idxs = to_sort.col_idxs;
+        auto vals = to_sort.values;
 
         // copy values
         array<ValueType> tmp_vals_array(exec, nnz);

--- a/common/cuda_hip/matrix/dense_kernels.cpp
+++ b/common/cuda_hip/matrix/dense_kernels.cpp
@@ -467,14 +467,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
 
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
     auto stride = source.stride;
 

--- a/common/cuda_hip/matrix/dense_kernels.cpp
+++ b/common/cuda_hip/matrix/dense_kernels.cpp
@@ -469,14 +469,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
 
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
     auto stride = source.stride;
 

--- a/common/cuda_hip/matrix/diagonal_kernels.cpp
+++ b/common/cuda_hip/matrix/diagonal_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -62,14 +62,13 @@ __global__ __launch_bounds__(default_block_size) void apply_to_csr(
 template <typename ValueType, typename IndexType>
 void apply_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                   const matrix::Diagonal<ValueType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
-                  matrix::Csr<ValueType, IndexType>* c, bool inverse)
+                  matrix::view::csr<const ValueType, const IndexType> b,
+                  matrix::view::csr<ValueType, IndexType> c, bool inverse)
 {
-    const auto num_rows = b->get_size()[0];
+    const auto num_rows = b.size[0];
     const auto diag_values = a->get_const_values();
-    c->copy_from(b);
-    auto csr_values = c->get_values();
-    const auto csr_row_ptrs = c->get_const_row_ptrs();
+    auto csr_values = c.values;
+    const auto csr_row_ptrs = c.row_ptrs;
 
     const auto grid_dim =
         ceildiv(num_rows * config::warp_size, default_block_size);

--- a/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
@@ -356,7 +356,7 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void convert_to_csr(const std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Fbcsr<ValueType, IndexType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     constexpr auto warps_per_block = default_block_size / config::warp_size;
     const auto num_blocks =
@@ -365,8 +365,8 @@ void convert_to_csr(const std::shared_ptr<const DefaultExecutor> exec,
         kernel::convert_to_csr<<<num_blocks, default_block_size, 0,
                                  exec->get_stream()>>>(
             source->get_const_row_ptrs(), source->get_const_col_idxs(),
-            as_device_type(source->get_const_values()), result->get_row_ptrs(),
-            result->get_col_idxs(), as_device_type(result->get_values()),
+            as_device_type(source->get_const_values()), result.row_ptrs,
+            result.col_idxs, as_device_type(result.values),
             source->get_num_block_rows(), source->get_block_size());
     }
 }

--- a/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
@@ -355,7 +355,7 @@ void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void convert_to_csr(const std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Fbcsr<ValueType, IndexType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     constexpr auto warps_per_block = default_block_size / config::warp_size;
     const auto num_blocks =
@@ -364,8 +364,8 @@ void convert_to_csr(const std::shared_ptr<const DefaultExecutor> exec,
         kernel::convert_to_csr<<<num_blocks, default_block_size, 0,
                                  exec->get_stream()>>>(
             source->get_const_row_ptrs(), source->get_const_col_idxs(),
-            as_device_type(source->get_const_values()), result->get_row_ptrs(),
-            result->get_col_idxs(), as_device_type(result->get_values()),
+            as_device_type(source->get_const_values()), result.row_ptrs,
+            result.col_idxs, as_device_type(result.values),
             source->get_num_block_rows(), source->get_block_size());
     }
 }

--- a/common/cuda_hip/preconditioner/isai_kernels.cpp
+++ b/common/cuda_hip/preconditioner/isai_kernels.cpp
@@ -458,13 +458,13 @@ __global__ __launch_bounds__(default_block_size) void copy_excess_solution(
 
 
 template <typename ValueType, typename IndexType>
-void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                          const matrix::Csr<ValueType, IndexType>* input,
-                          matrix::Csr<ValueType, IndexType>* inverse,
-                          IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs,
-                          bool lower)
+void generate_tri_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> inverse, IndexType* excess_rhs_ptrs,
+    IndexType* excess_nz_ptrs, bool lower)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(num_rows, block / subwarp_size);
@@ -472,20 +472,18 @@ void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
         if (lower) {
             kernel::generate_l_inverse<subwarp_size, subwarps_per_block>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    static_cast<IndexType>(num_rows),
-                    input->get_const_row_ptrs(), input->get_const_col_idxs(),
-                    as_device_type(input->get_const_values()),
-                    inverse->get_row_ptrs(), inverse->get_col_idxs(),
-                    as_device_type(inverse->get_values()), excess_rhs_ptrs,
+                    static_cast<IndexType>(num_rows), input.row_ptrs,
+                    input.col_idxs, as_device_type(input.values),
+                    inverse.row_ptrs, inverse.col_idxs,
+                    as_device_type(inverse.values), excess_rhs_ptrs,
                     excess_nz_ptrs);
         } else {
             kernel::generate_u_inverse<subwarp_size, subwarps_per_block>
                 <<<grid, block, 0, exec->get_stream()>>>(
-                    static_cast<IndexType>(num_rows),
-                    input->get_const_row_ptrs(), input->get_const_col_idxs(),
-                    as_device_type(input->get_const_values()),
-                    inverse->get_row_ptrs(), inverse->get_col_idxs(),
-                    as_device_type(inverse->get_values()), excess_rhs_ptrs,
+                    static_cast<IndexType>(num_rows), input.row_ptrs,
+                    input.col_idxs, as_device_type(input.values),
+                    inverse.row_ptrs, inverse.col_idxs,
+                    as_device_type(inverse.values), excess_rhs_ptrs,
                     excess_nz_ptrs);
         }
     }
@@ -498,25 +496,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_general_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                              const matrix::Csr<ValueType, IndexType>* input,
-                              matrix::Csr<ValueType, IndexType>* inverse,
-                              IndexType* excess_rhs_ptrs,
-                              IndexType* excess_nz_ptrs, bool spd)
+void generate_general_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> inverse, IndexType* excess_rhs_ptrs,
+    IndexType* excess_nz_ptrs, bool spd)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(num_rows, block / subwarp_size);
     if (grid > 0) {
         kernel::generate_general_inverse<subwarp_size, subwarps_per_block>
             <<<grid, block, 0, exec->get_stream()>>>(
-                static_cast<IndexType>(num_rows), input->get_const_row_ptrs(),
-                input->get_const_col_idxs(),
-                as_device_type(input->get_const_values()),
-                inverse->get_row_ptrs(), inverse->get_col_idxs(),
-                as_device_type(inverse->get_values()), excess_rhs_ptrs,
-                excess_nz_ptrs, spd);
+                static_cast<IndexType>(num_rows), input.row_ptrs,
+                input.col_idxs, as_device_type(input.values), inverse.row_ptrs,
+                inverse.col_idxs, as_device_type(inverse.values),
+                excess_rhs_ptrs, excess_nz_ptrs, spd);
     }
     components::prefix_sum_nonnegative(exec, excess_rhs_ptrs, num_rows + 1);
     components::prefix_sum_nonnegative(exec, excess_nz_ptrs, num_rows + 1);
@@ -527,29 +523,27 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_excess_system(std::shared_ptr<const DefaultExecutor> exec,
-                            const matrix::Csr<ValueType, IndexType>* input,
-                            const matrix::Csr<ValueType, IndexType>* inverse,
-                            const IndexType* excess_rhs_ptrs,
-                            const IndexType* excess_nz_ptrs,
-                            matrix::Csr<ValueType, IndexType>* excess_system,
-                            matrix::view::dense<ValueType> excess_rhs,
-                            size_type e_start, size_type e_end)
+void generate_excess_system(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<const ValueType, const IndexType> inverse,
+    const IndexType* excess_rhs_ptrs, const IndexType* excess_nz_ptrs,
+    matrix::view::csr<ValueType, IndexType> excess_system,
+    matrix::view::dense<ValueType> excess_rhs, size_type e_start,
+    size_type e_end)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(e_end - e_start, block / subwarp_size);
     if (grid > 0) {
         kernel::generate_excess_system<subwarp_size>
             <<<grid, block, 0, exec->get_stream()>>>(
-                static_cast<IndexType>(num_rows), input->get_const_row_ptrs(),
-                input->get_const_col_idxs(),
-                as_device_type(input->get_const_values()),
-                inverse->get_const_row_ptrs(), inverse->get_const_col_idxs(),
-                excess_rhs_ptrs, excess_nz_ptrs, excess_system->get_row_ptrs(),
-                excess_system->get_col_idxs(),
-                as_device_type(excess_system->get_values()),
+                static_cast<IndexType>(num_rows), input.row_ptrs,
+                input.col_idxs, as_device_type(input.values), inverse.row_ptrs,
+                inverse.col_idxs, excess_rhs_ptrs, excess_nz_ptrs,
+                excess_system.row_ptrs, excess_system.col_idxs,
+                as_device_type(excess_system.values),
                 as_device_type(excess_rhs.values), e_start, e_end);
     }
 }
@@ -583,19 +577,19 @@ void scatter_excess_solution(
     std::shared_ptr<const DefaultExecutor> exec,
     const IndexType* excess_rhs_ptrs,
     matrix::view::dense<const ValueType> excess_solution,
-    matrix::Csr<ValueType, IndexType>* inverse, size_type e_start,
+    matrix::view::csr<ValueType, IndexType> inverse, size_type e_start,
     size_type e_end)
 {
-    const auto num_rows = inverse->get_size()[0];
+    const auto num_rows = inverse.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(e_end - e_start, block / subwarp_size);
     if (grid > 0) {
         kernel::copy_excess_solution<subwarp_size>
             <<<grid, block, 0, exec->get_stream()>>>(
-                static_cast<IndexType>(num_rows), inverse->get_const_row_ptrs(),
+                static_cast<IndexType>(num_rows), inverse.row_ptrs,
                 excess_rhs_ptrs, as_device_type(excess_solution.values),
-                as_device_type(inverse->get_values()), e_start, e_end);
+                as_device_type(inverse.values), e_start, e_end);
     }
 }
 

--- a/common/cuda_hip/preconditioner/jacobi_generate_kernels.cpp
+++ b/common/cuda_hip/preconditioner/jacobi_generate_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -33,7 +33,7 @@ template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
 void generate(syn::value_list<int, max_block_size>,
               std::shared_ptr<const DefaultExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* mtx,
+              matrix::view::csr<const ValueType, const IndexType> mtx,
               remove_complex<ValueType> accuracy, ValueType* block_data,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&
                   storage_scheme,
@@ -46,7 +46,7 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_generate, generate);
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const DefaultExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* system_matrix,
+              matrix::view::csr<const ValueType, const IndexType> system_matrix,
               size_type num_blocks, uint32 max_block_size,
               remove_complex<ValueType> accuracy,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&

--- a/common/cuda_hip/preconditioner/jacobi_generate_kernels.instantiate.cpp
+++ b/common/cuda_hip/preconditioner/jacobi_generate_kernels.instantiate.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -219,7 +219,7 @@ template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
 void generate(syn::value_list<int, max_block_size>,
               std::shared_ptr<const DefaultExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* mtx,
+              matrix::view::csr<const ValueType, const IndexType> mtx,
               remove_complex<ValueType> accuracy, ValueType* block_data,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&
                   storage_scheme,
@@ -238,34 +238,31 @@ void generate(syn::value_list<int, max_block_size>,
             kernel::adaptive_generate<max_block_size, subwarp_size,
                                       warps_per_block>
                 <<<grid_size, block_size, 0, exec->get_stream()>>>(
-                    mtx->get_size()[0], mtx->get_const_row_ptrs(),
-                    mtx->get_const_col_idxs(),
-                    as_device_type(mtx->get_const_values()),
-                    as_device_type(accuracy), as_device_type(block_data),
-                    storage_scheme, as_device_type(conditioning),
-                    block_precisions, block_ptrs, num_blocks);
+                    mtx.size[0], mtx.row_ptrs, mtx.col_idxs,
+                    as_device_type(mtx.values), as_device_type(accuracy),
+                    as_device_type(block_data), storage_scheme,
+                    as_device_type(conditioning), block_precisions, block_ptrs,
+                    num_blocks);
         } else {
             kernel::generate<max_block_size, subwarp_size, warps_per_block>
                 <<<grid_size, block_size, 0, exec->get_stream()>>>(
-                    mtx->get_size()[0], mtx->get_const_row_ptrs(),
-                    mtx->get_const_col_idxs(),
-                    as_device_type(mtx->get_const_values()),
-                    as_device_type(block_data), storage_scheme, block_ptrs,
-                    num_blocks);
+                    mtx.size[0], mtx.row_ptrs, mtx.col_idxs,
+                    as_device_type(mtx.values), as_device_type(block_data),
+                    storage_scheme, block_ptrs, num_blocks);
         }
     }
 }
 
 
-#define DECLARE_JACOBI_GENERATE_INSTANTIATION(ValueType, IndexType)          \
-    void generate<config::min_warps_per_block, GKO_JACOBI_BLOCK_SIZE,        \
-                  ValueType, IndexType>(                                     \
-        syn::value_list<int, GKO_JACOBI_BLOCK_SIZE>,                         \
-        std::shared_ptr<const DefaultExecutor> exec,                         \
-        const matrix::Csr<ValueType, IndexType>*, remove_complex<ValueType>, \
-        ValueType*,                                                          \
-        const preconditioner::block_interleaved_storage_scheme<IndexType>&,  \
-        remove_complex<ValueType>*, precision_reduction*, const IndexType*,  \
+#define DECLARE_JACOBI_GENERATE_INSTANTIATION(ValueType, IndexType)         \
+    void generate<config::min_warps_per_block, GKO_JACOBI_BLOCK_SIZE,       \
+                  ValueType, IndexType>(                                    \
+        syn::value_list<int, GKO_JACOBI_BLOCK_SIZE>,                        \
+        std::shared_ptr<const DefaultExecutor> exec,                        \
+        matrix::view::csr<const ValueType, const IndexType>,                \
+        remove_complex<ValueType>, ValueType*,                              \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>&, \
+        remove_complex<ValueType>*, precision_reduction*, const IndexType*, \
         size_type)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/cuda_hip/preconditioner/jacobi_kernels.cpp
+++ b/common/cuda_hip/preconditioner/jacobi_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -224,27 +224,26 @@ __launch_bounds__(warps_per_block* config::warp_size) adaptive_transpose_jacobi(
 
 
 template <typename ValueType, typename IndexType>
-size_type find_natural_blocks(std::shared_ptr<const DefaultExecutor> exec,
-                              const matrix::Csr<ValueType, IndexType>* mtx,
-                              int32 max_block_size,
-                              IndexType* __restrict__ block_ptrs)
+size_type find_natural_blocks(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    int32 max_block_size, IndexType* __restrict__ block_ptrs)
 {
     array<size_type> nums(exec, 1);
 
     // FIXME: num_rows == 0 bug
-    array<bool> matching_next_row(exec, mtx->get_size()[0] - 1);
+    array<bool> matching_next_row(exec, mtx.size[0] - 1);
 
     const auto block_size = config::warp_size;
-    const auto grid_size =
-        ceildiv(mtx->get_size()[0] * config::warp_size, block_size);
+    const auto grid_size = ceildiv(mtx.size[0] * config::warp_size, block_size);
 
     if (grid_size > 0) {
         compare_adjacent_rows<<<grid_size, block_size, 0, exec->get_stream()>>>(
-            mtx->get_size()[0], max_block_size, mtx->get_const_row_ptrs(),
-            mtx->get_const_col_idxs(), matching_next_row.get_data());
+            mtx.size[0], max_block_size, mtx.row_ptrs, mtx.col_idxs,
+            matching_next_row.get_data());
     }
     generate_natural_block_pointer<<<1, 1, 0, exec->get_stream()>>>(
-        mtx->get_size()[0], max_block_size, matching_next_row.get_const_data(),
+        mtx.size[0], max_block_size, matching_next_row.get_const_data(),
         block_ptrs, nums.get_data());
     nums.set_executor(exec->get_master());
     return nums.get_const_data()[0];
@@ -286,10 +285,11 @@ void initialize_precisions(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void find_blocks(std::shared_ptr<const DefaultExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* system_matrix,
-                 uint32 max_block_size, size_type& num_blocks,
-                 array<IndexType>& block_pointers)
+void find_blocks(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    uint32 max_block_size, size_type& num_blocks,
+    array<IndexType>& block_pointers)
 {
     auto num_natural_blocks = find_natural_blocks(
         exec, system_matrix, max_block_size, block_pointers.get_data());

--- a/common/cuda_hip/preconditioner/sor_kernels.cpp
+++ b/common/cuda_hip/preconditioner/sor_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,10 +18,11 @@ namespace sor {
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const auto block_size = factorization::helpers::default_block_size;
     const auto grid_dim = static_cast<uint32>(
         ceildiv(num_rows, static_cast<size_type>(block_size)));
@@ -33,11 +34,9 @@ void initialize_weighted_l(
 
         factorization::helpers::
             initialize_l<<<grid_dim, block_size, 0, exec->get_stream()>>>(
-                num_rows, system_matrix->get_const_row_ptrs(),
-                system_matrix->get_const_col_idxs(),
-                as_device_type(system_matrix->get_const_values()),
-                l_mtx->get_const_row_ptrs(), l_mtx->get_col_idxs(),
-                as_device_type(l_mtx->get_values()),
+                num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+                as_device_type(system_matrix.values), l_mtx.row_ptrs,
+                l_mtx.col_idxs, as_device_type(l_mtx.values),
                 triangular_mtx_closure(
                     [inv_weight] __device__(auto val) {
                         return val * inv_weight;
@@ -53,11 +52,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l_u(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx,
-    matrix::Csr<ValueType, IndexType>* u_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx,
+    matrix::view::csr<ValueType, IndexType> u_mtx)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const auto block_size = factorization::helpers::default_block_size;
     const auto grid_dim = static_cast<uint32>(
         ceildiv(num_rows, static_cast<size_type>(block_size)));
@@ -72,13 +72,10 @@ void initialize_weighted_l_u(
 
         factorization::helpers::
             initialize_l_u<<<grid_dim, block_size, 0, exec->get_stream()>>>(
-                num_rows, system_matrix->get_const_row_ptrs(),
-                system_matrix->get_const_col_idxs(),
-                as_device_type(system_matrix->get_const_values()),
-                l_mtx->get_const_row_ptrs(), l_mtx->get_col_idxs(),
-                as_device_type(l_mtx->get_values()),
-                u_mtx->get_const_row_ptrs(), u_mtx->get_col_idxs(),
-                as_device_type(u_mtx->get_values()),
+                num_rows, system_matrix.row_ptrs, system_matrix.col_idxs,
+                as_device_type(system_matrix.values), l_mtx.row_ptrs,
+                l_mtx.col_idxs, as_device_type(l_mtx.values), u_mtx.row_ptrs,
+                u_mtx.col_idxs, as_device_type(u_mtx.values),
                 triangular_mtx_closure(
                     [inv_weight] __device__(auto val) {
                         return val * inv_weight;

--- a/common/unified/matrix/csr_kernels.cpp
+++ b/common/unified/matrix/csr_kernels.cpp
@@ -26,11 +26,11 @@ namespace csr {
 template <typename ValueType, typename IndexType>
 void inv_col_permute(std::shared_ptr<const DefaultExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* col_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto num_rows = orig->get_size()[0];
-    auto nnz = orig->get_num_stored_elements();
+    auto num_rows = orig.size[0];
+    auto nnz = orig.num_stored_elements;
     auto size = std::max(num_rows + 1, nnz);
     run_kernel(
         exec,
@@ -46,10 +46,8 @@ void inv_col_permute(std::shared_ptr<const DefaultExecutor> exec,
                 out_row_ptrs[tid] = in_row_ptrs[tid];
             }
         },
-        size, num_rows, nnz, perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), orig->get_const_values(),
-        col_permuted->get_row_ptrs(), col_permuted->get_col_idxs(),
-        col_permuted->get_values());
+        size, num_rows, nnz, perm, orig.row_ptrs, orig.col_idxs, orig.values,
+        col_permuted.row_ptrs, col_permuted.col_idxs, col_permuted.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -57,13 +55,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_col_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* col_permuted)
+void inv_col_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto num_rows = orig->get_size()[0];
-    auto nnz = orig->get_num_stored_elements();
+    auto num_rows = orig.size[0];
+    auto nnz = orig.num_stored_elements;
     auto size = std::max(num_rows + 1, nnz);
     run_kernel(
         exec,
@@ -80,10 +79,9 @@ void inv_col_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
                 out_row_ptrs[tid] = in_row_ptrs[tid];
             }
         },
-        size, num_rows, nnz, scale, perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), orig->get_const_values(),
-        col_permuted->get_row_ptrs(), col_permuted->get_col_idxs(),
-        col_permuted->get_values());
+        size, num_rows, nnz, scale, perm, orig.row_ptrs, orig.col_idxs,
+        orig.values, col_permuted.row_ptrs, col_permuted.col_idxs,
+        col_permuted.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -93,12 +91,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void scale(std::shared_ptr<const DefaultExecutor> exec,
            matrix::view::dense<const ValueType> alpha,
-           matrix::Csr<ValueType, IndexType>* x)
+           matrix::view::csr<ValueType, IndexType> x)
 {
     run_kernel(
         exec,
         [] GKO_KERNEL(auto nnz, auto alpha, auto x) { x[nnz] *= alpha[0]; },
-        x->get_num_stored_elements(), alpha.values, x->get_values());
+        x.num_stored_elements, alpha.values, x.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SCALE_KERNEL);
@@ -107,21 +105,22 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SCALE_KERNEL);
 template <typename ValueType, typename IndexType>
 void inv_scale(std::shared_ptr<const DefaultExecutor> exec,
                matrix::view::dense<const ValueType> alpha,
-               matrix::Csr<ValueType, IndexType>* x)
+               matrix::view::csr<ValueType, IndexType> x)
 {
     run_kernel(
         exec,
         [] GKO_KERNEL(auto nnz, auto alpha, auto x) { x[nnz] /= alpha[0]; },
-        x->get_num_stored_elements(), alpha.values, x->get_values());
+        x.num_stored_elements, alpha.values, x.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_INV_SCALE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* matrix,
-                      matrix::view::sellp<ValueType, IndexType> output)
+void convert_to_sellp(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> matrix,
+    matrix::view::sellp<ValueType, IndexType> output)
 {
     run_kernel(
         exec,
@@ -144,8 +143,7 @@ void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                 out_idx += slice_size;
             }
         },
-        output.size[0], matrix->get_const_col_idxs(),
-        matrix->get_const_values(), matrix->get_const_row_ptrs(),
+        output.size[0], matrix.col_idxs, matrix.values, matrix.row_ptrs,
         output.slice_size, output.slice_sets, output.col_idxs, output.values);
 }
 
@@ -155,7 +153,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* matrix,
+                    matrix::view::csr<const ValueType, const IndexType> matrix,
                     matrix::view::ell<ValueType, IndexType> output)
 {
     run_kernel(
@@ -174,8 +172,7 @@ void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,
                 out_idx += ell_stride;
             }
         },
-        output.size[0], matrix->get_const_col_idxs(),
-        matrix->get_const_values(), matrix->get_const_row_ptrs(),
+        output.size[0], matrix.col_idxs, matrix.values, matrix.row_ptrs,
         output.num_stored_elements_per_row, output.stride, output.col_idxs,
         output.values);
 }
@@ -185,10 +182,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       const int64* coo_row_ptrs,
-                       matrix::view::hybrid<ValueType, IndexType> result)
+void convert_to_hybrid(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const int64* coo_row_ptrs,
+    matrix::view::hybrid<ValueType, IndexType> result)
 {
     run_kernel(
         exec,
@@ -216,8 +214,7 @@ void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,
                 coo_vals[out_idx] = vals[in_idx];
             }
         },
-        source->get_size()[0], source->get_const_row_ptrs(),
-        source->get_const_col_idxs(), source->get_const_values(),
+        source.size[0], source.row_ptrs, source.col_idxs, source.values,
         result.ell_part.stride, result.ell_part.num_stored_elements_per_row,
         result.ell_part.col_idxs, result.ell_part.values, coo_row_ptrs,
         result.coo_part.row_idxs, result.coo_part.col_idxs,
@@ -311,9 +308,10 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_CSR_BENCHMARK_LOOKUP_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           array<ValueType>& sum)
+void row_wise_absolute_sum(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    array<ValueType>& sum)
 {
     run_kernel(
         exec,
@@ -323,8 +321,7 @@ void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,
                 sum_ptr[row] += abs(value_ptr[k]);
             }
         },
-        sum.get_size(), orig->get_const_row_ptrs(), orig->get_const_values(),
-        sum.get_data());
+        sum.get_size(), orig.row_ptrs, orig.values, sum.get_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/csr_kernels.cpp
+++ b/common/unified/matrix/csr_kernels.cpp
@@ -26,11 +26,11 @@ namespace csr {
 template <typename ValueType, typename IndexType>
 void inv_col_permute(std::shared_ptr<const DefaultExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* col_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto num_rows = orig->get_size()[0];
-    auto nnz = orig->get_num_stored_elements();
+    auto num_rows = orig.size[0];
+    auto nnz = orig.num_stored_elements;
     auto size = std::max(num_rows + 1, nnz);
     run_kernel(
         exec,
@@ -46,10 +46,8 @@ void inv_col_permute(std::shared_ptr<const DefaultExecutor> exec,
                 out_row_ptrs[tid] = in_row_ptrs[tid];
             }
         },
-        size, num_rows, nnz, perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), orig->get_const_values(),
-        col_permuted->get_row_ptrs(), col_permuted->get_col_idxs(),
-        col_permuted->get_values());
+        size, num_rows, nnz, perm, orig.row_ptrs, orig.col_idxs, orig.values,
+        col_permuted.row_ptrs, col_permuted.col_idxs, col_permuted.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -57,13 +55,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_col_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* col_permuted)
+void inv_col_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto num_rows = orig->get_size()[0];
-    auto nnz = orig->get_num_stored_elements();
+    auto num_rows = orig.size[0];
+    auto nnz = orig.num_stored_elements;
     auto size = std::max(num_rows + 1, nnz);
     run_kernel(
         exec,
@@ -80,10 +79,9 @@ void inv_col_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
                 out_row_ptrs[tid] = in_row_ptrs[tid];
             }
         },
-        size, num_rows, nnz, scale, perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), orig->get_const_values(),
-        col_permuted->get_row_ptrs(), col_permuted->get_col_idxs(),
-        col_permuted->get_values());
+        size, num_rows, nnz, scale, perm, orig.row_ptrs, orig.col_idxs,
+        orig.values, col_permuted.row_ptrs, col_permuted.col_idxs,
+        col_permuted.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -93,12 +91,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void scale(std::shared_ptr<const DefaultExecutor> exec,
            matrix::view::dense<const ValueType> alpha,
-           matrix::Csr<ValueType, IndexType>* x)
+           matrix::view::csr<ValueType, IndexType> x)
 {
     run_kernel(
         exec,
         [] GKO_KERNEL(auto nnz, auto alpha, auto x) { x[nnz] *= alpha[0]; },
-        x->get_num_stored_elements(), alpha.values, x->get_values());
+        x.num_stored_elements, alpha.values, x.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SCALE_KERNEL);
@@ -107,21 +105,22 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SCALE_KERNEL);
 template <typename ValueType, typename IndexType>
 void inv_scale(std::shared_ptr<const DefaultExecutor> exec,
                matrix::view::dense<const ValueType> alpha,
-               matrix::Csr<ValueType, IndexType>* x)
+               matrix::view::csr<ValueType, IndexType> x)
 {
     run_kernel(
         exec,
         [] GKO_KERNEL(auto nnz, auto alpha, auto x) { x[nnz] /= alpha[0]; },
-        x->get_num_stored_elements(), alpha.values, x->get_values());
+        x.num_stored_elements, alpha.values, x.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_INV_SCALE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* matrix,
-                      matrix::view::sellp<ValueType, IndexType> output)
+void convert_to_sellp(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> matrix,
+    matrix::view::sellp<ValueType, IndexType> output)
 {
     run_kernel(
         exec,
@@ -144,8 +143,7 @@ void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,
                 out_idx += slice_size;
             }
         },
-        output.size[0], matrix->get_const_col_idxs(),
-        matrix->get_const_values(), matrix->get_const_row_ptrs(),
+        output.size[0], matrix.col_idxs, matrix.values, matrix.row_ptrs,
         output.slice_size, output.slice_sets, output.col_idxs, output.values);
 }
 
@@ -155,7 +153,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* matrix,
+                    matrix::view::csr<const ValueType, const IndexType> matrix,
                     matrix::view::ell<ValueType, IndexType> output)
 {
     run_kernel(
@@ -174,8 +172,7 @@ void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,
                 out_idx += ell_stride;
             }
         },
-        output.size[0], matrix->get_const_col_idxs(),
-        matrix->get_const_values(), matrix->get_const_row_ptrs(),
+        output.size[0], matrix.col_idxs, matrix.values, matrix.row_ptrs,
         output.num_stored_elements_per_row, output.stride, output.col_idxs,
         output.values);
 }
@@ -185,10 +182,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       const int64* coo_row_ptrs,
-                       matrix::Hybrid<ValueType, IndexType>* result)
+void convert_to_hybrid(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const int64* coo_row_ptrs, matrix::Hybrid<ValueType, IndexType>* result)
 {
     run_kernel(
         exec,
@@ -216,8 +213,7 @@ void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,
                 coo_vals[out_idx] = vals[in_idx];
             }
         },
-        source->get_size()[0], source->get_const_row_ptrs(),
-        source->get_const_col_idxs(), source->get_const_values(),
+        source.size[0], source.row_ptrs, source.col_idxs, source.values,
         result->get_ell_stride(), result->get_ell_num_stored_elements_per_row(),
         result->get_ell_col_idxs(), result->get_ell_values(), coo_row_ptrs,
         result->get_coo_row_idxs(), result->get_coo_col_idxs(),
@@ -311,9 +307,10 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_CSR_BENCHMARK_LOOKUP_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           array<ValueType>& sum)
+void row_wise_absolute_sum(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    array<ValueType>& sum)
 {
     run_kernel(
         exec,
@@ -323,8 +320,7 @@ void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,
                 sum_ptr[row] += abs(value_ptr[k]);
             }
         },
-        sum.get_size(), orig->get_const_row_ptrs(), orig->get_const_values(),
-        sum.get_data());
+        sum.get_size(), orig.row_ptrs, orig.values, sum.get_data());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/diagonal_kernels.cpp
+++ b/common/unified/matrix/diagonal_kernels.cpp
@@ -102,7 +102,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Diagonal<ValueType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     run_kernel(
         exec,
@@ -116,8 +116,8 @@ void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
             }
         },
         source->get_size()[0], source->get_size()[0],
-        source->get_const_values(), result->get_row_ptrs(),
-        result->get_col_idxs(), result->get_values());
+        source->get_const_values(), result.row_ptrs, result.col_idxs,
+        result.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/diagonal_kernels.cpp
+++ b/common/unified/matrix/diagonal_kernels.cpp
@@ -60,18 +60,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType, typename IndexType>
 void right_apply_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                         const matrix::Diagonal<ValueType>* a,
-                        const matrix::Csr<ValueType, IndexType>* b,
-                        matrix::Csr<ValueType, IndexType>* c)
+                        matrix::view::csr<const ValueType, const IndexType> b,
+                        matrix::view::csr<ValueType, IndexType> c)
 {
-    // TODO: combine copy and diag apply together
-    c->copy_from(b);
     run_kernel(
         exec,
         [] GKO_KERNEL(auto tidx, auto diag, auto result_values, auto col_idxs) {
             result_values[tidx] *= diag[col_idxs[tidx]];
         },
-        c->get_num_stored_elements(), a->get_const_values(), c->get_values(),
-        c->get_const_col_idxs());
+        c.num_stored_elements, a->get_const_values(), c.values, c.col_idxs);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/ell_kernels.cpp
+++ b/common/unified/matrix/ell_kernels.cpp
@@ -123,7 +123,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_ELL_COPY_KERNEL);
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::ell<const ValueType, const IndexType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     // ELL is stored in column-major, so we swap row and column parameters
     run_kernel(
@@ -141,7 +141,7 @@ void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
         },
         dim<2>{source.num_stored_elements_per_row, source.size[0]},
         static_cast<int64>(source.stride), source.col_idxs, source.values,
-        result->get_row_ptrs(), result->get_col_idxs(), result->get_values());
+        result.row_ptrs, result.col_idxs, result.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/hybrid_kernels.cpp
+++ b/common/unified/matrix/hybrid_kernels.cpp
@@ -98,7 +98,7 @@ void convert_to_csr(
     std::shared_ptr<const DefaultExecutor> exec,
     matrix::view::hybrid<const ValueType, const IndexType> source,
     const IndexType* ell_row_ptrs, const IndexType* coo_row_ptrs,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
     const auto ell = source.ell_part;
     const auto coo = source.coo_part;
@@ -119,14 +119,14 @@ void convert_to_csr(
         },
         dim<2>{ell.num_stored_elements_per_row, ell.size[0]},
         static_cast<int64>(ell.stride), ell.col_idxs, ell.values, ell_row_ptrs,
-        coo_row_ptrs, result->get_col_idxs(), result->get_values());
+        coo_row_ptrs, result.col_idxs, result.values);
     run_kernel(
         exec,
         [] GKO_KERNEL(auto idx, auto ell_row_ptrs, auto coo_row_ptrs,
                       auto out_row_ptrs) {
             out_row_ptrs[idx] = ell_row_ptrs[idx] + coo_row_ptrs[idx];
         },
-        source.size[0] + 1, ell_row_ptrs, coo_row_ptrs, result->get_row_ptrs());
+        source.size[0] + 1, ell_row_ptrs, coo_row_ptrs, result.row_ptrs);
     run_kernel(
         exec,
         [] GKO_KERNEL(auto idx, auto in_rows, auto in_cols, auto in_vals,
@@ -144,8 +144,7 @@ void convert_to_csr(
             out_vals[out_idx] = val;
         },
         coo.num_stored_elements, coo.row_idxs, coo.col_idxs, coo.values,
-        ell_row_ptrs, coo_row_ptrs, result->get_col_idxs(),
-        result->get_values());
+        ell_row_ptrs, coo_row_ptrs, result.col_idxs, result.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/hybrid_kernels.cpp
+++ b/common/unified/matrix/hybrid_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -98,7 +98,7 @@ void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Hybrid<ValueType, IndexType>* source,
                     const IndexType* ell_row_ptrs,
                     const IndexType* coo_row_ptrs,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     const auto ell = source->get_ell();
     const auto coo = source->get_coo();
@@ -119,16 +119,15 @@ void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
         },
         dim<2>{ell->get_num_stored_elements_per_row(), ell->get_size()[0]},
         static_cast<int64>(ell->get_stride()), ell->get_const_col_idxs(),
-        ell->get_const_values(), ell_row_ptrs, coo_row_ptrs,
-        result->get_col_idxs(), result->get_values());
+        ell->get_const_values(), ell_row_ptrs, coo_row_ptrs, result.col_idxs,
+        result.values);
     run_kernel(
         exec,
         [] GKO_KERNEL(auto idx, auto ell_row_ptrs, auto coo_row_ptrs,
                       auto out_row_ptrs) {
             out_row_ptrs[idx] = ell_row_ptrs[idx] + coo_row_ptrs[idx];
         },
-        source->get_size()[0] + 1, ell_row_ptrs, coo_row_ptrs,
-        result->get_row_ptrs());
+        source->get_size()[0] + 1, ell_row_ptrs, coo_row_ptrs, result.row_ptrs);
     run_kernel(
         exec,
         [] GKO_KERNEL(auto idx, auto in_rows, auto in_cols, auto in_vals,
@@ -147,7 +146,7 @@ void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
         },
         coo->get_num_stored_elements(), coo->get_const_row_idxs(),
         coo->get_const_col_idxs(), coo->get_const_values(), ell_row_ptrs,
-        coo_row_ptrs, result->get_col_idxs(), result->get_values());
+        coo_row_ptrs, result.col_idxs, result.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/matrix/sellp_kernels.cpp
+++ b/common/unified/matrix/sellp_kernels.cpp
@@ -156,7 +156,7 @@ template <typename ValueType, typename IndexType>
 void convert_to_csr(
     std::shared_ptr<const DefaultExecutor> exec,
     matrix::view::sellp<const ValueType, const IndexType> source,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
     run_kernel(
         exec,
@@ -178,8 +178,7 @@ void convert_to_csr(
             }
         },
         source.size[0], source.slice_size, source.slice_sets, source.col_idxs,
-        source.values, result->get_row_ptrs(), result->get_col_idxs(),
-        result->get_values());
+        source.values, result.row_ptrs, result.col_idxs, result.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/unified/multigrid/pgm_kernels.cpp
+++ b/common/unified/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -146,7 +146,7 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void find_strongest_neighbor(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* weight_mtx,
+    matrix::view::csr<const ValueType, const IndexType> weight_mtx,
     const matrix::Diagonal<ValueType>* diag, array<IndexType>& agg,
     array<IndexType>& strongest_neighbor)
 {
@@ -196,9 +196,8 @@ void find_strongest_neighbor(
                 strongest_neighbor[row] = row;
             }
         },
-        agg.get_size(), weight_mtx->get_const_row_ptrs(),
-        weight_mtx->get_const_col_idxs(), weight_mtx->get_const_values(),
-        diag->get_const_values(), agg.get_data(),
+        agg.get_size(), weight_mtx.row_ptrs, weight_mtx.col_idxs,
+        weight_mtx.values, diag->get_const_values(), agg.get_data(),
         strongest_neighbor.get_data());
 }
 
@@ -206,11 +205,11 @@ GKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_PGM_FIND_STRONGEST_NEIGHBOR);
 
 template <typename ValueType, typename IndexType>
-void assign_to_exist_agg(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* weight_mtx,
-                         const matrix::Diagonal<ValueType>* diag,
-                         array<IndexType>& agg,
-                         array<IndexType>& intermediate_agg)
+void assign_to_exist_agg(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> weight_mtx,
+    const matrix::Diagonal<ValueType>* diag, array<IndexType>& agg,
+    array<IndexType>& intermediate_agg)
 {
     const auto num = agg.get_size();
     if (intermediate_agg.get_size() > 0) {
@@ -246,8 +245,7 @@ void assign_to_exist_agg(std::shared_ptr<const DefaultExecutor> exec,
                     agg_val[row] = row;
                 }
             },
-            num, weight_mtx->get_const_row_ptrs(),
-            weight_mtx->get_const_col_idxs(), weight_mtx->get_const_values(),
+            num, weight_mtx.row_ptrs, weight_mtx.col_idxs, weight_mtx.values,
             diag->get_const_values(), agg.get_const_data(),
             intermediate_agg.get_data());
         // Copy the intermediate_agg to agg
@@ -284,8 +282,7 @@ void assign_to_exist_agg(std::shared_ptr<const DefaultExecutor> exec,
                     agg_val[row] = row;
                 }
             },
-            num, weight_mtx->get_const_row_ptrs(),
-            weight_mtx->get_const_col_idxs(), weight_mtx->get_const_values(),
+            num, weight_mtx.row_ptrs, weight_mtx.col_idxs, weight_mtx.values,
             diag->get_const_values(), agg.get_data());
     }
 }

--- a/common/unified/multigrid/rs_kernels.cpp
+++ b/common/unified/multigrid/rs_kernels.cpp
@@ -25,7 +25,7 @@ namespace rs {
 
 template <typename ValueType, typename IndexType>
 void check_m_matrix(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* matrix,
+                    matrix::view::csr<const ValueType, const IndexType> matrix,
                     array<bool>& is_m_matrix_array)
 {
     GKO_NOT_IMPLEMENTED;
@@ -35,11 +35,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_RS_CHECK_M_MATRIX_KERNEL);
 
 template <typename ValueType, typename IndexType>
-void compute_soc_and_run_rs(std::shared_ptr<const DefaultExecutor> exec,
-                            const matrix::Csr<ValueType, IndexType>* A,
-                            double theta, array<bool>& is_strong,
-                            array<IndexType>& lambda,
-                            array<IndexType>& cf_marker, IndexType& coarse_size)
+void compute_soc_and_run_rs(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> A, double theta,
+    array<bool>& is_strong, array<IndexType>& lambda,
+    array<IndexType>& cf_marker, IndexType& coarse_size)
 {
     GKO_NOT_IMPLEMENTED;
 }
@@ -53,8 +53,8 @@ void fill_coarse_and_compute_prolong_row_ptrs(
     std::shared_ptr<const DefaultExecutor> exec,
     const array<IndexType>& cf_marker, array<IndexType>& coarse_rows,
     array<IndexType>& fine_to_coarse,
-    const matrix::Csr<ValueType, IndexType>* A, const array<bool>& is_strong,
-    array<IndexType>& row_ptrs)
+    matrix::view::csr<const ValueType, const IndexType> A,
+    const array<bool>& is_strong, array<IndexType>& row_ptrs)
 {
     GKO_NOT_IMPLEMENTED;
 }
@@ -64,12 +64,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_interpolation(std::shared_ptr<const DefaultExecutor> exec,
-                           const matrix::Csr<ValueType, IndexType>* A,
-                           const bool* is_strong,
-                           const array<IndexType>& cf_marker,
-                           const IndexType* fine_to_coarse,
-                           matrix::Csr<ValueType, IndexType>* P)
+void compute_interpolation(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> A,
+    const bool* is_strong, const array<IndexType>& cf_marker,
+    const IndexType* fine_to_coarse, matrix::view::csr<ValueType, IndexType> P)
 {
     GKO_NOT_IMPLEMENTED;
 }

--- a/common/unified/preconditioner/jacobi_kernels.cpp
+++ b/common/unified/preconditioner/jacobi_kernels.cpp
@@ -124,7 +124,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 
 template <typename ValueType, typename IndexType>
 void scalar_l1(std::shared_ptr<const DefaultExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* csr,
+               matrix::view::csr<const ValueType, const IndexType> csr,
                matrix::Diagonal<ValueType>* diag)
 {
     run_kernel(
@@ -143,8 +143,8 @@ void scalar_l1(std::shared_ptr<const DefaultExecutor> exec,
             // value.
             diag[row] += off_diag;
         },
-        csr->get_size()[0], csr->get_const_row_ptrs(),
-        csr->get_const_col_idxs(), csr->get_const_values(), diag->get_values());
+        csr.size[0], csr.row_ptrs, csr.col_idxs, csr.values,
+        diag->get_values());
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -154,7 +154,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void block_l1(std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,
               const array<IndexType>& block_ptrs,
-              matrix::Csr<ValueType, IndexType>* csr)
+              matrix::view::csr<ValueType, IndexType> csr)
 {
     // Note: there are two another possible ways to do it.
     // 1. allocate block_num * max_block_size -> have enough thread for rows in
@@ -186,8 +186,8 @@ void block_l1(std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,
                 vals[diag_idx] += off_diag;
             }
         },
-        num_blocks, block_ptrs.get_const_data(), csr->get_const_row_ptrs(),
-        csr->get_const_col_idxs(), csr->get_values());
+        num_blocks, block_ptrs.get_const_data(), csr.row_ptrs, csr.col_idxs,
+        csr.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/core/distributed/preconditioner/schwarz.cpp
+++ b/core/distributed/preconditioner/schwarz.cpp
@@ -222,8 +222,8 @@ void Schwarz<ValueType, LocalIndexType, GlobalIndexType>::generate(
 
         array<ValueType> l1_diag_arr{exec, diag_matrix->get_size()[0]};
 
-        exec->run(
-            make_row_wise_absolute_sum(off_diag_matrix.get(), l1_diag_arr));
+        exec->run(make_row_wise_absolute_sum(
+            off_diag_matrix->get_const_device_view(), l1_diag_arr));
 
         // compute diag_matrix_copy <- diag(l1) + diag_matrix_copy
         auto l1_diag = matrix::Diagonal<ValueType>::create(

--- a/core/factorization/cholesky.cpp
+++ b/core/factorization/cholesky.cpp
@@ -101,7 +101,7 @@ std::unique_ptr<LinOp> Cholesky<ValueType, IndexType>::generate_impl(
         forest =
             std::make_unique<gko::factorization::elimination_forest<IndexType>>(
                 exec, num_rows);
-        exec->run(make_from_factor(factors.get(), *forest));
+        exec->run(make_from_factor(factors->get_const_device_view(), *forest));
     }
     // setup lookup structure on factors
     const auto lookup = matrix::csr::build_lookup(factors.get());
@@ -112,16 +112,17 @@ std::unique_ptr<LinOp> Cholesky<ValueType, IndexType>::generate_impl(
                               factors->get_num_stored_elements(),
                               zero<ValueType>()));
     exec->run(make_initialize(
-        mtx.get(), lookup.storage_offsets.get_const_data(),
+        mtx->get_const_device_view(), lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-        diag_idxs.get_data(), transpose_idxs.get_data(), factors.get()));
+        diag_idxs.get_data(), transpose_idxs.get_data(),
+        factors->get_device_view()));
     // run numerical factorization
     array<int> tmp{exec};
     exec->run(make_factorize(
         lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
         diag_idxs.get_const_data(), transpose_idxs.get_const_data(), *forest,
-        factors.get(), true, tmp));
+        factors->get_device_view(), true, tmp));
     return factorization_type::create_from_combined_cholesky(
         std::move(factors));
 }

--- a/core/factorization/cholesky.cpp
+++ b/core/factorization/cholesky.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -102,7 +102,7 @@ std::unique_ptr<LinOp> Cholesky<ValueType, IndexType>::generate_impl(
         forest =
             std::make_unique<gko::factorization::elimination_forest<IndexType>>(
                 exec, num_rows);
-        exec->run(make_from_factor(factors.get(), *forest));
+        exec->run(make_from_factor(factors->get_const_device_view(), *forest));
     }
     // setup lookup structure on factors
     const auto lookup = matrix::csr::build_lookup(factors.get());
@@ -113,16 +113,17 @@ std::unique_ptr<LinOp> Cholesky<ValueType, IndexType>::generate_impl(
                               factors->get_num_stored_elements(),
                               zero<ValueType>()));
     exec->run(make_initialize(
-        mtx.get(), lookup.storage_offsets.get_const_data(),
+        mtx->get_const_device_view(), lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-        diag_idxs.get_data(), transpose_idxs.get_data(), factors.get()));
+        diag_idxs.get_data(), transpose_idxs.get_data(),
+        factors->get_device_view()));
     // run numerical factorization
     array<int> tmp{exec};
     exec->run(make_factorize(
         lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
         diag_idxs.get_const_data(), transpose_idxs.get_const_data(), *forest,
-        factors.get(), true, tmp));
+        factors->get_device_view(), true, tmp));
     return factorization_type::create_from_combined_cholesky(
         std::move(factors));
 }

--- a/core/factorization/cholesky_kernels.hpp
+++ b/core/factorization/cholesky_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -23,7 +23,7 @@ namespace kernels {
 #define GKO_DECLARE_CHOLESKY_SYMBOLIC_COUNT(ValueType, IndexType)        \
     void symbolic_count(                                                 \
         std::shared_ptr<const DefaultExecutor> exec,                     \
-        const matrix::Csr<ValueType, IndexType>* mtx,                    \
+        matrix::view::csr<const ValueType, const IndexType> mtx,         \
         const gko::factorization::elimination_forest<IndexType>& forest, \
         IndexType* row_nnz, array<IndexType>& tmp_storage)
 
@@ -31,30 +31,30 @@ namespace kernels {
 #define GKO_DECLARE_CHOLESKY_SYMBOLIC_FACTORIZE(ValueType, IndexType)    \
     void symbolic_factorize(                                             \
         std::shared_ptr<const DefaultExecutor> exec,                     \
-        const matrix::Csr<ValueType, IndexType>* mtx,                    \
+        matrix::view::csr<const ValueType, const IndexType> mtx,         \
         const gko::factorization::elimination_forest<IndexType>& forest, \
-        matrix::Csr<ValueType, IndexType>* l_factor,                     \
+        matrix::view::csr<ValueType, IndexType> l_factor,                \
         const array<IndexType>& tmp_storage)
 
 
 #define GKO_DECLARE_CHOLESKY_INITIALIZE(ValueType, IndexType)                 \
     void initialize(std::shared_ptr<const DefaultExecutor> exec,              \
-                    const matrix::Csr<ValueType, IndexType>* mtx,             \
+                    matrix::view::csr<const ValueType, const IndexType> mtx,  \
                     const IndexType* factor_lookup_offsets,                   \
                     const int64* factor_lookup_descs,                         \
                     const int32* factor_lookup_storage, IndexType* diag_idxs, \
                     IndexType* transpose_idxs,                                \
-                    matrix::Csr<ValueType, IndexType>* factors)
+                    matrix::view::csr<ValueType, IndexType> factors)
 
 
-#define GKO_DECLARE_CHOLESKY_FACTORIZE(ValueType, IndexType)             \
-    void factorize(                                                      \
-        std::shared_ptr<const DefaultExecutor> exec,                     \
-        const IndexType* lookup_offsets, const int64* lookup_descs,      \
-        const int32* lookup_storage, const IndexType* diag_idxs,         \
-        const IndexType* transpose_idxs,                                 \
-        const gko::factorization::elimination_forest<IndexType>& forest, \
-        matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,    \
+#define GKO_DECLARE_CHOLESKY_FACTORIZE(ValueType, IndexType)               \
+    void factorize(                                                        \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        const IndexType* lookup_offsets, const int64* lookup_descs,        \
+        const int32* lookup_storage, const IndexType* diag_idxs,           \
+        const IndexType* transpose_idxs,                                   \
+        const gko::factorization::elimination_forest<IndexType>& forest,   \
+        matrix::view::csr<ValueType, IndexType> factors, bool full_fillin, \
         array<int>& tmp_storage)
 
 

--- a/core/factorization/elimination_forest_kernels.hpp
+++ b/core/factorization/elimination_forest_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -31,7 +31,7 @@ namespace kernels {
 #define GKO_DECLARE_ELIMINATION_FOREST_FROM_FACTOR(ValueType, IndexType) \
     void from_factor(                                                    \
         std::shared_ptr<const DefaultExecutor> exec,                     \
-        const matrix::Csr<ValueType, IndexType>* factors,                \
+        matrix::view::csr<const ValueType, const IndexType> factors,     \
         gko::factorization::elimination_forest<IndexType>& forest)
 
 

--- a/core/factorization/factorization.cpp
+++ b/core/factorization/factorization.cpp
@@ -56,7 +56,8 @@ Factorization<ValueType, IndexType>::unpack() const
         array<index_type> l_row_ptrs{exec, size[0] + 1};
         array<index_type> u_row_ptrs{exec, size[0] + 1};
         const auto mtx = this->get_combined();
-        exec->run(make_initialize_row_ptrs_l_u(mtx.get(), l_row_ptrs.get_data(),
+        exec->run(make_initialize_row_ptrs_l_u(mtx->get_const_device_view(),
+                                               l_row_ptrs.get_data(),
                                                u_row_ptrs.get_data()));
         const auto l_nnz =
             static_cast<size_type>(get_element(l_row_ptrs, size[0]));
@@ -70,7 +71,9 @@ Factorization<ValueType, IndexType>::unpack() const
             exec, size, array<value_type>{exec, u_nnz},
             array<index_type>{exec, u_nnz}, std::move(u_row_ptrs));
         // fill matrices
-        exec->run(make_initialize_l_u(mtx.get(), l_mtx.get(), u_mtx.get()));
+        exec->run(make_initialize_l_u(mtx->get_const_device_view(),
+                                      l_mtx->get_device_view(),
+                                      u_mtx->get_device_view()));
         return create_from_composition(
             composition_type::create(std::move(l_mtx), std::move(u_mtx)));
     }
@@ -78,7 +81,8 @@ Factorization<ValueType, IndexType>::unpack() const
         // count nonzeros
         array<index_type> l_row_ptrs{exec, size[0] + 1};
         const auto mtx = this->get_combined();
-        exec->run(make_initialize_row_ptrs_l(mtx.get(), l_row_ptrs.get_data()));
+        exec->run(make_initialize_row_ptrs_l(mtx->get_const_device_view(),
+                                             l_row_ptrs.get_data()));
         const auto l_nnz =
             static_cast<size_type>(get_element(l_row_ptrs, size[0]));
         // create matrices
@@ -86,7 +90,8 @@ Factorization<ValueType, IndexType>::unpack() const
             exec, size, array<value_type>{exec, l_nnz},
             array<index_type>{exec, l_nnz}, std::move(l_row_ptrs));
         // fill matrices
-        exec->run(make_initialize_l(mtx.get(), l_mtx.get(), false));
+        exec->run(make_initialize_l(mtx->get_const_device_view(),
+                                    l_mtx->get_device_view(), false));
         auto u_mtx = l_mtx->conj_transpose();
         return create_from_symm_composition(
             composition_type::create(std::move(l_mtx), std::move(u_mtx)));

--- a/core/factorization/factorization.cpp
+++ b/core/factorization/factorization.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -46,7 +46,8 @@ Factorization<ValueType, IndexType>::unpack() const
         array<index_type> l_row_ptrs{exec, size[0] + 1};
         array<index_type> u_row_ptrs{exec, size[0] + 1};
         const auto mtx = this->get_combined();
-        exec->run(make_initialize_row_ptrs_l_u(mtx.get(), l_row_ptrs.get_data(),
+        exec->run(make_initialize_row_ptrs_l_u(mtx->get_const_device_view(),
+                                               l_row_ptrs.get_data(),
                                                u_row_ptrs.get_data()));
         const auto l_nnz =
             static_cast<size_type>(get_element(l_row_ptrs, size[0]));
@@ -60,7 +61,9 @@ Factorization<ValueType, IndexType>::unpack() const
             exec, size, array<value_type>{exec, u_nnz},
             array<index_type>{exec, u_nnz}, std::move(u_row_ptrs));
         // fill matrices
-        exec->run(make_initialize_l_u(mtx.get(), l_mtx.get(), u_mtx.get()));
+        exec->run(make_initialize_l_u(mtx->get_const_device_view(),
+                                      l_mtx->get_device_view(),
+                                      u_mtx->get_device_view()));
         return create_from_composition(
             composition_type::create(std::move(l_mtx), std::move(u_mtx)));
     }
@@ -68,7 +71,8 @@ Factorization<ValueType, IndexType>::unpack() const
         // count nonzeros
         array<index_type> l_row_ptrs{exec, size[0] + 1};
         const auto mtx = this->get_combined();
-        exec->run(make_initialize_row_ptrs_l(mtx.get(), l_row_ptrs.get_data()));
+        exec->run(make_initialize_row_ptrs_l(mtx->get_const_device_view(),
+                                             l_row_ptrs.get_data()));
         const auto l_nnz =
             static_cast<size_type>(get_element(l_row_ptrs, size[0]));
         // create matrices
@@ -76,7 +80,8 @@ Factorization<ValueType, IndexType>::unpack() const
             exec, size, array<value_type>{exec, l_nnz},
             array<index_type>{exec, l_nnz}, std::move(l_row_ptrs));
         // fill matrices
-        exec->run(make_initialize_l(mtx.get(), l_mtx.get(), false));
+        exec->run(make_initialize_l(mtx->get_const_device_view(),
+                                    l_mtx->get_device_view(), false));
         auto u_mtx = l_mtx->conj_transpose();
         return create_from_symm_composition(
             composition_type::create(std::move(l_mtx), std::move(u_mtx)));

--- a/core/factorization/factorization_kernels.hpp
+++ b/core/factorization/factorization_kernels.hpp
@@ -31,36 +31,36 @@ namespace kernels {
                                                                  IndexType) \
     void initialize_row_ptrs_l_u(                                           \
         std::shared_ptr<const DefaultExecutor> exec,                        \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,             \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix,  \
         IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 
 #define GKO_DECLARE_FACTORIZATION_INITIALIZE_L_U_KERNEL(ValueType, IndexType) \
     void initialize_l_u(                                                      \
         std::shared_ptr<const DefaultExecutor> exec,                          \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,               \
-        matrix::Csr<ValueType, IndexType>* l_factor,                          \
-        matrix::Csr<ValueType, IndexType>* u_factor)
+        matrix::view::csr<const ValueType, const IndexType> system_matrix,    \
+        matrix::view::csr<ValueType, IndexType> l_factor,                     \
+        matrix::view::csr<ValueType, IndexType> u_factor)
 
-#define GKO_DECLARE_FACTORIZATION_INITIALIZE_ROW_PTRS_L_KERNEL(ValueType, \
-                                                               IndexType) \
-    void initialize_row_ptrs_l(                                           \
-        std::shared_ptr<const DefaultExecutor> exec,                      \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,           \
+#define GKO_DECLARE_FACTORIZATION_INITIALIZE_ROW_PTRS_L_KERNEL(ValueType,  \
+                                                               IndexType)  \
+    void initialize_row_ptrs_l(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
         IndexType* l_row_ptrs)
 
-#define GKO_DECLARE_FACTORIZATION_INITIALIZE_L_KERNEL(ValueType, IndexType)   \
-    void initialize_l(std::shared_ptr<const DefaultExecutor> exec,            \
-                      const matrix::Csr<ValueType, IndexType>* system_matrix, \
-                      matrix::Csr<ValueType, IndexType>* l_factor,            \
-                      bool diag_sqrt)
+#define GKO_DECLARE_FACTORIZATION_INITIALIZE_L_KERNEL(ValueType, IndexType) \
+    void initialize_l(                                                      \
+        std::shared_ptr<const DefaultExecutor> exec,                        \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix,  \
+        matrix::view::csr<ValueType, IndexType> l_factor, bool diag_sqrt)
 
-#define GKO_DECLARE_FACTORIZATION_SYMBOLIC_VALIDATE_KERNEL(ValueType, \
-                                                           IndexType) \
-    void symbolic_validate(                                           \
-        std::shared_ptr<const DefaultExecutor> exec,                  \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,       \
-        const matrix::Csr<ValueType, IndexType>* factors,             \
-        const matrix::csr::lookup_data<IndexType>& factors_lookup,    \
+#define GKO_DECLARE_FACTORIZATION_SYMBOLIC_VALIDATE_KERNEL(ValueType,      \
+                                                           IndexType)      \
+    void symbolic_validate(                                                \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
+        matrix::view::csr<const ValueType, const IndexType> factors,       \
+        const matrix::csr::lookup_data<IndexType>& factors_lookup,         \
         bool& valid)
 
 

--- a/core/factorization/factorization_kernels.hpp
+++ b/core/factorization/factorization_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,36 +30,36 @@ namespace kernels {
                                                                  IndexType) \
     void initialize_row_ptrs_l_u(                                           \
         std::shared_ptr<const DefaultExecutor> exec,                        \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,             \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix,  \
         IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 
 #define GKO_DECLARE_FACTORIZATION_INITIALIZE_L_U_KERNEL(ValueType, IndexType) \
     void initialize_l_u(                                                      \
         std::shared_ptr<const DefaultExecutor> exec,                          \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,               \
-        matrix::Csr<ValueType, IndexType>* l_factor,                          \
-        matrix::Csr<ValueType, IndexType>* u_factor)
+        matrix::view::csr<const ValueType, const IndexType> system_matrix,    \
+        matrix::view::csr<ValueType, IndexType> l_factor,                     \
+        matrix::view::csr<ValueType, IndexType> u_factor)
 
-#define GKO_DECLARE_FACTORIZATION_INITIALIZE_ROW_PTRS_L_KERNEL(ValueType, \
-                                                               IndexType) \
-    void initialize_row_ptrs_l(                                           \
-        std::shared_ptr<const DefaultExecutor> exec,                      \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,           \
+#define GKO_DECLARE_FACTORIZATION_INITIALIZE_ROW_PTRS_L_KERNEL(ValueType,  \
+                                                               IndexType)  \
+    void initialize_row_ptrs_l(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
         IndexType* l_row_ptrs)
 
-#define GKO_DECLARE_FACTORIZATION_INITIALIZE_L_KERNEL(ValueType, IndexType)   \
-    void initialize_l(std::shared_ptr<const DefaultExecutor> exec,            \
-                      const matrix::Csr<ValueType, IndexType>* system_matrix, \
-                      matrix::Csr<ValueType, IndexType>* l_factor,            \
-                      bool diag_sqrt)
+#define GKO_DECLARE_FACTORIZATION_INITIALIZE_L_KERNEL(ValueType, IndexType) \
+    void initialize_l(                                                      \
+        std::shared_ptr<const DefaultExecutor> exec,                        \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix,  \
+        matrix::view::csr<ValueType, IndexType> l_factor, bool diag_sqrt)
 
-#define GKO_DECLARE_FACTORIZATION_SYMBOLIC_VALIDATE_KERNEL(ValueType, \
-                                                           IndexType) \
-    void symbolic_validate(                                           \
-        std::shared_ptr<const DefaultExecutor> exec,                  \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,       \
-        const matrix::Csr<ValueType, IndexType>* factors,             \
-        const matrix::csr::lookup_data<IndexType>& factors_lookup,    \
+#define GKO_DECLARE_FACTORIZATION_SYMBOLIC_VALIDATE_KERNEL(ValueType,      \
+                                                           IndexType)      \
+    void symbolic_validate(                                                \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
+        matrix::view::csr<const ValueType, const IndexType> factors,       \
+        const matrix::csr::lookup_data<IndexType>& factors_lookup,         \
         bool& valid)
 
 

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -124,7 +124,8 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
         forest =
             std::make_unique<gko::factorization::elimination_forest<IndexType>>(
                 exec, num_rows);
-        exec->run(ic_factorization::make_from_factor(factors.get(), *forest));
+        exec->run(ic_factorization::make_from_factor(
+            factors->get_const_device_view(), *forest));
 
         // setup lookup structure on factors
         const auto lookup = matrix::csr::build_lookup(factors.get());
@@ -136,20 +137,22 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
             factors->get_values(), factors->get_num_stored_elements(),
             zero<ValueType>()));
         exec->run(ic_factorization::make_initialize(
-            local_system_matrix.get(), lookup.storage_offsets.get_const_data(),
+            local_system_matrix->get_const_device_view(),
+            lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-            diag_idxs.get_data(), transpose_idxs.get_data(), factors.get()));
+            diag_idxs.get_data(), transpose_idxs.get_data(),
+            factors->get_device_view()));
         // run numerical factorization
         array<int> tmp{exec};
         exec->run(ic_factorization::make_factorize(
             lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
             diag_idxs.get_const_data(), transpose_idxs.get_const_data(),
-            *forest, factors.get(), false, tmp));
+            *forest, factors->get_device_view(), false, tmp));
         ic = factors;
     } else {
-        exec->run(
-            ic_factorization::make_sparselib_ic(local_system_matrix.get()));
+        exec->run(ic_factorization::make_sparselib_ic(
+            local_system_matrix->get_device_view()));
         ic = local_system_matrix;
     }
 
@@ -158,7 +161,7 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
     const auto num_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, num_rows + 1};
     exec->run(ic_factorization::make_initialize_row_ptrs_l(
-        ic.get(), l_row_ptrs.get_data()));
+        ic->get_const_device_view(), l_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, num_rows));
@@ -171,8 +174,8 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
         std::move(l_row_ptrs), parameters_.l_strategy);
 
     // Extract lower factor: columns and values
-    exec->run(
-        ic_factorization::make_initialize_l(ic.get(), l_factor.get(), false));
+    exec->run(ic_factorization::make_initialize_l(
+        ic->get_const_device_view(), l_factor->get_device_view(), false));
 
     if (both_factors) {
         auto lh_factor = l_factor->conj_transpose();

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -123,7 +123,8 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
         forest =
             std::make_unique<gko::factorization::elimination_forest<IndexType>>(
                 exec, num_rows);
-        exec->run(ic_factorization::make_from_factor(factors.get(), *forest));
+        exec->run(ic_factorization::make_from_factor(
+            factors->get_const_device_view(), *forest));
 
         // setup lookup structure on factors
         const auto lookup = matrix::csr::build_lookup(factors.get());
@@ -135,20 +136,22 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
             factors->get_values(), factors->get_num_stored_elements(),
             zero<ValueType>()));
         exec->run(ic_factorization::make_initialize(
-            local_system_matrix.get(), lookup.storage_offsets.get_const_data(),
+            local_system_matrix->get_const_device_view(),
+            lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-            diag_idxs.get_data(), transpose_idxs.get_data(), factors.get()));
+            diag_idxs.get_data(), transpose_idxs.get_data(),
+            factors->get_device_view()));
         // run numerical factorization
         array<int> tmp{exec};
         exec->run(ic_factorization::make_factorize(
             lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
             diag_idxs.get_const_data(), transpose_idxs.get_const_data(),
-            *forest, factors.get(), false, tmp));
+            *forest, factors->get_device_view(), false, tmp));
         ic = factors;
     } else {
-        exec->run(
-            ic_factorization::make_sparselib_ic(local_system_matrix.get()));
+        exec->run(ic_factorization::make_sparselib_ic(
+            local_system_matrix->get_device_view()));
         ic = local_system_matrix;
     }
 
@@ -157,7 +160,7 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
     const auto num_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, num_rows + 1};
     exec->run(ic_factorization::make_initialize_row_ptrs_l(
-        ic.get(), l_row_ptrs.get_data()));
+        ic->get_const_device_view(), l_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, num_rows));
@@ -170,8 +173,8 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
         std::move(l_row_ptrs), parameters_.l_strategy);
 
     // Extract lower factor: columns and values
-    exec->run(
-        ic_factorization::make_initialize_l(ic.get(), l_factor.get(), false));
+    exec->run(ic_factorization::make_initialize_l(
+        ic->get_const_device_view(), l_factor->get_device_view(), false));
 
     if (both_factors) {
         auto lh_factor = l_factor->conj_transpose();

--- a/core/factorization/ic_kernels.hpp
+++ b/core/factorization/ic_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,7 +21,7 @@ namespace kernels {
 
 #define GKO_DECLARE_IC_SPARSELIB_IC_KERNEL(ValueType, IndexType)   \
     void sparselib_ic(std::shared_ptr<const DefaultExecutor> exec, \
-                      matrix::Csr<ValueType, IndexType>* system_matrix)
+                      matrix::view::csr<ValueType, IndexType> system_matrix)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                  \
     template <typename ValueType, typename IndexType> \

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -119,19 +119,21 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
         const auto lookup = matrix::csr::build_lookup(factors.get());
         array<IndexType> diag_idxs{exec, num_rows};
         exec->run(ilu_factorization::make_initialize(
-            local_system_matrix.get(), lookup.storage_offsets.get_const_data(),
+            local_system_matrix->get_const_device_view(),
+            lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-            diag_idxs.get_data(), factors.get()));
+            diag_idxs.get_data(), factors->get_device_view()));
         // run numerical factorization
         array<int> tmp{exec};
         exec->run(ilu_factorization::make_factorize(
             lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-            diag_idxs.get_const_data(), factors.get(), false, tmp));
+            diag_idxs.get_const_data(), factors->get_device_view(), false,
+            tmp));
         ilu = factors;
     } else {
-        exec->run(
-            ilu_factorization::make_sparselib_ilu(local_system_matrix.get()));
+        exec->run(ilu_factorization::make_sparselib_ilu(
+            local_system_matrix->get_device_view()));
         ilu = local_system_matrix;
     }
     // Separate L and U factors: nnz
@@ -140,7 +142,8 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
     array<IndexType> l_row_ptrs{exec, num_rows + 1};
     array<IndexType> u_row_ptrs{exec, num_rows + 1};
     exec->run(ilu_factorization::make_initialize_row_ptrs_l_u(
-        ilu.get(), l_row_ptrs.get_data(), u_row_ptrs.get_data()));
+        ilu->get_const_device_view(), l_row_ptrs.get_data(),
+        u_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, num_rows));
@@ -159,8 +162,9 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
         std::move(u_row_ptrs), parameters_.u_strategy);
 
     // Separate L and U: columns and values
-    exec->run(ilu_factorization::make_initialize_l_u(ilu.get(), l_factor.get(),
-                                                     u_factor.get()));
+    exec->run(ilu_factorization::make_initialize_l_u(
+        ilu->get_const_device_view(), l_factor->get_device_view(),
+        u_factor->get_device_view()));
 
     return Composition<ValueType>::create(std::move(l_factor),
                                           std::move(u_factor));

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -119,19 +119,21 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
         const auto lookup = matrix::csr::build_lookup(factors.get());
         array<IndexType> diag_idxs{exec, num_rows};
         exec->run(ilu_factorization::make_initialize(
-            local_system_matrix.get(), lookup.storage_offsets.get_const_data(),
+            local_system_matrix->get_const_device_view(),
+            lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-            diag_idxs.get_data(), factors.get()));
+            diag_idxs.get_data(), factors->get_device_view()));
         // run numerical factorization
         array<int> tmp{exec};
         exec->run(ilu_factorization::make_factorize(
             lookup.storage_offsets.get_const_data(),
             lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-            diag_idxs.get_const_data(), factors.get(), false, tmp));
+            diag_idxs.get_const_data(), factors->get_device_view(), false,
+            tmp));
         ilu = factors;
     } else {
-        exec->run(
-            ilu_factorization::make_sparselib_ilu(local_system_matrix.get()));
+        exec->run(ilu_factorization::make_sparselib_ilu(
+            local_system_matrix->get_device_view()));
         ilu = local_system_matrix;
     }
     // Separate L and U factors: nnz
@@ -140,7 +142,8 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
     array<IndexType> l_row_ptrs{exec, num_rows + 1};
     array<IndexType> u_row_ptrs{exec, num_rows + 1};
     exec->run(ilu_factorization::make_initialize_row_ptrs_l_u(
-        ilu.get(), l_row_ptrs.get_data(), u_row_ptrs.get_data()));
+        ilu->get_const_device_view(), l_row_ptrs.get_data(),
+        u_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, num_rows));
@@ -159,8 +162,9 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
         std::move(u_row_ptrs), parameters_.u_strategy);
 
     // Separate L and U: columns and values
-    exec->run(ilu_factorization::make_initialize_l_u(ilu.get(), l_factor.get(),
-                                                     u_factor.get()));
+    exec->run(ilu_factorization::make_initialize_l_u(
+        ilu->get_const_device_view(), l_factor->get_device_view(),
+        u_factor->get_device_view()));
 
     return Composition<ValueType>::create(std::move(l_factor),
                                           std::move(u_factor));

--- a/core/factorization/ilu_kernels.hpp
+++ b/core/factorization/ilu_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -22,7 +22,7 @@ namespace kernels {
 
 #define GKO_DECLARE_ILU_SPARSELIB_ILU_KERNEL(ValueType, IndexType)  \
     void sparselib_ilu(std::shared_ptr<const DefaultExecutor> exec, \
-                       matrix::Csr<ValueType, IndexType>* system_matrix)
+                       matrix::view::csr<ValueType, IndexType> system_matrix)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                  \

--- a/core/factorization/lu.cpp
+++ b/core/factorization/lu.cpp
@@ -133,15 +133,15 @@ std::unique_ptr<LinOp> Lu<ValueType, IndexType>::generate_impl(
     const auto lookup = matrix::csr::build_lookup(factors.get());
     array<IndexType> diag_idxs{exec, num_rows};
     exec->run(make_initialize(
-        mtx.get(), lookup.storage_offsets.get_const_data(),
+        mtx->get_const_device_view(), lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-        diag_idxs.get_data(), factors.get()));
+        diag_idxs.get_data(), factors->get_device_view()));
     // run numerical factorization
     array<int> tmp{exec};
     exec->run(make_factorize(
         lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-        diag_idxs.get_const_data(), factors.get(), true, tmp));
+        diag_idxs.get_const_data(), factors->get_device_view(), true, tmp));
     return factorization_type::create_from_combined_lu(std::move(factors));
 }
 

--- a/core/factorization/lu.cpp
+++ b/core/factorization/lu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -134,15 +134,15 @@ std::unique_ptr<LinOp> Lu<ValueType, IndexType>::generate_impl(
     const auto lookup = matrix::csr::build_lookup(factors.get());
     array<IndexType> diag_idxs{exec, num_rows};
     exec->run(make_initialize(
-        mtx.get(), lookup.storage_offsets.get_const_data(),
+        mtx->get_const_device_view(), lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-        diag_idxs.get_data(), factors.get()));
+        diag_idxs.get_data(), factors->get_device_view()));
     // run numerical factorization
     array<int> tmp{exec};
     exec->run(make_factorize(
         lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-        diag_idxs.get_const_data(), factors.get(), true, tmp));
+        diag_idxs.get_const_data(), factors->get_device_view(), true, tmp));
     return factorization_type::create_from_combined_lu(std::move(factors));
 }
 

--- a/core/factorization/lu_kernels.hpp
+++ b/core/factorization/lu_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,18 +21,18 @@ namespace kernels {
 
 #define GKO_DECLARE_LU_INITIALIZE(ValueType, IndexType)                       \
     void initialize(std::shared_ptr<const DefaultExecutor> exec,              \
-                    const matrix::Csr<ValueType, IndexType>* mtx,             \
+                    matrix::view::csr<const ValueType, const IndexType> mtx,  \
                     const IndexType* factor_lookup_offsets,                   \
                     const int64* factor_lookup_descs,                         \
                     const int32* factor_lookup_storage, IndexType* diag_idxs, \
-                    matrix::Csr<ValueType, IndexType>* factors)
+                    matrix::view::csr<ValueType, IndexType> factors)
 
 
 #define GKO_DECLARE_LU_FACTORIZE(ValueType, IndexType)                         \
     void factorize(std::shared_ptr<const DefaultExecutor> exec,                \
                    const IndexType* lookup_offsets, const int64* lookup_descs, \
                    const int32* lookup_storage, const IndexType* diag_idxs,    \
-                   matrix::Csr<ValueType, IndexType>* factors,                 \
+                   matrix::view::csr<ValueType, IndexType> factors,            \
                    bool full_fillin, array<int>& tmp_storage)
 
 
@@ -42,13 +42,14 @@ namespace kernels {
         const IndexType* row_ptrs, const IndexType* col_idxs,                 \
         const IndexType* factor_lookup_offsets,                               \
         const int64* factor_lookup_descs, const int32* factor_lookup_storage, \
-        matrix::Csr<float, IndexType>* factors, IndexType* out_row_nnz)
+        matrix::view::csr<float, IndexType> factors, IndexType* out_row_nnz)
 
 
 #define GKO_DECLARE_LU_SYMMETRIC_FACTORIZE_SIMPLE_FINALIZE(IndexType) \
     void symbolic_factorize_simple_finalize(                          \
         std::shared_ptr<const DefaultExecutor> exec,                  \
-        const matrix::Csr<float, IndexType>* factors, IndexType* col_idxs)
+        matrix::view::csr<const float, const IndexType> factors,      \
+        IndexType* col_idxs)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                      \

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};
     exec->run(par_ic_factorization::make_initialize_row_ptrs_l(
-        csr_system_matrix.get(), l_row_ptrs.get_data()));
+        csr_system_matrix->get_const_device_view(), l_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, number_rows));
@@ -113,8 +113,9 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
         exec, matrix_size, std::move(l_vals), std::move(l_col_idxs),
         std::move(l_row_ptrs), parameters_.l_strategy);
 
-    exec->run(par_ic_factorization::make_initialize_l(csr_system_matrix.get(),
-                                                      l_factor.get(), false));
+    exec->run(par_ic_factorization::make_initialize_l(
+        csr_system_matrix->get_const_device_view(), l_factor->get_device_view(),
+        false));
 
     // build COO representation of lower factor
     array<IndexType> l_row_idxs{exec, l_nnz};
@@ -128,12 +129,13 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
                           std::move(a_col_idxs), std::move(a_row_idxs));
 
     // compute sqrt of diagonal entries
-    exec->run(par_ic_factorization::make_init_factor(l_factor.get()));
+    exec->run(
+        par_ic_factorization::make_init_factor(l_factor->get_device_view()));
 
     // execute sweeps
     exec->run(par_ic_factorization::make_compute_factor(
         parameters_.iterations, a_lower_coo->get_const_device_view(),
-        l_factor.get()));
+        l_factor->get_device_view()));
 
     if (both_factors) {
         auto lh_factor = l_factor->conj_transpose();

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -99,7 +99,7 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};
     exec->run(par_ic_factorization::make_initialize_row_ptrs_l(
-        csr_system_matrix.get(), l_row_ptrs.get_data()));
+        csr_system_matrix->get_const_device_view(), l_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, number_rows));
@@ -112,8 +112,9 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
         exec, matrix_size, std::move(l_vals), std::move(l_col_idxs),
         std::move(l_row_ptrs), parameters_.l_strategy);
 
-    exec->run(par_ic_factorization::make_initialize_l(csr_system_matrix.get(),
-                                                      l_factor.get(), false));
+    exec->run(par_ic_factorization::make_initialize_l(
+        csr_system_matrix->get_const_device_view(), l_factor->get_device_view(),
+        false));
 
     // build COO representation of lower factor
     array<IndexType> l_row_idxs{exec, l_nnz};
@@ -127,12 +128,13 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
                           std::move(a_col_idxs), std::move(a_row_idxs));
 
     // compute sqrt of diagonal entries
-    exec->run(par_ic_factorization::make_init_factor(l_factor.get()));
+    exec->run(
+        par_ic_factorization::make_init_factor(l_factor->get_device_view()));
 
     // execute sweeps
     exec->run(par_ic_factorization::make_compute_factor(
         parameters_.iterations, a_lower_coo->get_const_device_view(),
-        l_factor.get()));
+        l_factor->get_device_view()));
 
     if (both_factors) {
         auto lh_factor = l_factor->conj_transpose();

--- a/core/factorization/par_ic_kernels.hpp
+++ b/core/factorization/par_ic_kernels.hpp
@@ -23,14 +23,14 @@ namespace kernels {
 
 #define GKO_DECLARE_PAR_IC_INIT_FACTOR_KERNEL(ValueType, IndexType) \
     void init_factor(std::shared_ptr<const DefaultExecutor> exec,   \
-                     matrix::Csr<ValueType, IndexType>* l_factor)
+                     matrix::view::csr<ValueType, IndexType> l_factor)
 
 #define GKO_DECLARE_PAR_IC_COMPUTE_FACTOR_KERNEL(ValueType, IndexType)      \
     void compute_factor(std::shared_ptr<const DefaultExecutor> exec,        \
                         size_type iterations,                               \
                         matrix::view::coo<const ValueType, const IndexType> \
                             lower_system_matrix,                            \
-                        matrix::Csr<ValueType, IndexType>* l_factor)
+                        matrix::view::csr<ValueType, IndexType> l_factor)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                             \
     template <typename ValueType, typename IndexType>            \

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -126,7 +126,8 @@ struct ParIctState {
         llh = CsrMatrix::create(exec, mtx_size);
         l_new = CsrMatrix::create(exec, mtx_size);
         l_coo = CooMatrix::create(exec, mtx_size);
-        exec->run(make_csr_conj_transpose(l.get(), lh.get()));
+        exec->run(make_csr_conj_transpose(l->get_const_device_view(),
+                                          lh->get_device_view()));
     }
 
     std::unique_ptr<Composition<ValueType>> to_factors() &&
@@ -197,7 +198,8 @@ ParIct<ValueType, IndexType>::generate_l_lt(
     const auto num_rows = csr_system_matrix->get_size()[0];
     array<IndexType> l_row_ptrs_array{exec, num_rows + 1};
     auto l_row_ptrs = l_row_ptrs_array.get_data();
-    exec->run(make_initialize_row_ptrs_l(csr_system_matrix.get(), l_row_ptrs));
+    exec->run(make_initialize_row_ptrs_l(
+        csr_system_matrix->get_const_device_view(), l_row_ptrs));
 
     auto l_nnz =
         static_cast<size_type>(get_element(l_row_ptrs_array, num_rows));
@@ -208,7 +210,8 @@ ParIct<ValueType, IndexType>::generate_l_lt(
                                std::move(l_row_ptrs_array));
 
     // initialize L
-    exec->run(make_initialize_l(csr_system_matrix.get(), l.get(), true));
+    exec->run(make_initialize_l(csr_system_matrix->get_const_device_view(),
+                                l->get_device_view(), true));
 
     // compute limit #nnz for L
     auto l_nnz_limit =
@@ -238,8 +241,9 @@ void ParIctState<ValueType, IndexType>::iterate()
         make_spgemm(l.get(), lh.get(), make_builder_unique_ptr(llh).get()));
 
     // add new candidates to L' factor
-    exec->run(make_add_candidates(llh.get(), system_matrix, l.get(),
-                                  make_builder_unique_ptr(l_new).get()));
+    exec->run(make_add_candidates(
+        llh->get_const_device_view(), system_matrix->get_const_device_view(),
+        l->get_const_device_view(), make_builder_unique_ptr(l_new).get()));
 
     // update L(COO), L'^H sizes and pointers
     {
@@ -260,7 +264,8 @@ void ParIctState<ValueType, IndexType>::iterate()
                                         l_coo->get_row_idxs()));
 
     // execute asynchronous iteration
-    exec->run(make_compute_factor(system_matrix, l_new.get(),
+    exec->run(make_compute_factor(system_matrix->get_const_device_view(),
+                                  l_new->get_device_view(),
                                   l_coo->get_const_device_view()));
 
     // determine ranks for selection/filtering
@@ -271,22 +276,24 @@ void ParIctState<ValueType, IndexType>::iterate()
         remove_complex<ValueType> tmp{};
         // remove approximately smallest candidates
         exec->run(make_threshold_filter_approx(
-            l_new.get(), l_filter_rank, selection_tmp, tmp,
+            l_new->get_const_device_view(), l_filter_rank, selection_tmp, tmp,
             make_builder_unique_ptr(l).get(), l_coo.get()));
     } else {
         // select threshold to remove smallest candidates
         remove_complex<ValueType> l_threshold{};
-        exec->run(make_threshold_select(l_new.get(), l_filter_rank,
-                                        selection_tmp, selection_tmp2,
-                                        l_threshold));
+        exec->run(make_threshold_select(l_new->get_const_device_view(),
+                                        l_filter_rank, selection_tmp,
+                                        selection_tmp2, l_threshold));
+
         // remove smallest candidates
-        exec->run(make_threshold_filter(l_new.get(), l_threshold,
-                                        make_builder_unique_ptr(l).get(),
-                                        l_coo.get(), true));
+        exec->run(make_threshold_filter(
+            l_new->get_const_device_view(), l_threshold,
+            make_builder_unique_ptr(l).get(), l_coo.get(), true));
     }
 
     // execute asynchronous iteration
-    exec->run(make_compute_factor(system_matrix, l.get(),
+    exec->run(make_compute_factor(system_matrix->get_const_device_view(),
+                                  l->get_device_view(),
                                   l_coo->get_const_device_view()));
 
     // convert L to L^H
@@ -295,7 +302,8 @@ void ParIctState<ValueType, IndexType>::iterate()
         CsrBuilder lh_builder{lh};
         lh_builder.get_col_idx_array().resize_and_reset(l_nnz);
         lh_builder.get_value_array().resize_and_reset(l_nnz);
-        exec->run(make_csr_conj_transpose(l.get(), lh.get()));
+        exec->run(make_csr_conj_transpose(l->get_const_device_view(),
+                                          lh->get_device_view()));
     }
 }
 

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -237,8 +237,9 @@ template <typename ValueType, typename IndexType>
 void ParIctState<ValueType, IndexType>::iterate()
 {
     // compute L * L^H
-    exec->run(
-        make_spgemm(l.get(), lh.get(), make_builder_unique_ptr(llh).get()));
+    exec->run(make_spgemm(l->get_const_device_view(),
+                          lh->get_const_device_view(),
+                          make_builder_unique_ptr(llh).get()));
 
     // add new candidates to L' factor
     exec->run(make_add_candidates(

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -241,8 +241,7 @@ void ParIctState<ValueType, IndexType>::iterate()
     exec->run(make_spgemm(l.get(), lh.get(), llh.get()));
 
     // add new candidates to L' factor
-    exec->run(make_add_candidates(llh->get_const_device_view(),
-                                  system_matrix->get_const_device_view(),
+    exec->run(make_add_candidates(llh.get(), system_matrix,
                                   l->get_const_device_view(), l_new.get()));
 
     // update L(COO), L'^H sizes and pointers

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -127,7 +127,8 @@ struct ParIctState {
         llh = CsrMatrix::create(exec, mtx_size);
         l_new = CsrMatrix::create(exec, mtx_size);
         l_coo = CooMatrix::create(exec, mtx_size);
-        exec->run(make_csr_conj_transpose(l.get(), lh.get()));
+        exec->run(make_csr_conj_transpose(l->get_const_device_view(),
+                                          lh->get_device_view()));
     }
 
     std::unique_ptr<Composition<ValueType>> to_factors() &&
@@ -198,7 +199,8 @@ ParIct<ValueType, IndexType>::generate_l_lt(
     const auto num_rows = csr_system_matrix->get_size()[0];
     array<IndexType> l_row_ptrs_array{exec, num_rows + 1};
     auto l_row_ptrs = l_row_ptrs_array.get_data();
-    exec->run(make_initialize_row_ptrs_l(csr_system_matrix.get(), l_row_ptrs));
+    exec->run(make_initialize_row_ptrs_l(
+        csr_system_matrix->get_const_device_view(), l_row_ptrs));
 
     auto l_nnz =
         static_cast<size_type>(get_element(l_row_ptrs_array, num_rows));
@@ -209,7 +211,8 @@ ParIct<ValueType, IndexType>::generate_l_lt(
                                std::move(l_row_ptrs_array));
 
     // initialize L
-    exec->run(make_initialize_l(csr_system_matrix.get(), l.get(), true));
+    exec->run(make_initialize_l(csr_system_matrix->get_const_device_view(),
+                                l->get_device_view(), true));
 
     // compute limit #nnz for L
     auto l_nnz_limit =
@@ -238,8 +241,9 @@ void ParIctState<ValueType, IndexType>::iterate()
     exec->run(make_spgemm(l.get(), lh.get(), llh.get()));
 
     // add new candidates to L' factor
-    exec->run(
-        make_add_candidates(llh.get(), system_matrix, l.get(), l_new.get()));
+    exec->run(make_add_candidates(llh->get_const_device_view(),
+                                  system_matrix->get_const_device_view(),
+                                  l->get_const_device_view(), l_new.get()));
 
     // update L(COO), L'^H sizes and pointers
     {
@@ -260,7 +264,8 @@ void ParIctState<ValueType, IndexType>::iterate()
                                         l_coo->get_row_idxs()));
 
     // execute asynchronous iteration
-    exec->run(make_compute_factor(system_matrix, l_new.get(),
+    exec->run(make_compute_factor(system_matrix->get_const_device_view(),
+                                  l_new->get_device_view(),
                                   l_coo->get_const_device_view()));
 
     // determine ranks for selection/filtering
@@ -270,23 +275,25 @@ void ParIctState<ValueType, IndexType>::iterate()
     if (use_approx_select) {
         remove_complex<ValueType> tmp{};
         // remove approximately smallest candidates
-        exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
-                                               selection_tmp, tmp, l.get(),
-                                               l_coo.get()));
+        exec->run(make_threshold_filter_approx(l_new->get_const_device_view(),
+                                               l_filter_rank, selection_tmp,
+                                               tmp, l.get(), l_coo.get()));
     } else {
         // select threshold to remove smallest candidates
         remove_complex<ValueType> l_threshold{};
-        exec->run(make_threshold_select(l_new.get(), l_filter_rank,
-                                        selection_tmp, selection_tmp2,
-                                        l_threshold));
+        exec->run(make_threshold_select(l_new->get_const_device_view(),
+                                        l_filter_rank, selection_tmp,
+                                        selection_tmp2, l_threshold));
 
         // remove smallest candidates
-        exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
-                                        l_coo.get(), true));
+        exec->run(make_threshold_filter(l_new->get_const_device_view(),
+                                        l_threshold, l.get(), l_coo.get(),
+                                        true));
     }
 
     // execute asynchronous iteration
-    exec->run(make_compute_factor(system_matrix, l.get(),
+    exec->run(make_compute_factor(system_matrix->get_const_device_view(),
+                                  l->get_device_view(),
                                   l_coo->get_const_device_view()));
 
     // convert L to L^H
@@ -296,7 +303,8 @@ void ParIctState<ValueType, IndexType>::iterate()
         lt_builder.get_col_idx_array().resize_and_reset(l_nnz);
         lt_builder.get_value_array().resize_and_reset(l_nnz);
     }
-    exec->run(make_csr_conj_transpose(l.get(), lh.get()));
+    exec->run(make_csr_conj_transpose(l->get_const_device_view(),
+                                      lh->get_device_view()));
 }
 
 

--- a/core/factorization/par_ict_kernels.hpp
+++ b/core/factorization/par_ict_kernels.hpp
@@ -25,16 +25,16 @@ namespace kernels {
 #define GKO_DECLARE_PAR_ICT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
     void add_candidates(                                                \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* llh,                   \
-        const matrix::Csr<ValueType, IndexType>* a,                     \
-        const matrix::Csr<ValueType, IndexType>* l,                     \
+        matrix::view::csr<const ValueType, const IndexType> llh,        \
+        matrix::view::csr<const ValueType, const IndexType> a,          \
+        matrix::view::csr<const ValueType, const IndexType> l,          \
         matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 
 #define GKO_DECLARE_PAR_ICT_COMPUTE_FACTOR_KERNEL(ValueType, IndexType) \
     void compute_factor(                                                \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* a,                     \
-        matrix::Csr<ValueType, IndexType>* l,                           \
+        matrix::view::csr<const ValueType, const IndexType> a,          \
+        matrix::view::csr<ValueType, IndexType> l,                      \
         matrix::view::coo<const ValueType, const IndexType> l_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                 \

--- a/core/factorization/par_ict_kernels.hpp
+++ b/core/factorization/par_ict_kernels.hpp
@@ -23,17 +23,18 @@ namespace kernels {
 
 
 #define GKO_DECLARE_PAR_ICT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
-    void add_candidates(std::shared_ptr<const DefaultExecutor> exec,    \
-                        const matrix::Csr<ValueType, IndexType>* llh,   \
-                        const matrix::Csr<ValueType, IndexType>* a,     \
-                        const matrix::Csr<ValueType, IndexType>* l,     \
-                        matrix::Csr<ValueType, IndexType>* l_new)
+    void add_candidates(                                                \
+        std::shared_ptr<const DefaultExecutor> exec,                    \
+        matrix::view::csr<const ValueType, const IndexType> llh,        \
+        matrix::view::csr<const ValueType, const IndexType> a,          \
+        matrix::view::csr<const ValueType, const IndexType> l,          \
+        matrix::Csr<ValueType, IndexType>* l_new)
 
 #define GKO_DECLARE_PAR_ICT_COMPUTE_FACTOR_KERNEL(ValueType, IndexType) \
     void compute_factor(                                                \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* a,                     \
-        matrix::Csr<ValueType, IndexType>* l,                           \
+        matrix::view::csr<const ValueType, const IndexType> a,          \
+        matrix::view::csr<ValueType, IndexType> l,                      \
         matrix::view::coo<const ValueType, const IndexType> l_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                 \

--- a/core/factorization/par_ict_kernels.hpp
+++ b/core/factorization/par_ict_kernels.hpp
@@ -22,13 +22,12 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_PAR_ICT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
-    void add_candidates(                                                \
-        std::shared_ptr<const DefaultExecutor> exec,                    \
-        matrix::view::csr<const ValueType, const IndexType> llh,        \
-        matrix::view::csr<const ValueType, const IndexType> a,          \
-        matrix::view::csr<const ValueType, const IndexType> l,          \
-        matrix::Csr<ValueType, IndexType>* l_new)
+#define GKO_DECLARE_PAR_ICT_ADD_CANDIDATES_KERNEL(ValueType, IndexType)        \
+    void add_candidates(std::shared_ptr<const DefaultExecutor> exec,           \
+                        const matrix::Csr<ValueType, IndexType>* llh,          \
+                        const matrix::Csr<ValueType, IndexType>* a,            \
+                        matrix::view::csr<const ValueType, const IndexType> l, \
+                        matrix::Csr<ValueType, IndexType>* l_new)
 
 #define GKO_DECLARE_PAR_ICT_COMPUTE_FACTOR_KERNEL(ValueType, IndexType) \
     void compute_factor(                                                \

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -101,7 +101,8 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     array<IndexType> l_row_ptrs{exec, number_rows + 1};
     array<IndexType> u_row_ptrs{exec, number_rows + 1};
     exec->run(par_ilu_factorization::make_initialize_row_ptrs_l_u(
-        csr_system_matrix.get(), l_row_ptrs.get_data(), u_row_ptrs.get_data()));
+        csr_system_matrix->get_const_device_view(), l_row_ptrs.get_data(),
+        u_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, number_rows));
@@ -121,7 +122,8 @@ ParIlu<ValueType, IndexType>::generate_l_u(
         std::move(u_row_ptrs), u_strategy);
 
     exec->run(par_ilu_factorization::make_initialize_l_u(
-        csr_system_matrix.get(), l_factor.get(), u_factor.get()));
+        csr_system_matrix->get_const_device_view(), l_factor->get_device_view(),
+        u_factor->get_device_view()));
 
     // We use `transpose()` here to convert the Csr format to Csc.
     auto u_factor_transpose_lin_op = u_factor->transpose();
@@ -147,14 +149,15 @@ ParIlu<ValueType, IndexType>::generate_l_u(
 
     exec->run(par_ilu_factorization::make_compute_l_u_factors(
         parameters_.iterations, coo_system_matrix_ptr->get_const_device_view(),
-        l_factor.get(), u_factor_transpose));
+        l_factor->get_device_view(), u_factor_transpose->get_device_view()));
 
     // Transpose it again, which is basically a conversion from CSC back to CSR
     // Since the transposed version has the exact same non-zero positions
     // as `u_factor`, we can both skip the allocation and the `make_srow()`
     // call from CSR, leaving just the `transpose()` kernel call
-    exec->run(par_ilu_factorization::make_csr_transpose(u_factor_transpose,
-                                                        u_factor.get()));
+    exec->run(par_ilu_factorization::make_csr_transpose(
+        u_factor_transpose->get_const_device_view(),
+        u_factor->get_device_view()));
 
     return Composition<ValueType>::create(std::move(l_factor),
                                           std::move(u_factor));

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -100,7 +100,8 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     array<IndexType> l_row_ptrs{exec, number_rows + 1};
     array<IndexType> u_row_ptrs{exec, number_rows + 1};
     exec->run(par_ilu_factorization::make_initialize_row_ptrs_l_u(
-        csr_system_matrix.get(), l_row_ptrs.get_data(), u_row_ptrs.get_data()));
+        csr_system_matrix->get_const_device_view(), l_row_ptrs.get_data(),
+        u_row_ptrs.get_data()));
 
     // Get nnz from device memory
     auto l_nnz = static_cast<size_type>(get_element(l_row_ptrs, number_rows));
@@ -120,7 +121,8 @@ ParIlu<ValueType, IndexType>::generate_l_u(
         std::move(u_row_ptrs), u_strategy);
 
     exec->run(par_ilu_factorization::make_initialize_l_u(
-        csr_system_matrix.get(), l_factor.get(), u_factor.get()));
+        csr_system_matrix->get_const_device_view(), l_factor->get_device_view(),
+        u_factor->get_device_view()));
 
     // We use `transpose()` here to convert the Csr format to Csc.
     auto u_factor_transpose_lin_op = u_factor->transpose();
@@ -146,14 +148,15 @@ ParIlu<ValueType, IndexType>::generate_l_u(
 
     exec->run(par_ilu_factorization::make_compute_l_u_factors(
         parameters_.iterations, coo_system_matrix_ptr->get_const_device_view(),
-        l_factor.get(), u_factor_transpose));
+        l_factor->get_device_view(), u_factor_transpose->get_device_view()));
 
     // Transpose it again, which is basically a conversion from CSC back to CSR
     // Since the transposed version has the exact same non-zero positions
     // as `u_factor`, we can both skip the allocation and the `make_srow()`
     // call from CSR, leaving just the `transpose()` kernel call
-    exec->run(par_ilu_factorization::make_csr_transpose(u_factor_transpose,
-                                                        u_factor.get()));
+    exec->run(par_ilu_factorization::make_csr_transpose(
+        u_factor_transpose->get_const_device_view(),
+        u_factor->get_device_view()));
 
     return Composition<ValueType>::create(std::move(l_factor),
                                           std::move(u_factor));

--- a/core/factorization/par_ilu_kernels.hpp
+++ b/core/factorization/par_ilu_kernels.hpp
@@ -24,8 +24,8 @@ namespace kernels {
     void compute_l_u_factors(                                                \
         std::shared_ptr<const DefaultExecutor> exec, size_type iterations,   \
         matrix::view::coo<const ValueType, const IndexType> system_matrix,   \
-        matrix::Csr<ValueType, IndexType>* l_factor,                         \
-        matrix::Csr<ValueType, IndexType>* u_factor)
+        matrix::view::csr<ValueType, IndexType> l_factor,                    \
+        matrix::view::csr<ValueType, IndexType> u_factor)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                  \

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -265,7 +265,9 @@ template <typename ValueType, typename IndexType>
 void ParIlutState<ValueType, IndexType>::iterate()
 {
     // compute L * U
-    exec->run(make_spgemm(l.get(), u.get(), make_builder_unique_ptr(lu).get()));
+    exec->run(make_spgemm(l->get_const_device_view(),
+                          u->get_const_device_view(),
+                          make_builder_unique_ptr(lu).get()));
 
     // add new candidates to L' and U' factors
     exec->run(make_add_candidates(

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -142,7 +142,8 @@ struct ParIlutState {
         u_new_csc = CsrMatrix::create(exec, mtx_size);
         l_coo = CooMatrix::create(exec, mtx_size);
         u_coo = CooMatrix::create(exec, mtx_size);
-        exec->run(make_csr_transpose(u.get(), u_csc.get()));
+        exec->run(make_csr_transpose(u->get_const_device_view(),
+                                     u_csc->get_device_view()));
     }
 
     std::unique_ptr<Composition<ValueType>> to_factors() &&
@@ -216,8 +217,8 @@ ParIlut<ValueType, IndexType>::generate_l_u(
     array<IndexType> u_row_ptrs_array{exec, num_rows + 1};
     auto l_row_ptrs = l_row_ptrs_array.get_data();
     auto u_row_ptrs = u_row_ptrs_array.get_data();
-    exec->run(make_initialize_row_ptrs_l_u(csr_system_matrix.get(), l_row_ptrs,
-                                           u_row_ptrs));
+    exec->run(make_initialize_row_ptrs_l_u(
+        csr_system_matrix->get_const_device_view(), l_row_ptrs, u_row_ptrs));
 
     auto l_nnz =
         static_cast<size_type>(get_element(l_row_ptrs_array, num_rows));
@@ -233,7 +234,8 @@ ParIlut<ValueType, IndexType>::generate_l_u(
                                std::move(u_row_ptrs_array));
 
     // initialize L and U
-    exec->run(make_initialize_l_u(csr_system_matrix.get(), l.get(), u.get()));
+    exec->run(make_initialize_l_u(csr_system_matrix->get_const_device_view(),
+                                  l->get_device_view(), u->get_device_view()));
 
     // compute limit #nnz for L and U
     auto l_nnz_limit =
@@ -266,9 +268,11 @@ void ParIlutState<ValueType, IndexType>::iterate()
     exec->run(make_spgemm(l.get(), u.get(), make_builder_unique_ptr(lu).get()));
 
     // add new candidates to L' and U' factors
-    exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
-                                  make_builder_unique_ptr(l_new).get(),
-                                  make_builder_unique_ptr(u_new).get()));
+    exec->run(make_add_candidates(
+        lu->get_const_device_view(), system_matrix->get_const_device_view(),
+        l->get_const_device_view(), u->get_const_device_view(),
+        make_builder_unique_ptr(l_new).get(),
+        make_builder_unique_ptr(u_new).get()));
 
     // update U'(CSC), L'(COO), U'(COO) sizes and pointers
     {
@@ -294,7 +298,8 @@ void ParIlutState<ValueType, IndexType>::iterate()
     }
 
     // convert U' into CSC format
-    exec->run(make_csr_transpose(u_new.get(), u_new_csc.get()));
+    exec->run(make_csr_transpose(u_new->get_const_device_view(),
+                                 u_new_csc->get_device_view()));
 
     // convert L' and U' into COO format
     exec->run(make_convert_ptrs_to_idxs(l_new->get_const_row_ptrs(),
@@ -306,8 +311,9 @@ void ParIlutState<ValueType, IndexType>::iterate()
 
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(
-        system_matrix, l_new.get(), l_coo->get_const_device_view(), u_new.get(),
-        u_coo->get_const_device_view(), u_new_csc.get()));
+        system_matrix->get_const_device_view(), l_new->get_device_view(),
+        l_coo->get_const_device_view(), u_new->get_device_view(),
+        u_coo->get_const_device_view(), u_new_csc->get_device_view()));
 
     // determine ranks for selection/filtering
     IndexType l_nnz = l_new->get_num_stored_elements();
@@ -321,37 +327,38 @@ void ParIlutState<ValueType, IndexType>::iterate()
     if (use_approx_select) {
         // remove approximately smallest candidates from L' and U'^T
         exec->run(make_threshold_filter_approx(
-            l_new.get(), l_filter_rank, selection_tmp, l_threshold,
-            make_builder_unique_ptr(l).get(), l_coo.get()));
+            l_new->get_const_device_view(), l_filter_rank, selection_tmp,
+            l_threshold, make_builder_unique_ptr(l).get(), l_coo.get()));
         exec->run(make_threshold_filter_approx(
-            u_new_csc.get(), u_filter_rank, selection_tmp, u_threshold,
-            make_builder_unique_ptr(u_csc).get(), null_coo));
+            u_new_csc->get_const_device_view(), u_filter_rank, selection_tmp,
+            u_threshold, make_builder_unique_ptr(u_csc).get(), null_coo));
     } else {
         // select threshold to remove smallest candidates
-        exec->run(make_threshold_select(l_new.get(), l_filter_rank,
-                                        selection_tmp, selection_tmp2,
-                                        l_threshold));
-        exec->run(make_threshold_select(u_new_csc.get(), u_filter_rank,
-                                        selection_tmp, selection_tmp2,
-                                        u_threshold));
+        exec->run(make_threshold_select(l_new->get_const_device_view(),
+                                        l_filter_rank, selection_tmp,
+                                        selection_tmp2, l_threshold));
+        exec->run(make_threshold_select(u_new_csc->get_const_device_view(),
+                                        u_filter_rank, selection_tmp,
+                                        selection_tmp2, u_threshold));
 
         // remove smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter(l_new.get(), l_threshold,
-                                        make_builder_unique_ptr(l).get(),
-                                        l_coo.get(), true));
-        exec->run(make_threshold_filter(u_new_csc.get(), u_threshold,
-                                        make_builder_unique_ptr(u_csc).get(),
-                                        null_coo, true));
+        exec->run(make_threshold_filter(
+            l_new->get_const_device_view(), l_threshold,
+            make_builder_unique_ptr(l).get(), l_coo.get(), true));
+        exec->run(make_threshold_filter(
+            u_new_csc->get_const_device_view(), u_threshold,
+            make_builder_unique_ptr(u_csc).get(), null_coo, true));
     }
     // remove smallest candidates from U'
-    exec->run(make_threshold_filter(u_new.get(), u_threshold,
+    exec->run(make_threshold_filter(u_new->get_const_device_view(), u_threshold,
                                     make_builder_unique_ptr(u).get(),
                                     u_coo.get(), false));
 
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(
-        system_matrix, l.get(), l_coo->get_const_device_view(), u.get(),
-        u_coo->get_const_device_view(), u_csc.get()));
+        system_matrix->get_const_device_view(), l->get_device_view(),
+        l_coo->get_const_device_view(), u->get_device_view(),
+        u_coo->get_const_device_view(), u_csc->get_device_view()));
 }
 
 

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -269,9 +269,8 @@ void ParIlutState<ValueType, IndexType>::iterate()
 
     // add new candidates to L' and U' factors
     exec->run(make_add_candidates(
-        lu->get_const_device_view(), system_matrix->get_const_device_view(),
-        l->get_const_device_view(), u->get_const_device_view(), l_new.get(),
-        u_new.get()));
+        lu.get(), system_matrix, l->get_const_device_view(),
+        u->get_const_device_view(), l_new.get(), u_new.get()));
 
     // update U'(CSC), L'(COO), U'(COO) sizes and pointers
     {

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -142,7 +142,8 @@ struct ParIlutState {
         u_new_csc = CsrMatrix::create(exec, mtx_size);
         l_coo = CooMatrix::create(exec, mtx_size);
         u_coo = CooMatrix::create(exec, mtx_size);
-        exec->run(make_csr_transpose(u.get(), u_csc.get()));
+        exec->run(make_csr_transpose(u->get_const_device_view(),
+                                     u_csc->get_device_view()));
     }
 
     std::unique_ptr<Composition<ValueType>> to_factors() &&
@@ -216,8 +217,8 @@ ParIlut<ValueType, IndexType>::generate_l_u(
     array<IndexType> u_row_ptrs_array{exec, num_rows + 1};
     auto l_row_ptrs = l_row_ptrs_array.get_data();
     auto u_row_ptrs = u_row_ptrs_array.get_data();
-    exec->run(make_initialize_row_ptrs_l_u(csr_system_matrix.get(), l_row_ptrs,
-                                           u_row_ptrs));
+    exec->run(make_initialize_row_ptrs_l_u(
+        csr_system_matrix->get_const_device_view(), l_row_ptrs, u_row_ptrs));
 
     auto l_nnz =
         static_cast<size_type>(get_element(l_row_ptrs_array, num_rows));
@@ -233,7 +234,8 @@ ParIlut<ValueType, IndexType>::generate_l_u(
                                std::move(u_row_ptrs_array));
 
     // initialize L and U
-    exec->run(make_initialize_l_u(csr_system_matrix.get(), l.get(), u.get()));
+    exec->run(make_initialize_l_u(csr_system_matrix->get_const_device_view(),
+                                  l->get_device_view(), u->get_device_view()));
 
     // compute limit #nnz for L and U
     auto l_nnz_limit =
@@ -266,8 +268,10 @@ void ParIlutState<ValueType, IndexType>::iterate()
     exec->run(make_spgemm(l.get(), u.get(), lu.get()));
 
     // add new candidates to L' and U' factors
-    exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
-                                  l_new.get(), u_new.get()));
+    exec->run(make_add_candidates(
+        lu->get_const_device_view(), system_matrix->get_const_device_view(),
+        l->get_const_device_view(), u->get_const_device_view(), l_new.get(),
+        u_new.get()));
 
     // update U'(CSC), L'(COO), U'(COO) sizes and pointers
     {
@@ -293,7 +297,8 @@ void ParIlutState<ValueType, IndexType>::iterate()
     }
 
     // convert U' into CSC format
-    exec->run(make_csr_transpose(u_new.get(), u_new_csc.get()));
+    exec->run(make_csr_transpose(u_new->get_const_device_view(),
+                                 u_new_csc->get_device_view()));
 
     // convert L' and U' into COO format
     exec->run(make_convert_ptrs_to_idxs(l_new->get_const_row_ptrs(),
@@ -305,8 +310,9 @@ void ParIlutState<ValueType, IndexType>::iterate()
 
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(
-        system_matrix, l_new.get(), l_coo->get_const_device_view(), u_new.get(),
-        u_coo->get_const_device_view(), u_new_csc.get()));
+        system_matrix->get_const_device_view(), l_new->get_device_view(),
+        l_coo->get_const_device_view(), u_new->get_device_view(),
+        u_coo->get_const_device_view(), u_new_csc->get_device_view()));
 
     // determine ranks for selection/filtering
     IndexType l_nnz = l_new->get_num_stored_elements();
@@ -319,35 +325,38 @@ void ParIlutState<ValueType, IndexType>::iterate()
     CooMatrix* null_coo = nullptr;
     if (use_approx_select) {
         // remove approximately smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
-                                               selection_tmp, l_threshold,
-                                               l.get(), l_coo.get()));
-        exec->run(make_threshold_filter_approx(u_new_csc.get(), u_filter_rank,
-                                               selection_tmp, u_threshold,
-                                               u_csc.get(), null_coo));
+        exec->run(make_threshold_filter_approx(
+            l_new->get_const_device_view(), l_filter_rank, selection_tmp,
+            l_threshold, l.get(), l_coo.get()));
+        exec->run(make_threshold_filter_approx(
+            u_new_csc->get_const_device_view(), u_filter_rank, selection_tmp,
+            u_threshold, u_csc.get(), null_coo));
     } else {
         // select threshold to remove smallest candidates
-        exec->run(make_threshold_select(l_new.get(), l_filter_rank,
-                                        selection_tmp, selection_tmp2,
-                                        l_threshold));
-        exec->run(make_threshold_select(u_new_csc.get(), u_filter_rank,
-                                        selection_tmp, selection_tmp2,
-                                        u_threshold));
+        exec->run(make_threshold_select(l_new->get_const_device_view(),
+                                        l_filter_rank, selection_tmp,
+                                        selection_tmp2, l_threshold));
+        exec->run(make_threshold_select(u_new_csc->get_const_device_view(),
+                                        u_filter_rank, selection_tmp,
+                                        selection_tmp2, u_threshold));
 
         // remove smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
-                                        l_coo.get(), true));
-        exec->run(make_threshold_filter(u_new_csc.get(), u_threshold,
-                                        u_csc.get(), null_coo, true));
+        exec->run(make_threshold_filter(l_new->get_const_device_view(),
+                                        l_threshold, l.get(), l_coo.get(),
+                                        true));
+        exec->run(make_threshold_filter(u_new_csc->get_const_device_view(),
+                                        u_threshold, u_csc.get(), null_coo,
+                                        true));
     }
     // remove smallest candidates from U'
-    exec->run(make_threshold_filter(u_new.get(), u_threshold, u.get(),
-                                    u_coo.get(), false));
+    exec->run(make_threshold_filter(u_new->get_const_device_view(), u_threshold,
+                                    u.get(), u_coo.get(), false));
 
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(
-        system_matrix, l.get(), l_coo->get_const_device_view(), u.get(),
-        u_coo->get_const_device_view(), u_csc.get()));
+        system_matrix->get_const_device_view(), l->get_device_view(),
+        l_coo->get_const_device_view(), u->get_device_view(),
+        u_coo->get_const_device_view(), u_csc->get_device_view()));
 }
 
 

--- a/core/factorization/par_ilut_kernels.hpp
+++ b/core/factorization/par_ilut_kernels.hpp
@@ -26,45 +26,45 @@ namespace kernels {
 #define GKO_DECLARE_PAR_ILUT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
     void add_candidates(                                                 \
         std::shared_ptr<const DefaultExecutor> exec,                     \
-        const matrix::Csr<ValueType, IndexType>* lu,                     \
-        const matrix::Csr<ValueType, IndexType>* a,                      \
-        const matrix::Csr<ValueType, IndexType>* l,                      \
-        const matrix::Csr<ValueType, IndexType>* u,                      \
+        matrix::view::csr<const ValueType, const IndexType> lu,          \
+        matrix::view::csr<const ValueType, const IndexType> a,           \
+        matrix::view::csr<const ValueType, const IndexType> l,           \
+        matrix::view::csr<const ValueType, const IndexType> u,           \
         matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,         \
         matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 
 #define GKO_DECLARE_PAR_ILUT_COMPUTE_LU_FACTORS_KERNEL(ValueType, IndexType) \
     void compute_l_u_factors(                                                \
         std::shared_ptr<const DefaultExecutor> exec,                         \
-        const matrix::Csr<ValueType, IndexType>* a,                          \
-        matrix::Csr<ValueType, IndexType>* l,                                \
+        matrix::view::csr<const ValueType, const IndexType> a,               \
+        matrix::view::csr<ValueType, IndexType> l,                           \
         matrix::view::coo<const ValueType, const IndexType> l_coo,           \
-        matrix::Csr<ValueType, IndexType>* u,                                \
+        matrix::view::csr<ValueType, IndexType> u,                           \
         matrix::view::coo<const ValueType, const IndexType> u_coo,           \
-        matrix::Csr<ValueType, IndexType>* u_csc)
+        matrix::view::csr<ValueType, IndexType> u_csc)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_SELECT_KERNEL(ValueType, IndexType) \
-    void threshold_select(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* m,      \
-                          IndexType rank, array<ValueType>& tmp,           \
-                          array<remove_complex<ValueType>>& tmp2,          \
-                          remove_complex<ValueType>& threshold)
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_SELECT_KERNEL(ValueType, IndexType)     \
+    void threshold_select(                                                     \
+        std::shared_ptr<const DefaultExecutor> exec,                           \
+        matrix::view::csr<const ValueType, const IndexType> m, IndexType rank, \
+        array<ValueType>& tmp, array<remove_complex<ValueType>>& tmp2,         \
+        remove_complex<ValueType>& threshold)
 
 #define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL(ValueType, IndexType) \
     void threshold_filter(                                                 \
         std::shared_ptr<const DefaultExecutor> exec,                       \
-        const matrix::Csr<ValueType, IndexType>* m,                        \
+        matrix::view::csr<const ValueType, const IndexType> m,             \
         remove_complex<ValueType> threshold,                               \
         matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,           \
         matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType, \
-                                                            IndexType) \
-    void threshold_filter_approx(                                      \
-        std::shared_ptr<const DefaultExecutor> exec,                   \
-        const matrix::Csr<ValueType, IndexType>* m, IndexType rank,    \
-        array<ValueType>& tmp, remove_complex<ValueType>& threshold,   \
-        matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,       \
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType,         \
+                                                            IndexType)         \
+    void threshold_filter_approx(                                              \
+        std::shared_ptr<const DefaultExecutor> exec,                           \
+        matrix::view::csr<const ValueType, const IndexType> m, IndexType rank, \
+        array<ValueType>& tmp, remove_complex<ValueType>& threshold,           \
+        matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,               \
         matrix::Coo<ValueType, IndexType>* m_out_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                      \

--- a/core/factorization/par_ilut_kernels.hpp
+++ b/core/factorization/par_ilut_kernels.hpp
@@ -23,47 +23,48 @@ namespace kernels {
 
 
 #define GKO_DECLARE_PAR_ILUT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
-    void add_candidates(std::shared_ptr<const DefaultExecutor> exec,     \
-                        const matrix::Csr<ValueType, IndexType>* lu,     \
-                        const matrix::Csr<ValueType, IndexType>* a,      \
-                        const matrix::Csr<ValueType, IndexType>* l,      \
-                        const matrix::Csr<ValueType, IndexType>* u,      \
-                        matrix::Csr<ValueType, IndexType>* l_new,        \
-                        matrix::Csr<ValueType, IndexType>* u_new)
+    void add_candidates(                                                 \
+        std::shared_ptr<const DefaultExecutor> exec,                     \
+        matrix::view::csr<const ValueType, const IndexType> lu,          \
+        matrix::view::csr<const ValueType, const IndexType> a,           \
+        matrix::view::csr<const ValueType, const IndexType> l,           \
+        matrix::view::csr<const ValueType, const IndexType> u,           \
+        matrix::Csr<ValueType, IndexType>* l_new,                        \
+        matrix::Csr<ValueType, IndexType>* u_new)
 
 #define GKO_DECLARE_PAR_ILUT_COMPUTE_LU_FACTORS_KERNEL(ValueType, IndexType) \
     void compute_l_u_factors(                                                \
         std::shared_ptr<const DefaultExecutor> exec,                         \
-        const matrix::Csr<ValueType, IndexType>* a,                          \
-        matrix::Csr<ValueType, IndexType>* l,                                \
+        matrix::view::csr<const ValueType, const IndexType> a,               \
+        matrix::view::csr<ValueType, IndexType> l,                           \
         matrix::view::coo<const ValueType, const IndexType> l_coo,           \
-        matrix::Csr<ValueType, IndexType>* u,                                \
+        matrix::view::csr<ValueType, IndexType> u,                           \
         matrix::view::coo<const ValueType, const IndexType> u_coo,           \
-        matrix::Csr<ValueType, IndexType>* u_csc)
+        matrix::view::csr<ValueType, IndexType> u_csc)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_SELECT_KERNEL(ValueType, IndexType) \
-    void threshold_select(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* m,      \
-                          IndexType rank, array<ValueType>& tmp,           \
-                          array<remove_complex<ValueType>>& tmp2,          \
-                          remove_complex<ValueType>& threshold)
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_SELECT_KERNEL(ValueType, IndexType)     \
+    void threshold_select(                                                     \
+        std::shared_ptr<const DefaultExecutor> exec,                           \
+        matrix::view::csr<const ValueType, const IndexType> m, IndexType rank, \
+        array<ValueType>& tmp, array<remove_complex<ValueType>>& tmp2,         \
+        remove_complex<ValueType>& threshold)
 
 #define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL(ValueType, IndexType) \
-    void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* m,      \
-                          remove_complex<ValueType> threshold,             \
-                          matrix::Csr<ValueType, IndexType>* m_out,        \
-                          matrix::Coo<ValueType, IndexType>* m_out_coo,    \
-                          bool lower)
+    void threshold_filter(                                                 \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> m,             \
+        remove_complex<ValueType> threshold,                               \
+        matrix::Csr<ValueType, IndexType>* m_out,                          \
+        matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType,        \
-                                                            IndexType)        \
-    void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec, \
-                                 const matrix::Csr<ValueType, IndexType>* m,  \
-                                 IndexType rank, array<ValueType>& tmp,       \
-                                 remove_complex<ValueType>& threshold,        \
-                                 matrix::Csr<ValueType, IndexType>* m_out,    \
-                                 matrix::Coo<ValueType, IndexType>* m_out_coo)
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType,         \
+                                                            IndexType)         \
+    void threshold_filter_approx(                                              \
+        std::shared_ptr<const DefaultExecutor> exec,                           \
+        matrix::view::csr<const ValueType, const IndexType> m, IndexType rank, \
+        array<ValueType>& tmp, remove_complex<ValueType>& threshold,           \
+        matrix::Csr<ValueType, IndexType>* m_out,                              \
+        matrix::Coo<ValueType, IndexType>* m_out_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                      \
     constexpr auto sampleselect_searchtree_height = 8;                    \

--- a/core/factorization/par_ilut_kernels.hpp
+++ b/core/factorization/par_ilut_kernels.hpp
@@ -22,15 +22,14 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_PAR_ILUT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
-    void add_candidates(                                                 \
-        std::shared_ptr<const DefaultExecutor> exec,                     \
-        matrix::view::csr<const ValueType, const IndexType> lu,          \
-        matrix::view::csr<const ValueType, const IndexType> a,           \
-        matrix::view::csr<const ValueType, const IndexType> l,           \
-        matrix::view::csr<const ValueType, const IndexType> u,           \
-        matrix::Csr<ValueType, IndexType>* l_new,                        \
-        matrix::Csr<ValueType, IndexType>* u_new)
+#define GKO_DECLARE_PAR_ILUT_ADD_CANDIDATES_KERNEL(ValueType, IndexType)       \
+    void add_candidates(std::shared_ptr<const DefaultExecutor> exec,           \
+                        const matrix::Csr<ValueType, IndexType>* lu,           \
+                        const matrix::Csr<ValueType, IndexType>* a,            \
+                        matrix::view::csr<const ValueType, const IndexType> l, \
+                        matrix::view::csr<const ValueType, const IndexType> u, \
+                        matrix::Csr<ValueType, IndexType>* l_new,              \
+                        matrix::Csr<ValueType, IndexType>* u_new)
 
 #define GKO_DECLARE_PAR_ILUT_COMPUTE_LU_FACTORS_KERNEL(ValueType, IndexType) \
     void compute_l_u_factors(                                                \

--- a/core/factorization/symbolic.cpp
+++ b/core/factorization/symbolic.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -55,14 +55,16 @@ void symbolic_cholesky(
     const auto num_rows = mtx->get_size()[0];
     array<IndexType> row_ptrs{exec, num_rows + 1};
     array<IndexType> tmp{exec};
-    exec->run(make_symbolic_count(mtx, *forest, row_ptrs.get_data(), tmp));
+    exec->run(make_symbolic_count(mtx->get_const_device_view(), *forest,
+                                  row_ptrs.get_data(), tmp));
     exec->run(make_prefix_sum_nonnegative(row_ptrs.get_data(), num_rows + 1));
     const auto factor_nnz =
         static_cast<size_type>(get_element(row_ptrs, num_rows));
     factors = matrix_type::create(
         exec, mtx->get_size(), array<ValueType>{exec, factor_nnz},
         array<IndexType>{exec, factor_nnz}, std::move(row_ptrs));
-    exec->run(make_symbolic(mtx, *forest, factors.get(), tmp));
+    exec->run(make_symbolic(mtx->get_const_device_view(), *forest,
+                            factors->get_device_view(), tmp));
     factors->sort_by_column_index();
     if (symmetrize) {
         auto lt_factor = as<matrix_type>(factors->transpose());
@@ -103,14 +105,16 @@ void symbolic_cholesky_device(
     }
     array<IndexType> row_ptrs{exec, num_rows + 1};
     array<IndexType> tmp{exec};
-    exec->run(make_symbolic_count(mtx, *forest, row_ptrs.get_data(), tmp));
+    exec->run(make_symbolic_count(mtx->get_const_device_view(), *forest,
+                                  row_ptrs.get_data(), tmp));
     exec->run(make_prefix_sum_nonnegative(row_ptrs.get_data(), num_rows + 1));
     const auto factor_nnz =
         static_cast<size_type>(get_element(row_ptrs, num_rows));
     factors = matrix_type::create(
         exec, mtx->get_size(), array<ValueType>{exec, factor_nnz},
         array<IndexType>{exec, factor_nnz}, std::move(row_ptrs));
-    exec->run(make_symbolic(mtx, *forest, factors.get(), tmp));
+    exec->run(make_symbolic(mtx->get_const_device_view(), *forest,
+                            factors->get_device_view(), tmp));
     factors->sort_by_column_index();
     if (symmetrize) {
         auto lt_factor = as<matrix_type>(factors->transpose());
@@ -172,7 +176,7 @@ void symbolic_lu_near_symm(
         mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
         lookup.storage_offsets.get_const_data(),
         lookup.row_descs.get_const_data(), lookup.storage.get_const_data(),
-        symm_factors.get(), factor_row_ptrs.get_data()));
+        symm_factors->get_device_view(), factor_row_ptrs.get_data()));
     // build row pointers from nnz
     exec->run(
         make_prefix_sum_nonnegative(factor_row_ptrs.get_data(), size[0] + 1));
@@ -180,8 +184,8 @@ void symbolic_lu_near_symm(
         static_cast<size_type>(get_element(factor_row_ptrs, size[0]));
     // copy over nonzero columns
     array<IndexType> factor_cols{exec, factor_nnz};
-    exec->run(make_symbolic_factorize_simple_finalize(symm_factors.get(),
-                                                      factor_cols.get_data()));
+    exec->run(make_symbolic_factorize_simple_finalize(
+        symm_factors->get_const_device_view(), factor_cols.get_data()));
     factors =
         matrix_type::create(exec, size, array<ValueType>{exec, factor_nnz},
                             std::move(factor_cols), std::move(factor_row_ptrs));

--- a/core/matrix/batch_csr.cpp
+++ b/core/matrix/batch_csr.cpp
@@ -227,7 +227,8 @@ void Csr<ValueType, IndexType>::add_scaled_identity(
     auto csr_mat = this->create_const_view_for_item(0);
 
     bool has_all_diags{false};
-    exec->run(csr::make_check_diagonal_entries(csr_mat.get(), has_all_diags));
+    exec->run(csr::make_check_diagonal_entries(csr_mat->get_const_device_view(),
+                                               has_all_diags));
     if (!has_all_diags) {
         GKO_UNSUPPORTED_MATRIX_PROPERTY(
             "The matrix is missing one or more diagonal entries!");

--- a/core/matrix/batch_ell.cpp
+++ b/core/matrix/batch_ell.cpp
@@ -247,7 +247,8 @@ void Ell<ValueType, IndexType>::add_scaled_identity(
     this->create_const_view_for_item(0)->convert_to(csr_mat);
 
     bool has_all_diags{false};
-    exec->run(ell::make_check_diagonal_entries(csr_mat.get(), has_all_diags));
+    exec->run(ell::make_check_diagonal_entries(csr_mat->get_const_device_view(),
+                                               has_all_diags));
     if (!has_all_diags) {
         GKO_UNSUPPORTED_MATRIX_PROPERTY(
             "The matrix is missing one or more diagonal entries!");

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -379,12 +379,14 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
         // if b is a CSR matrix, we compute a SpGeMM
         auto x_csr = as<TCsr>(x);
         this->get_executor()->run(csr::make_spgemm(
-            this, b_csr, make_builder_unique_ptr(x_csr).get()));
+            this->get_const_device_view(), b_csr->get_const_device_view(),
+            make_builder_unique_ptr(x_csr).get()));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this](auto dense_b, auto dense_x) {
                 this->get_executor()->run(csr::make_spmv(
-                    this->get_actual_strategy(), max_nnz_per_row_, this,
+                    this->get_actual_strategy(), max_nnz_per_row_,
+                    this->get_const_device_view(),
                     dense_b->get_const_device_view(),
                     dense_x->get_device_view()));
             },
@@ -502,16 +504,20 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
         auto x_csr = as<TCsr>(x);
         auto x_copy = x_csr->clone();
         this->get_executor()->run(csr::make_advanced_spgemm(
-            as<Dense<ValueType>>(alpha)->get_const_device_view(), this, b_csr,
-            as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
+            as<Dense<ValueType>>(alpha)->get_const_device_view(),
+            this->get_const_device_view(), b_csr->get_const_device_view(),
+            as<Dense<ValueType>>(beta)->get_const_device_view(),
+            x_copy->get_const_device_view(),
             make_builder_unique_ptr(x_csr).get()));
     } else if (dynamic_cast<const Identity<ValueType>*>(b)) {
         // if b is an identity matrix, we compute an SpGEAM
         auto x_csr = as<TCsr>(x);
         auto x_copy = x_csr->clone();
         this->get_executor()->run(csr::make_spgeam(
-            as<Dense<ValueType>>(alpha)->get_const_device_view(), this,
-            as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
+            as<Dense<ValueType>>(alpha)->get_const_device_view(),
+            this->get_const_device_view(),
+            as<Dense<ValueType>>(beta)->get_const_device_view(),
+            x_copy->get_const_device_view(),
             make_builder_unique_ptr(x_csr).get()));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
@@ -522,7 +528,8 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
                     beta);
                 this->get_executor()->run(csr::make_advanced_spmv(
                     this->get_actual_strategy(), max_nnz_per_row_,
-                    dense_alpha->get_const_device_view(), this,
+                    dense_alpha->get_const_device_view(),
+                    this->get_const_device_view(),
                     dense_b->get_const_device_view(),
                     dense_beta->get_const_device_view(),
                     dense_x->get_device_view()));
@@ -884,7 +891,8 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::multiply(
     auto exec = this->get_executor();
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
-    exec->run(csr::make_spgemm(this, local_other.get(),
+    exec->run(csr::make_spgemm(this->get_const_device_view(),
+                               local_other->get_const_device_view(),
                                make_builder_unique_ptr(result).get()));
     return result;
 }
@@ -967,7 +975,8 @@ Csr<ValueType, IndexType>::multiply_reuse(ptr_param<const Csr> other) const
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
     {
-        exec->run(csr::make_spgemm(this, local_other.get(),
+        exec->run(csr::make_spgemm(this->get_const_device_view(),
+                                   local_other->get_const_device_view(),
                                    make_builder_unique_ptr(result).get()));
     }
     auto lookup = csr::build_lookup(result.get());
@@ -1002,8 +1011,10 @@ Csr<ValueType, IndexType>::multiply_add(
     auto local_mtx_add = make_temporary_clone(exec, mtx_add);
     auto result = Csr::create(exec, result_size);
     exec->run(csr::make_advanced_spgemm(
-        local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
-        local_scale_add->get_const_device_view(), local_mtx_add.get(),
+        local_scale_mult->get_const_device_view(),
+        this->get_const_device_view(), local_mtx_mult->get_const_device_view(),
+        local_scale_add->get_const_device_view(),
+        local_mtx_add->get_const_device_view(),
         make_builder_unique_ptr(result).get()));
     return result;
 }
@@ -1109,8 +1120,10 @@ Csr<ValueType, IndexType>::multiply_add_reuse(
     auto local_mtx_add = make_temporary_clone(exec, mtx_add);
     auto result = Csr::create(exec, result_size);
     exec->run(csr::make_advanced_spgemm(
-        local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
-        local_scale_add->get_const_device_view(), local_mtx_add.get(),
+        local_scale_mult->get_const_device_view(),
+        this->get_const_device_view(), local_mtx_mult->get_const_device_view(),
+        local_scale_add->get_const_device_view(),
+        local_mtx_add->get_const_device_view(),
         make_builder_unique_ptr(result).get()));
     auto lookup = csr::build_lookup(result.get());
     auto reuse_info = multiply_add_reuse_info{
@@ -1139,9 +1152,10 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::scale_add(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(), this,
+    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(),
+                               this->get_const_device_view(),
                                local_scale_other->get_const_device_view(),
-                               local_mtx_other.get(),
+                               local_mtx_other->get_const_device_view(),
                                make_builder_unique_ptr(result).get()));
     return result;
 }
@@ -1235,9 +1249,10 @@ Csr<ValueType, IndexType>::add_scale_reuse(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(), this,
+    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(),
+                               this->get_const_device_view(),
                                local_scale_other->get_const_device_view(),
-                               local_mtx_other.get(),
+                               local_mtx_other->get_const_device_view(),
                                make_builder_unique_ptr(result).get()));
     return std::make_pair(
         std::move(result),
@@ -1881,9 +1896,10 @@ csr::spmv_strategy Csr<ValueType, IndexType>::get_actual_strategy()
 template <typename ValueType, typename IndexType>
 auto Csr<ValueType, IndexType>::get_device_view() -> device_view
 {
-    return device_view{this->get_size(), this->get_num_stored_elements(),
-                       this->get_values(), this->get_row_ptrs(),
-                       this->get_col_idxs()};
+    return device_view{this->get_size(),     this->get_num_stored_elements(),
+                       this->get_values(),   this->get_row_ptrs(),
+                       this->get_col_idxs(), this->get_num_srow_elements(),
+                       this->get_srow()};
 }
 
 
@@ -1891,10 +1907,11 @@ template <typename ValueType, typename IndexType>
 auto Csr<ValueType, IndexType>::get_const_device_view() const
     -> const_device_view
 {
-    return const_device_view{this->get_size(), this->get_num_stored_elements(),
-                             this->get_const_values(),
-                             this->get_const_row_ptrs(),
-                             this->get_const_col_idxs()};
+    return const_device_view{
+        this->get_size(),           this->get_num_stored_elements(),
+        this->get_const_values(),   this->get_const_row_ptrs(),
+        this->get_const_col_idxs(), this->get_num_srow_elements(),
+        this->get_const_srow()};
 }
 
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -1841,6 +1841,26 @@ csr::spmv_strategy Csr<ValueType, IndexType>::get_actual_strategy()
 }
 
 
+template <typename ValueType, typename IndexType>
+auto Csr<ValueType, IndexType>::get_device_view() -> device_view
+{
+    return device_view{this->get_size(), this->get_num_stored_elements(),
+                       this->get_values(), this->get_row_ptrs(),
+                       this->get_col_idxs()};
+}
+
+
+template <typename ValueType, typename IndexType>
+auto Csr<ValueType, IndexType>::get_const_device_view() const
+    -> const_device_view
+{
+    return const_device_view{this->get_size(), this->get_num_stored_elements(),
+                             this->get_const_values(),
+                             this->get_const_row_ptrs(),
+                             this->get_const_col_idxs()};
+}
+
+
 #define GKO_DECLARE_CSR_MATRIX(ValueType, IndexType) \
     class Csr<ValueType, IndexType>
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_MATRIX);

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -624,7 +624,8 @@ void Csr<ValueType, IndexType>::convert_to(Dense<ValueType>* result) const
     auto tmp_result = make_temporary_output_clone(exec, result);
     tmp_result->resize(this->get_size());
     tmp_result->fill(zero<ValueType>());
-    exec->run(csr::make_fill_in_dense(this, tmp_result->get_device_view()));
+    exec->run(csr::make_fill_in_dense(this->get_const_device_view(),
+                                      tmp_result->get_device_view()));
 }
 
 
@@ -658,7 +659,8 @@ void Csr<ValueType, IndexType>::convert_to(
     coo_nnz = get_element(coo_row_ptrs, num_rows);
     auto tmp = make_temporary_clone(exec, result);
     tmp->resize(this->get_size(), ell_lim, coo_nnz);
-    exec->run(csr::make_convert_to_hybrid(this, coo_row_ptrs.get_const_data(),
+    exec->run(csr::make_convert_to_hybrid(this->get_const_device_view(),
+                                          coo_row_ptrs.get_const_data(),
                                           tmp->get_device_view()));
 }
 
@@ -692,7 +694,8 @@ void Csr<ValueType, IndexType>::convert_to(
     tmp->col_idxs_.resize_and_reset(total_cols * slice_size);
     tmp->values_.resize_and_reset(total_cols * slice_size);
     tmp->set_size(this->get_size());
-    exec->run(csr::make_convert_to_sellp(this, tmp->get_device_view()));
+    exec->run(csr::make_convert_to_sellp(this->get_const_device_view(),
+                                         tmp->get_device_view()));
 }
 
 
@@ -742,7 +745,8 @@ void Csr<ValueType, IndexType>::convert_to(
         tmp->values_.resize_and_reset(storage);
         tmp->set_size(this->get_size());
     }
-    exec->run(csr::make_convert_to_ell(this, tmp->get_device_view()));
+    exec->run(csr::make_convert_to_ell(this->get_const_device_view(),
+                                       tmp->get_device_view()));
 }
 
 
@@ -764,8 +768,9 @@ void Csr<ValueType, IndexType>::convert_to(
     auto tmp = make_temporary_clone(exec, result);
     tmp->row_ptrs_.resize_and_reset(row_blocks + 1);
     tmp->set_size(this->get_size());
-    exec->run(csr::make_convert_to_fbcsr(this, bs, tmp->row_ptrs_,
-                                         tmp->col_idxs_, tmp->values_));
+    exec->run(csr::make_convert_to_fbcsr(this->get_const_device_view(), bs,
+                                         tmp->row_ptrs_, tmp->col_idxs_,
+                                         tmp->values_));
 }
 
 
@@ -944,8 +949,10 @@ void Csr<ValueType, IndexType>::multiply_reuse_info::update_values(
     auto local_mtx1 = make_temporary_clone(exec, mtx1);
     auto local_mtx2 = make_temporary_clone(exec, mtx2);
     auto local_out = make_temporary_clone(exec, out);
-    exec->run(csr::make_spgemm_reuse(local_mtx1.get(), local_mtx2.get(),
-                                     internal->data, local_out.get()));
+    exec->run(csr::make_spgemm_reuse(local_mtx1->get_const_device_view(),
+                                     local_mtx2->get_const_device_view(),
+                                     internal->data,
+                                     local_out->get_device_view()));
 }
 
 
@@ -1072,9 +1079,12 @@ void Csr<ValueType, IndexType>::multiply_add_reuse_info::update_values(
     auto local_alpha = make_temporary_clone(exec, alpha);
     auto local_beta = make_temporary_clone(exec, beta);
     exec->run(csr::make_advanced_spgemm_reuse(
-        local_alpha->get_const_device_view(), local_mtx1.get(),
-        local_mtx2.get(), local_beta->get_const_device_view(), local_mtx3.get(),
-        internal->data, local_out.get()));
+        local_alpha->get_const_device_view(),
+        local_mtx1->get_const_device_view(),
+        local_mtx2->get_const_device_view(),
+        local_beta->get_const_device_view(),
+        local_mtx3->get_const_device_view(), internal->data,
+        local_out->get_device_view()));
 }
 
 
@@ -1191,9 +1201,10 @@ void Csr<ValueType, IndexType>::scale_add_reuse_info::update_values(
     auto local_mtx2 = make_temporary_clone(exec, mtx2);
     auto local_mtx_out = make_temporary_clone(exec, out);
     exec->run(csr::make_spgeam_numeric(local_scale1->get_const_device_view(),
-                                       local_mtx1.get(),
+                                       local_mtx1->get_const_device_view(),
                                        local_scale2->get_const_device_view(),
-                                       local_mtx2.get(), local_mtx_out.get()));
+                                       local_mtx2->get_const_device_view(),
+                                       local_mtx_out->get_device_view()));
 }
 
 
@@ -1333,7 +1344,8 @@ std::unique_ptr<LinOp> Csr<ValueType, IndexType>::transpose() const
         Csr::create(exec, gko::transpose(this->get_size()),
                     this->get_num_stored_elements(), this->get_strategy());
 
-    exec->run(csr::make_transpose(this, trans_cpy.get()));
+    exec->run(csr::make_transpose(this->get_const_device_view(),
+                                  trans_cpy->get_device_view()));
     trans_cpy->make_srow();
     return std::move(trans_cpy);
 }
@@ -1347,7 +1359,8 @@ std::unique_ptr<LinOp> Csr<ValueType, IndexType>::conj_transpose() const
         Csr::create(exec, gko::transpose(this->get_size()),
                     this->get_num_stored_elements(), this->get_strategy());
 
-    exec->run(csr::make_conj_transpose(this, trans_cpy.get()));
+    exec->run(csr::make_conj_transpose(this->get_const_device_view(),
+                                       trans_cpy->get_device_view()));
     trans_cpy->make_srow();
     return std::move(trans_cpy);
 }
@@ -1380,23 +1393,34 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::permute(
     }
     switch (mode) {
     case permute_mode::rows:
-        exec->run(csr::make_row_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_row_permute(perm_idxs,
+                                        this->get_const_device_view(),
+                                        result->get_device_view()));
         break;
     case permute_mode::columns:
-        exec->run(csr::make_inv_col_permute(inv_perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_col_permute(inv_perm_idxs,
+                                            this->get_const_device_view(),
+                                            result->get_device_view()));
         break;
     case permute_mode::inverse_rows:
-        exec->run(csr::make_inv_row_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_row_permute(perm_idxs,
+                                            this->get_const_device_view(),
+                                            result->get_device_view()));
         break;
     case permute_mode::inverse_columns:
-        exec->run(csr::make_inv_col_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_col_permute(perm_idxs,
+                                            this->get_const_device_view(),
+                                            result->get_device_view()));
         break;
     case permute_mode::symmetric:
-        exec->run(
-            csr::make_inv_symm_permute(inv_perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_symm_permute(inv_perm_idxs,
+                                             this->get_const_device_view(),
+                                             result->get_device_view()));
         break;
     case permute_mode::inverse_symmetric:
-        exec->run(csr::make_inv_symm_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_symm_permute(perm_idxs,
+                                             this->get_const_device_view(),
+                                             result->get_device_view()));
         break;
     default:
         GKO_INVALID_STATE("Invalid permute mode");
@@ -1425,14 +1449,15 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::permute(
     if (invert) {
         exec->run(csr::make_inv_nonsymm_permute(
             local_row_permutation->get_const_permutation(),
-            local_col_permutation->get_const_permutation(), this,
-            result.get()));
+            local_col_permutation->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     } else {
         const auto inv_row_perm = local_row_permutation->compute_inverse();
         const auto inv_col_perm = local_col_permutation->compute_inverse();
         exec->run(csr::make_inv_nonsymm_permute(
             inv_row_perm->get_const_permutation(),
-            inv_col_perm->get_const_permutation(), this, result.get()));
+            inv_col_perm->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     }
     result->make_srow();
     result->sort_by_column_index();
@@ -1496,28 +1521,34 @@ Csr<ValueType, IndexType>::scale_permute(
     }
     switch (mode) {
     case permute_mode::rows:
-        exec->run(csr::make_row_scale_permute(scale_factors, perm_idxs, this,
-                                              result.get()));
+        exec->run(csr::make_row_scale_permute(scale_factors, perm_idxs,
+                                              this->get_const_device_view(),
+                                              result->get_device_view()));
         break;
     case permute_mode::columns:
         exec->run(csr::make_inv_col_scale_permute(
-            inv_scale_factors, inv_perm_idxs, this, result.get()));
+            inv_scale_factors, inv_perm_idxs, this->get_const_device_view(),
+            result->get_device_view()));
         break;
     case permute_mode::inverse_rows:
         exec->run(csr::make_inv_row_scale_permute(scale_factors, perm_idxs,
-                                                  this, result.get()));
+                                                  this->get_const_device_view(),
+                                                  result->get_device_view()));
         break;
     case permute_mode::inverse_columns:
         exec->run(csr::make_inv_col_scale_permute(scale_factors, perm_idxs,
-                                                  this, result.get()));
+                                                  this->get_const_device_view(),
+                                                  result->get_device_view()));
         break;
     case permute_mode::symmetric:
         exec->run(csr::make_inv_symm_scale_permute(
-            inv_scale_factors, inv_perm_idxs, this, result.get()));
+            inv_scale_factors, inv_perm_idxs, this->get_const_device_view(),
+            result->get_device_view()));
         break;
     case permute_mode::inverse_symmetric:
-        exec->run(csr::make_inv_symm_scale_permute(scale_factors, perm_idxs,
-                                                   this, result.get()));
+        exec->run(csr::make_inv_symm_scale_permute(
+            scale_factors, perm_idxs, this->get_const_device_view(),
+            result->get_device_view()));
         break;
     default:
         GKO_INVALID_STATE("Invalid permute mode");
@@ -1550,8 +1581,8 @@ Csr<ValueType, IndexType>::scale_permute(
             local_row_permutation->get_const_scaling_factors(),
             local_row_permutation->get_const_permutation(),
             local_col_permutation->get_const_scaling_factors(),
-            local_col_permutation->get_const_permutation(), this,
-            result.get()));
+            local_col_permutation->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     } else {
         const auto inv_row_perm = local_row_permutation->compute_inverse();
         const auto inv_col_perm = local_col_permutation->compute_inverse();
@@ -1559,7 +1590,8 @@ Csr<ValueType, IndexType>::scale_permute(
             inv_row_perm->get_const_scaling_factors(),
             inv_row_perm->get_const_permutation(),
             inv_col_perm->get_const_scaling_factors(),
-            inv_col_perm->get_const_permutation(), this, result.get()));
+            inv_col_perm->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     }
     result->make_srow();
     result->sort_by_column_index();
@@ -1634,7 +1666,7 @@ template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::sort_by_column_index()
 {
     auto exec = this->get_executor();
-    exec->run(csr::make_sort_by_column_index(this));
+    exec->run(csr::make_sort_by_column_index(this->get_device_view()));
 }
 
 
@@ -1643,7 +1675,8 @@ bool Csr<ValueType, IndexType>::is_sorted_by_column_index() const
 {
     auto exec = this->get_executor();
     bool is_sorted;
-    exec->run(csr::make_is_sorted_by_column_index(this, is_sorted));
+    exec->run(csr::make_is_sorted_by_column_index(this->get_const_device_view(),
+                                                  is_sorted));
     return is_sorted;
 }
 
@@ -1658,7 +1691,7 @@ Csr<ValueType, IndexType>::create_submatrix(const gko::span& row_span,
     auto sub_mat_size = gko::dim<2>(row_span.length(), column_span.length());
     array<IndexType> row_ptrs(exec, row_span.length() + 1);
     exec->run(csr::make_calculate_nonzeros_per_row_in_span(
-        this, row_span, column_span, row_ptrs));
+        this->get_const_device_view(), row_span, column_span, row_ptrs));
     exec->run(csr::make_prefix_sum_nonnegative(row_ptrs.get_data(),
                                                row_span.length() + 1));
     auto num_nnz = get_element(row_ptrs, sub_mat_size[0]);
@@ -1666,8 +1699,9 @@ Csr<ValueType, IndexType>::create_submatrix(const gko::span& row_span,
                                std::move(array<ValueType>(exec, num_nnz)),
                                std::move(array<IndexType>(exec, num_nnz)),
                                std::move(row_ptrs), this->get_strategy());
-    exec->run(csr::make_compute_submatrix(this, row_span, column_span,
-                                          sub_mat.get()));
+    exec->run(csr::make_compute_submatrix(this->get_const_device_view(),
+                                          row_span, column_span,
+                                          sub_mat->get_device_view()));
     sub_mat->make_srow();
     return sub_mat;
 }
@@ -1702,7 +1736,8 @@ Csr<ValueType, IndexType>::create_submatrix(
         auto sub_mat_size = gko::dim<2>(submat_num_rows, submat_num_cols);
         array<IndexType> row_ptrs(exec, submat_num_rows + 1);
         exec->run(csr::make_calculate_nonzeros_per_row_in_index_set(
-            this, row_index_set, col_index_set, row_ptrs.get_data()));
+            this->get_const_device_view(), row_index_set, col_index_set,
+            row_ptrs.get_data()));
         exec->run(csr::make_prefix_sum_nonnegative(row_ptrs.get_data(),
                                                    submat_num_rows + 1));
         auto num_nnz = get_element(row_ptrs, sub_mat_size[0]);
@@ -1711,7 +1746,8 @@ Csr<ValueType, IndexType>::create_submatrix(
                                    std::move(array<IndexType>(exec, num_nnz)),
                                    std::move(row_ptrs), this->get_strategy());
         exec->run(csr::make_compute_submatrix_from_index_set(
-            this, row_index_set, col_index_set, sub_mat.get()));
+            this->get_const_device_view(), row_index_set, col_index_set,
+            sub_mat->get_device_view()));
         sub_mat->make_srow();
         return sub_mat;
     }
@@ -1751,7 +1787,8 @@ Csr<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(csr::make_fill_array(diag->get_values(), diag->get_size()[0],
                                    zero<ValueType>()));
-    exec->run(csr::make_extract_diagonal(this, diag.get()));
+    exec->run(
+        csr::make_extract_diagonal(this->get_const_device_view(), diag.get()));
     return diag;
 }
 
@@ -1792,7 +1829,7 @@ void Csr<ValueType, IndexType>::scale_impl(const LinOp* alpha)
     auto exec = this->get_executor();
     exec->run(csr::make_scale(
         make_temporary_conversion<ValueType>(alpha)->get_const_device_view(),
-        this));
+        this->get_device_view()));
 }
 
 
@@ -1802,7 +1839,7 @@ void Csr<ValueType, IndexType>::inv_scale_impl(const LinOp* alpha)
     auto exec = this->get_executor();
     exec->run(csr::make_inv_scale(
         make_temporary_conversion<ValueType>(alpha)->get_const_device_view(),
-        this));
+        this->get_device_view()));
 }
 
 
@@ -1811,8 +1848,8 @@ void Csr<ValueType, IndexType>::add_scaled_identity_impl(const LinOp* a,
                                                          const LinOp* b)
 {
     bool has_diags{false};
-    this->get_executor()->run(
-        csr::make_check_diagonal_entries(this, has_diags));
+    this->get_executor()->run(csr::make_check_diagonal_entries(
+        this->get_const_device_view(), has_diags));
     if (!has_diags) {
         GKO_UNSUPPORTED_MATRIX_PROPERTY(
             "The matrix has one or more structurally zero diagonal entries!");
@@ -1820,7 +1857,7 @@ void Csr<ValueType, IndexType>::add_scaled_identity_impl(const LinOp* a,
     this->get_executor()->run(csr::make_add_scaled_identity(
         make_temporary_conversion<ValueType>(a)->get_const_device_view(),
         make_temporary_conversion<ValueType>(b)->get_const_device_view(),
-        this));
+        this->get_device_view()));
 }
 
 template <typename ValueType, typename IndexType>

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -386,6 +386,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
             [this](auto dense_b, auto dense_x) {
                 this->get_executor()->run(csr::make_spmv(
                     this->get_actual_strategy(), max_nnz_per_row_,
+                    this->get_num_srow_elements(), this->get_const_srow(),
                     this->get_const_device_view(),
                     dense_b->get_const_device_view(),
                     dense_x->get_device_view()));
@@ -528,6 +529,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
                     beta);
                 this->get_executor()->run(csr::make_advanced_spmv(
                     this->get_actual_strategy(), max_nnz_per_row_,
+                    this->get_num_srow_elements(), this->get_const_srow(),
                     dense_alpha->get_const_device_view(),
                     this->get_const_device_view(),
                     dense_b->get_const_device_view(),
@@ -1896,10 +1898,9 @@ csr::spmv_strategy Csr<ValueType, IndexType>::get_actual_strategy()
 template <typename ValueType, typename IndexType>
 auto Csr<ValueType, IndexType>::get_device_view() -> device_view
 {
-    return device_view{this->get_size(),     this->get_num_stored_elements(),
-                       this->get_values(),   this->get_row_ptrs(),
-                       this->get_col_idxs(), this->get_num_srow_elements(),
-                       this->get_srow()};
+    return device_view{this->get_size(), this->get_num_stored_elements(),
+                       this->get_values(), this->get_row_ptrs(),
+                       this->get_col_idxs()};
 }
 
 
@@ -1907,11 +1908,10 @@ template <typename ValueType, typename IndexType>
 auto Csr<ValueType, IndexType>::get_const_device_view() const
     -> const_device_view
 {
-    return const_device_view{
-        this->get_size(),           this->get_num_stored_elements(),
-        this->get_const_values(),   this->get_const_row_ptrs(),
-        this->get_const_col_idxs(), this->get_num_srow_elements(),
-        this->get_const_srow()};
+    return const_device_view{this->get_size(), this->get_num_stored_elements(),
+                             this->get_const_values(),
+                             this->get_const_row_ptrs(),
+                             this->get_const_col_idxs()};
 }
 
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -407,7 +407,8 @@ void Csr<ValueType, IndexType>::convert_to(Dense<ValueType>* result) const
     auto tmp_result = make_temporary_output_clone(exec, result);
     tmp_result->resize(this->get_size());
     tmp_result->fill(zero<ValueType>());
-    exec->run(csr::make_fill_in_dense(this, tmp_result->get_device_view()));
+    exec->run(csr::make_fill_in_dense(this->get_const_device_view(),
+                                      tmp_result->get_device_view()));
 }
 
 
@@ -441,7 +442,8 @@ void Csr<ValueType, IndexType>::convert_to(
     coo_nnz = get_element(coo_row_ptrs, num_rows);
     auto tmp = make_temporary_clone(exec, result);
     tmp->resize(this->get_size(), ell_lim, coo_nnz);
-    exec->run(csr::make_convert_to_hybrid(this, coo_row_ptrs.get_const_data(),
+    exec->run(csr::make_convert_to_hybrid(this->get_const_device_view(),
+                                          coo_row_ptrs.get_const_data(),
                                           tmp.get()));
 }
 
@@ -475,7 +477,8 @@ void Csr<ValueType, IndexType>::convert_to(
     tmp->col_idxs_.resize_and_reset(total_cols * slice_size);
     tmp->values_.resize_and_reset(total_cols * slice_size);
     tmp->set_size(this->get_size());
-    exec->run(csr::make_convert_to_sellp(this, tmp->get_device_view()));
+    exec->run(csr::make_convert_to_sellp(this->get_const_device_view(),
+                                         tmp->get_device_view()));
 }
 
 
@@ -525,7 +528,8 @@ void Csr<ValueType, IndexType>::convert_to(
         tmp->values_.resize_and_reset(storage);
         tmp->set_size(this->get_size());
     }
-    exec->run(csr::make_convert_to_ell(this, tmp->get_device_view()));
+    exec->run(csr::make_convert_to_ell(this->get_const_device_view(),
+                                       tmp->get_device_view()));
 }
 
 
@@ -547,8 +551,9 @@ void Csr<ValueType, IndexType>::convert_to(
     auto tmp = make_temporary_clone(exec, result);
     tmp->row_ptrs_.resize_and_reset(row_blocks + 1);
     tmp->set_size(this->get_size());
-    exec->run(csr::make_convert_to_fbcsr(this, bs, tmp->row_ptrs_,
-                                         tmp->col_idxs_, tmp->values_));
+    exec->run(csr::make_convert_to_fbcsr(this->get_const_device_view(), bs,
+                                         tmp->row_ptrs_, tmp->col_idxs_,
+                                         tmp->values_));
 }
 
 
@@ -726,8 +731,10 @@ void Csr<ValueType, IndexType>::multiply_reuse_info::update_values(
     auto local_mtx1 = make_temporary_clone(exec, mtx1);
     auto local_mtx2 = make_temporary_clone(exec, mtx2);
     auto local_out = make_temporary_clone(exec, out);
-    exec->run(csr::make_spgemm_reuse(local_mtx1.get(), local_mtx2.get(),
-                                     internal->data, local_out.get()));
+    exec->run(csr::make_spgemm_reuse(local_mtx1->get_const_device_view(),
+                                     local_mtx2->get_const_device_view(),
+                                     internal->data,
+                                     local_out->get_device_view()));
 }
 
 
@@ -851,9 +858,12 @@ void Csr<ValueType, IndexType>::multiply_add_reuse_info::update_values(
     auto local_alpha = make_temporary_clone(exec, alpha);
     auto local_beta = make_temporary_clone(exec, beta);
     exec->run(csr::make_advanced_spgemm_reuse(
-        local_alpha->get_const_device_view(), local_mtx1.get(),
-        local_mtx2.get(), local_beta->get_const_device_view(), local_mtx3.get(),
-        internal->data, local_out.get()));
+        local_alpha->get_const_device_view(),
+        local_mtx1->get_const_device_view(),
+        local_mtx2->get_const_device_view(),
+        local_beta->get_const_device_view(),
+        local_mtx3->get_const_device_view(), internal->data,
+        local_out->get_device_view()));
 }
 
 
@@ -969,9 +979,10 @@ void Csr<ValueType, IndexType>::scale_add_reuse_info::update_values(
     auto local_mtx2 = make_temporary_clone(exec, mtx2);
     auto local_mtx_out = make_temporary_clone(exec, out);
     exec->run(csr::make_spgeam_numeric(local_scale1->get_const_device_view(),
-                                       local_mtx1.get(),
+                                       local_mtx1->get_const_device_view(),
                                        local_scale2->get_const_device_view(),
-                                       local_mtx2.get(), local_mtx_out.get()));
+                                       local_mtx2->get_const_device_view(),
+                                       local_mtx_out->get_device_view()));
 }
 
 
@@ -1110,7 +1121,8 @@ std::unique_ptr<LinOp> Csr<ValueType, IndexType>::transpose() const
         Csr::create(exec, gko::transpose(this->get_size()),
                     this->get_num_stored_elements(), this->get_strategy());
 
-    exec->run(csr::make_transpose(this, trans_cpy.get()));
+    exec->run(csr::make_transpose(this->get_const_device_view(),
+                                  trans_cpy->get_device_view()));
     trans_cpy->make_srow();
     return std::move(trans_cpy);
 }
@@ -1124,7 +1136,8 @@ std::unique_ptr<LinOp> Csr<ValueType, IndexType>::conj_transpose() const
         Csr::create(exec, gko::transpose(this->get_size()),
                     this->get_num_stored_elements(), this->get_strategy());
 
-    exec->run(csr::make_conj_transpose(this, trans_cpy.get()));
+    exec->run(csr::make_conj_transpose(this->get_const_device_view(),
+                                       trans_cpy->get_device_view()));
     trans_cpy->make_srow();
     return std::move(trans_cpy);
 }
@@ -1157,23 +1170,34 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::permute(
     }
     switch (mode) {
     case permute_mode::rows:
-        exec->run(csr::make_row_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_row_permute(perm_idxs,
+                                        this->get_const_device_view(),
+                                        result->get_device_view()));
         break;
     case permute_mode::columns:
-        exec->run(csr::make_inv_col_permute(inv_perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_col_permute(inv_perm_idxs,
+                                            this->get_const_device_view(),
+                                            result->get_device_view()));
         break;
     case permute_mode::inverse_rows:
-        exec->run(csr::make_inv_row_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_row_permute(perm_idxs,
+                                            this->get_const_device_view(),
+                                            result->get_device_view()));
         break;
     case permute_mode::inverse_columns:
-        exec->run(csr::make_inv_col_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_col_permute(perm_idxs,
+                                            this->get_const_device_view(),
+                                            result->get_device_view()));
         break;
     case permute_mode::symmetric:
-        exec->run(
-            csr::make_inv_symm_permute(inv_perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_symm_permute(inv_perm_idxs,
+                                             this->get_const_device_view(),
+                                             result->get_device_view()));
         break;
     case permute_mode::inverse_symmetric:
-        exec->run(csr::make_inv_symm_permute(perm_idxs, this, result.get()));
+        exec->run(csr::make_inv_symm_permute(perm_idxs,
+                                             this->get_const_device_view(),
+                                             result->get_device_view()));
         break;
     default:
         GKO_INVALID_STATE("Invalid permute mode");
@@ -1202,14 +1226,15 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::permute(
     if (invert) {
         exec->run(csr::make_inv_nonsymm_permute(
             local_row_permutation->get_const_permutation(),
-            local_col_permutation->get_const_permutation(), this,
-            result.get()));
+            local_col_permutation->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     } else {
         const auto inv_row_perm = local_row_permutation->compute_inverse();
         const auto inv_col_perm = local_col_permutation->compute_inverse();
         exec->run(csr::make_inv_nonsymm_permute(
             inv_row_perm->get_const_permutation(),
-            inv_col_perm->get_const_permutation(), this, result.get()));
+            inv_col_perm->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     }
     result->make_srow();
     result->sort_by_column_index();
@@ -1273,28 +1298,34 @@ Csr<ValueType, IndexType>::scale_permute(
     }
     switch (mode) {
     case permute_mode::rows:
-        exec->run(csr::make_row_scale_permute(scale_factors, perm_idxs, this,
-                                              result.get()));
+        exec->run(csr::make_row_scale_permute(scale_factors, perm_idxs,
+                                              this->get_const_device_view(),
+                                              result->get_device_view()));
         break;
     case permute_mode::columns:
         exec->run(csr::make_inv_col_scale_permute(
-            inv_scale_factors, inv_perm_idxs, this, result.get()));
+            inv_scale_factors, inv_perm_idxs, this->get_const_device_view(),
+            result->get_device_view()));
         break;
     case permute_mode::inverse_rows:
         exec->run(csr::make_inv_row_scale_permute(scale_factors, perm_idxs,
-                                                  this, result.get()));
+                                                  this->get_const_device_view(),
+                                                  result->get_device_view()));
         break;
     case permute_mode::inverse_columns:
         exec->run(csr::make_inv_col_scale_permute(scale_factors, perm_idxs,
-                                                  this, result.get()));
+                                                  this->get_const_device_view(),
+                                                  result->get_device_view()));
         break;
     case permute_mode::symmetric:
         exec->run(csr::make_inv_symm_scale_permute(
-            inv_scale_factors, inv_perm_idxs, this, result.get()));
+            inv_scale_factors, inv_perm_idxs, this->get_const_device_view(),
+            result->get_device_view()));
         break;
     case permute_mode::inverse_symmetric:
-        exec->run(csr::make_inv_symm_scale_permute(scale_factors, perm_idxs,
-                                                   this, result.get()));
+        exec->run(csr::make_inv_symm_scale_permute(
+            scale_factors, perm_idxs, this->get_const_device_view(),
+            result->get_device_view()));
         break;
     default:
         GKO_INVALID_STATE("Invalid permute mode");
@@ -1327,8 +1358,8 @@ Csr<ValueType, IndexType>::scale_permute(
             local_row_permutation->get_const_scaling_factors(),
             local_row_permutation->get_const_permutation(),
             local_col_permutation->get_const_scaling_factors(),
-            local_col_permutation->get_const_permutation(), this,
-            result.get()));
+            local_col_permutation->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     } else {
         const auto inv_row_perm = local_row_permutation->compute_inverse();
         const auto inv_col_perm = local_col_permutation->compute_inverse();
@@ -1336,7 +1367,8 @@ Csr<ValueType, IndexType>::scale_permute(
             inv_row_perm->get_const_scaling_factors(),
             inv_row_perm->get_const_permutation(),
             inv_col_perm->get_const_scaling_factors(),
-            inv_col_perm->get_const_permutation(), this, result.get()));
+            inv_col_perm->get_const_permutation(),
+            this->get_const_device_view(), result->get_device_view()));
     }
     result->make_srow();
     result->sort_by_column_index();
@@ -1411,7 +1443,7 @@ template <typename ValueType, typename IndexType>
 void Csr<ValueType, IndexType>::sort_by_column_index()
 {
     auto exec = this->get_executor();
-    exec->run(csr::make_sort_by_column_index(this));
+    exec->run(csr::make_sort_by_column_index(this->get_device_view()));
 }
 
 
@@ -1420,7 +1452,8 @@ bool Csr<ValueType, IndexType>::is_sorted_by_column_index() const
 {
     auto exec = this->get_executor();
     bool is_sorted;
-    exec->run(csr::make_is_sorted_by_column_index(this, is_sorted));
+    exec->run(csr::make_is_sorted_by_column_index(this->get_const_device_view(),
+                                                  is_sorted));
     return is_sorted;
 }
 
@@ -1435,7 +1468,7 @@ Csr<ValueType, IndexType>::create_submatrix(const gko::span& row_span,
     auto sub_mat_size = gko::dim<2>(row_span.length(), column_span.length());
     array<IndexType> row_ptrs(exec, row_span.length() + 1);
     exec->run(csr::make_calculate_nonzeros_per_row_in_span(
-        this, row_span, column_span, row_ptrs));
+        this->get_const_device_view(), row_span, column_span, row_ptrs));
     exec->run(csr::make_prefix_sum_nonnegative(row_ptrs.get_data(),
                                                row_span.length() + 1));
     auto num_nnz = get_element(row_ptrs, sub_mat_size[0]);
@@ -1443,8 +1476,9 @@ Csr<ValueType, IndexType>::create_submatrix(const gko::span& row_span,
                                std::move(array<ValueType>(exec, num_nnz)),
                                std::move(array<IndexType>(exec, num_nnz)),
                                std::move(row_ptrs), this->get_strategy());
-    exec->run(csr::make_compute_submatrix(this, row_span, column_span,
-                                          sub_mat.get()));
+    exec->run(csr::make_compute_submatrix(this->get_const_device_view(),
+                                          row_span, column_span,
+                                          sub_mat->get_device_view()));
     sub_mat->make_srow();
     return sub_mat;
 }
@@ -1479,7 +1513,8 @@ Csr<ValueType, IndexType>::create_submatrix(
         auto sub_mat_size = gko::dim<2>(submat_num_rows, submat_num_cols);
         array<IndexType> row_ptrs(exec, submat_num_rows + 1);
         exec->run(csr::make_calculate_nonzeros_per_row_in_index_set(
-            this, row_index_set, col_index_set, row_ptrs.get_data()));
+            this->get_const_device_view(), row_index_set, col_index_set,
+            row_ptrs.get_data()));
         exec->run(csr::make_prefix_sum_nonnegative(row_ptrs.get_data(),
                                                    submat_num_rows + 1));
         auto num_nnz = get_element(row_ptrs, sub_mat_size[0]);
@@ -1488,7 +1523,8 @@ Csr<ValueType, IndexType>::create_submatrix(
                                    std::move(array<IndexType>(exec, num_nnz)),
                                    std::move(row_ptrs), this->get_strategy());
         exec->run(csr::make_compute_submatrix_from_index_set(
-            this, row_index_set, col_index_set, sub_mat.get()));
+            this->get_const_device_view(), row_index_set, col_index_set,
+            sub_mat->get_device_view()));
         sub_mat->make_srow();
         return sub_mat;
     }
@@ -1528,7 +1564,8 @@ Csr<ValueType, IndexType>::extract_diagonal() const
     auto diag = Diagonal<ValueType>::create(exec, diag_size);
     exec->run(csr::make_fill_array(diag->get_values(), diag->get_size()[0],
                                    zero<ValueType>()));
-    exec->run(csr::make_extract_diagonal(this, diag.get()));
+    exec->run(
+        csr::make_extract_diagonal(this->get_const_device_view(), diag.get()));
     return diag;
 }
 
@@ -1569,7 +1606,7 @@ void Csr<ValueType, IndexType>::scale_impl(const LinOp* alpha)
     auto exec = this->get_executor();
     exec->run(csr::make_scale(
         make_temporary_conversion<ValueType>(alpha)->get_const_device_view(),
-        this));
+        this->get_device_view()));
 }
 
 
@@ -1579,7 +1616,7 @@ void Csr<ValueType, IndexType>::inv_scale_impl(const LinOp* alpha)
     auto exec = this->get_executor();
     exec->run(csr::make_inv_scale(
         make_temporary_conversion<ValueType>(alpha)->get_const_device_view(),
-        this));
+        this->get_device_view()));
 }
 
 
@@ -1588,8 +1625,8 @@ void Csr<ValueType, IndexType>::add_scaled_identity_impl(const LinOp* a,
                                                          const LinOp* b)
 {
     bool has_diags{false};
-    this->get_executor()->run(
-        csr::make_check_diagonal_entries(this, has_diags));
+    this->get_executor()->run(csr::make_check_diagonal_entries(
+        this->get_const_device_view(), has_diags));
     if (!has_diags) {
         GKO_UNSUPPORTED_MATRIX_PROPERTY(
             "The matrix has one or more structurally zero diagonal entries!");
@@ -1597,7 +1634,7 @@ void Csr<ValueType, IndexType>::add_scaled_identity_impl(const LinOp* a,
     this->get_executor()->run(csr::make_add_scaled_identity(
         make_temporary_conversion<ValueType>(a)->get_const_device_view(),
         make_temporary_conversion<ValueType>(b)->get_const_device_view(),
-        this));
+        this->get_device_view()));
 }
 
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -1601,6 +1601,26 @@ void Csr<ValueType, IndexType>::add_scaled_identity_impl(const LinOp* a,
 }
 
 
+template <typename ValueType, typename IndexType>
+auto Csr<ValueType, IndexType>::get_device_view() -> device_view
+{
+    return device_view{this->get_size(), this->get_num_stored_elements(),
+                       this->get_values(), this->get_row_ptrs(),
+                       this->get_col_idxs()};
+}
+
+
+template <typename ValueType, typename IndexType>
+auto Csr<ValueType, IndexType>::get_const_device_view() const
+    -> const_device_view
+{
+    return const_device_view{this->get_size(), this->get_num_stored_elements(),
+                             this->get_const_values(),
+                             this->get_const_row_ptrs(),
+                             this->get_const_col_idxs()};
+}
+
+
 #define GKO_DECLARE_CSR_MATRIX(ValueType, IndexType) \
     class Csr<ValueType, IndexType>
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_MATRIX);

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -978,11 +978,10 @@ void Csr<ValueType, IndexType>::scale_add_reuse_info::update_values(
     auto local_mtx1 = make_temporary_clone(exec, mtx1);
     auto local_mtx2 = make_temporary_clone(exec, mtx2);
     auto local_mtx_out = make_temporary_clone(exec, out);
-    exec->run(csr::make_spgeam_numeric(local_scale1->get_const_device_view(),
-                                       local_mtx1->get_const_device_view(),
-                                       local_scale2->get_const_device_view(),
-                                       local_mtx2->get_const_device_view(),
-                                       local_mtx_out->get_device_view()));
+    exec->run(csr::make_spgeam_numeric(
+        local_scale1->get_const_device_view(), local_mtx1.get(),
+        local_scale2->get_const_device_view(), local_mtx2.get(),
+        local_mtx_out->get_device_view()));
 }
 
 

--- a/core/matrix/csr_accessor_helper.hpp
+++ b/core/matrix/csr_accessor_helper.hpp
@@ -80,24 +80,25 @@ auto build_const_rrm_accessor(matrix::view::dense<const ValueType> input,
 
 
 template <typename ArthType, typename ValueType, typename IndexType>
-auto build_rrm_accessor(matrix::Csr<ValueType, IndexType>* input)
+auto build_rrm_accessor(matrix::view::csr<ValueType, IndexType> input)
 {
     using accessor = gko::acc::reduced_row_major<1, ArthType, ValueType>;
     return gko::acc::range<accessor>(
         std::array<acc::size_type, 1>{
-            {static_cast<acc::size_type>(input->get_num_stored_elements())}},
-        input->get_values());
+            {static_cast<acc::size_type>(input.num_stored_elements)}},
+        input.values);
 }
 
 
 template <typename ArthType, typename ValueType, typename IndexType>
-auto build_const_rrm_accessor(const matrix::Csr<ValueType, IndexType>* input)
+auto build_const_rrm_accessor(
+    matrix::view::csr<const ValueType, const IndexType> input)
 {
     using accessor = gko::acc::reduced_row_major<1, ArthType, const ValueType>;
     return gko::acc::range<accessor>(
         std::array<acc::size_type, 1>{
-            {static_cast<acc::size_type>(input->get_num_stored_elements())}},
-        input->get_const_values());
+            {static_cast<acc::size_type>(input.num_stored_elements)}},
+        input.values);
 }
 
 

--- a/core/matrix/csr_accessor_helper.hpp
+++ b/core/matrix/csr_accessor_helper.hpp
@@ -80,25 +80,24 @@ auto build_const_rrm_accessor(matrix::view::dense<const ValueType> input,
 
 
 template <typename ArthType, typename ValueType, typename IndexType>
-auto build_rrm_accessor(matrix::view::csr<ValueType, IndexType> input)
+auto build_rrm_accessor(matrix::Csr<ValueType, IndexType>* input)
 {
     using accessor = gko::acc::reduced_row_major<1, ArthType, ValueType>;
     return gko::acc::range<accessor>(
         std::array<acc::size_type, 1>{
-            {static_cast<acc::size_type>(input.num_stored_elements)}},
-        input.values);
+            {static_cast<acc::size_type>(input->get_num_stored_elements())}},
+        input->get_values());
 }
 
 
 template <typename ArthType, typename ValueType, typename IndexType>
-auto build_const_rrm_accessor(
-    matrix::view::csr<const ValueType, const IndexType> input)
+auto build_const_rrm_accessor(const matrix::Csr<ValueType, IndexType>* input)
 {
     using accessor = gko::acc::reduced_row_major<1, ArthType, const ValueType>;
     return gko::acc::range<accessor>(
         std::array<acc::size_type, 1>{
-            {static_cast<acc::size_type>(input.num_stored_elements)}},
-        input.values);
+            {static_cast<acc::size_type>(input->get_num_stored_elements())}},
+        input->get_const_values());
 }
 
 

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -24,13 +24,14 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_CSR_SPMV_KERNEL(MatrixValueType, InputValueType,       \
-                                    OutputValueType, IndexType)            \
-    void spmv(std::shared_ptr<const DefaultExecutor> exec,                 \
-              const matrix::csr::spmv_strategy strategy,                   \
-              const IndexType max_nnz_per_row,                             \
-              matrix::view::csr<const MatrixValueType, const IndexType> a, \
-              matrix::view::dense<const InputValueType> b,                 \
+#define GKO_DECLARE_CSR_SPMV_KERNEL(MatrixValueType, InputValueType,        \
+                                    OutputValueType, IndexType)             \
+    void spmv(std::shared_ptr<const DefaultExecutor> exec,                  \
+              const matrix::csr::spmv_strategy strategy,                    \
+              const IndexType max_nnz_per_row, size_type num_srow_elements, \
+              const IndexType* srow,                                        \
+              matrix::view::csr<const MatrixValueType, const IndexType> a,  \
+              matrix::view::dense<const InputValueType> b,                  \
               matrix::view::dense<OutputValueType> c)
 
 #define GKO_DECLARE_CSR_ADVANCED_SPMV_KERNEL(MatrixValueType, InputValueType, \
@@ -38,7 +39,8 @@ namespace kernels {
     void advanced_spmv(                                                       \
         std::shared_ptr<const DefaultExecutor> exec,                          \
         const matrix::csr::spmv_strategy strategy,                            \
-        const IndexType max_nnz_per_row,                                      \
+        const IndexType max_nnz_per_row, size_type num_srow_elements,         \
+        const IndexType* srow,                                                \
         matrix::view::dense<const MatrixValueType> alpha,                     \
         matrix::view::csr<const MatrixValueType, const IndexType> a,          \
         matrix::view::dense<const InputValueType> b,                          \

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -59,23 +59,23 @@ namespace kernels {
                          const matrix::Csr<ValueType, IndexType>* d,  \
                          matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
-#define GKO_DECLARE_CSR_SPGEMM_REUSE_KERNEL(ValueType, IndexType)          \
-    void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,         \
-                      const matrix::Csr<ValueType, IndexType>* a,          \
-                      const matrix::Csr<ValueType, IndexType>* b,          \
-                      const matrix::csr::lookup_data<IndexType>& c_lookup, \
-                      matrix::Csr<ValueType, IndexType>* c)
+#define GKO_DECLARE_CSR_SPGEMM_REUSE_KERNEL(ValueType, IndexType)            \
+    void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,           \
+                      matrix::view::csr<const ValueType, const IndexType> a, \
+                      matrix::view::csr<const ValueType, const IndexType> b, \
+                      const matrix::csr::lookup_data<IndexType>& c_lookup,   \
+                      matrix::view::csr<ValueType, IndexType> c)
 
 #define GKO_DECLARE_CSR_ADVANCED_SPGEMM_REUSE_KERNEL(ValueType, IndexType) \
     void advanced_spgemm_reuse(                                            \
         std::shared_ptr<const DefaultExecutor> exec,                       \
         matrix::view::dense<const ValueType> alpha,                        \
-        const matrix::Csr<ValueType, IndexType>* a,                        \
-        const matrix::Csr<ValueType, IndexType>* b,                        \
+        matrix::view::csr<const ValueType, const IndexType> a,             \
+        matrix::view::csr<const ValueType, const IndexType> b,             \
         matrix::view::dense<const ValueType> beta,                         \
-        const matrix::Csr<ValueType, IndexType>* d,                        \
+        matrix::view::csr<const ValueType, const IndexType> d,             \
         const matrix::csr::lookup_data<IndexType>& c_lookup,               \
-        matrix::Csr<ValueType, IndexType>* c)
+        matrix::view::csr<ValueType, IndexType> c)
 
 #define GKO_DECLARE_CSR_SPGEAM_KERNEL(ValueType, IndexType)  \
     void spgeam(std::shared_ptr<const DefaultExecutor> exec, \
@@ -85,110 +85,119 @@ namespace kernels {
                 const matrix::Csr<ValueType, IndexType>* b,  \
                 matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
-#define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)  \
-    void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec, \
-                        matrix::view::dense<const ValueType> alpha,  \
-                        const matrix::Csr<ValueType, IndexType>* a,  \
-                        matrix::view::dense<const ValueType> beta,   \
-                        const matrix::Csr<ValueType, IndexType>* b,  \
-                        matrix::Csr<ValueType, IndexType>* c)
+#define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)            \
+    void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,           \
+                        matrix::view::dense<const ValueType> alpha,            \
+                        matrix::view::csr<const ValueType, const IndexType> a, \
+                        matrix::view::dense<const ValueType> beta,             \
+                        matrix::view::csr<const ValueType, const IndexType> b, \
+                        matrix::view::csr<ValueType, IndexType> c)
 
-#define GKO_DECLARE_CSR_FILL_IN_DENSE_KERNEL(ValueType, IndexType)      \
-    void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,     \
-                       const matrix::Csr<ValueType, IndexType>* source, \
-                       matrix::view::dense<ValueType> result)
+#define GKO_DECLARE_CSR_FILL_IN_DENSE_KERNEL(ValueType, IndexType)  \
+    void fill_in_dense(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> source, \
+        matrix::view::dense<ValueType> result)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_ELL_KERNEL(ValueType, IndexType)      \
-    void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,     \
-                        const matrix::Csr<ValueType, IndexType>* source, \
-                        matrix::view::ell<ValueType, IndexType> result)
+#define GKO_DECLARE_CSR_CONVERT_TO_ELL_KERNEL(ValueType, IndexType) \
+    void convert_to_ell(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> source, \
+        matrix::view::ell<ValueType, IndexType> result)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_FBCSR_KERNEL(ValueType, IndexType)      \
-    void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* source, \
-                          int block_size, array<IndexType>& row_ptrs,      \
-                          array<IndexType>& col_idxs,                      \
-                          array<ValueType>& values)
+#define GKO_DECLARE_CSR_CONVERT_TO_FBCSR_KERNEL(ValueType, IndexType) \
+    void convert_to_fbcsr(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        matrix::view::csr<const ValueType, const IndexType> source,   \
+        int block_size, array<IndexType>& row_ptrs,                   \
+        array<IndexType>& col_idxs, array<ValueType>& values)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_HYBRID_KERNEL(ValueType, IndexType)      \
-    void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,     \
-                           const matrix::Csr<ValueType, IndexType>* source, \
-                           const int64* coo_row_ptrs,                       \
-                           matrix::view::hybrid<ValueType, IndexType> result)
+#define GKO_DECLARE_CSR_CONVERT_TO_HYBRID_KERNEL(ValueType, IndexType) \
+    void convert_to_hybrid(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                   \
+        matrix::view::csr<const ValueType, const IndexType> source,    \
+        const int64* coo_row_ptrs,                                     \
+        matrix::view::hybrid<ValueType, IndexType> result)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_SELLP_KERNEL(ValueType, IndexType)      \
-    void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* source, \
-                          matrix::view::sellp<ValueType, IndexType> result)
+#define GKO_DECLARE_CSR_CONVERT_TO_SELLP_KERNEL(ValueType, IndexType) \
+    void convert_to_sellp(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        matrix::view::csr<const ValueType, const IndexType> source,   \
+        matrix::view::sellp<ValueType, IndexType> result)
 
-#define GKO_DECLARE_CSR_TRANSPOSE_KERNEL(ValueType, IndexType)    \
-    void transpose(std::shared_ptr<const DefaultExecutor> exec,   \
-                   const matrix::Csr<ValueType, IndexType>* orig, \
-                   matrix::Csr<ValueType, IndexType>* trans)
+#define GKO_DECLARE_CSR_TRANSPOSE_KERNEL(ValueType, IndexType)               \
+    void transpose(std::shared_ptr<const DefaultExecutor> exec,              \
+                   matrix::view::csr<const ValueType, const IndexType> orig, \
+                   matrix::view::csr<ValueType, IndexType> trans)
 
-#define GKO_DECLARE_CSR_CONJ_TRANSPOSE_KERNEL(ValueType, IndexType)    \
-    void conj_transpose(std::shared_ptr<const DefaultExecutor> exec,   \
-                        const matrix::Csr<ValueType, IndexType>* orig, \
-                        matrix::Csr<ValueType, IndexType>* trans)
+#define GKO_DECLARE_CSR_CONJ_TRANSPOSE_KERNEL(ValueType, IndexType) \
+    void conj_transpose(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> orig,   \
+        matrix::view::csr<ValueType, IndexType> trans)
 
-#define GKO_DECLARE_CSR_INV_SYMM_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_symm_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                          const IndexType* permutation_indices,          \
-                          const matrix::Csr<ValueType, IndexType>* orig, \
-                          matrix::Csr<ValueType, IndexType>* permuted)
+#define GKO_DECLARE_CSR_INV_SYMM_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_symm_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        const IndexType* permutation_indices,                         \
+        matrix::view::csr<const ValueType, const IndexType> orig,     \
+        matrix::view::csr<ValueType, IndexType> permuted)
 
-#define GKO_DECLARE_CSR_ROW_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void row_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                     const IndexType* permutation_indices,          \
-                     const matrix::Csr<ValueType, IndexType>* orig, \
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+#define GKO_DECLARE_CSR_ROW_PERMUTE_KERNEL(ValueType, IndexType)               \
+    void row_permute(std::shared_ptr<const DefaultExecutor> exec,              \
+                     const IndexType* permutation_indices,                     \
+                     matrix::view::csr<const ValueType, const IndexType> orig, \
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 
-#define GKO_DECLARE_CSR_INV_ROW_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_row_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                         const IndexType* permutation_indices,          \
-                         const matrix::Csr<ValueType, IndexType>* orig, \
-                         matrix::Csr<ValueType, IndexType>* row_permuted)
+#define GKO_DECLARE_CSR_INV_ROW_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_row_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                 \
+        const IndexType* permutation_indices,                        \
+        matrix::view::csr<const ValueType, const IndexType> orig,    \
+        matrix::view::csr<ValueType, IndexType> row_permuted)
 
-#define GKO_DECLARE_CSR_INV_COL_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_col_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                         const IndexType* permutation_indices,          \
-                         const matrix::Csr<ValueType, IndexType>* orig, \
-                         matrix::Csr<ValueType, IndexType>* col_permuted)
+#define GKO_DECLARE_CSR_INV_COL_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_col_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                 \
+        const IndexType* permutation_indices,                        \
+        matrix::view::csr<const ValueType, const IndexType> orig,    \
+        matrix::view::csr<ValueType, IndexType> col_permuted)
 
-#define GKO_DECLARE_CSR_INV_NONSYMM_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                             const IndexType* row_permutation_indices,      \
-                             const IndexType* column_permutation_indices,   \
-                             const matrix::Csr<ValueType, IndexType>* orig, \
-                             matrix::Csr<ValueType, IndexType>* permuted)
+#define GKO_DECLARE_CSR_INV_NONSYMM_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_nonsymm_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                     \
+        const IndexType* row_permutation_indices,                        \
+        const IndexType* column_permutation_indices,                     \
+        matrix::view::csr<const ValueType, const IndexType> orig,        \
+        matrix::view::csr<ValueType, IndexType> permuted)
 
-#define GKO_DECLARE_CSR_INV_SYMM_SCALE_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_symm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                                const ValueType* scale,                        \
-                                const IndexType* permutation_indices,          \
-                                const matrix::Csr<ValueType, IndexType>* orig, \
-                                matrix::Csr<ValueType, IndexType>* permuted)
+#define GKO_DECLARE_CSR_INV_SYMM_SCALE_PERMUTE_KERNEL(ValueType, IndexType)  \
+    void inv_symm_scale_permute(                                             \
+        std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
+        const IndexType* permutation_indices,                                \
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> permuted)
 
-#define GKO_DECLARE_CSR_ROW_SCALE_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                           const ValueType* scale,                        \
-                           const IndexType* permutation_indices,          \
-                           const matrix::Csr<ValueType, IndexType>* orig, \
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+#define GKO_DECLARE_CSR_ROW_SCALE_PERMUTE_KERNEL(ValueType, IndexType)       \
+    void row_scale_permute(                                                  \
+        std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
+        const IndexType* permutation_indices,                                \
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> row_permuted)
 
 #define GKO_DECLARE_CSR_INV_ROW_SCALE_PERMUTE_KERNEL(ValueType, IndexType)   \
     void inv_row_scale_permute(                                              \
         std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
         const IndexType* permutation_indices,                                \
-        const matrix::Csr<ValueType, IndexType>* orig,                       \
-        matrix::Csr<ValueType, IndexType>* row_permuted)
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> row_permuted)
 
 #define GKO_DECLARE_CSR_INV_COL_SCALE_PERMUTE_KERNEL(ValueType, IndexType)   \
     void inv_col_scale_permute(                                              \
         std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
         const IndexType* permutation_indices,                                \
-        const matrix::Csr<ValueType, IndexType>* orig,                       \
-        matrix::Csr<ValueType, IndexType>* col_permuted)
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> col_permuted)
 
 #define GKO_DECLARE_CSR_INV_NONSYMM_SCALE_PERMUTE_KERNEL(ValueType, IndexType) \
     void inv_nonsymm_scale_permute(                                            \
@@ -196,72 +205,76 @@ namespace kernels {
         const ValueType* row_scale, const IndexType* row_permutation_indices,  \
         const ValueType* column_scale,                                         \
         const IndexType* column_permutation_indices,                           \
-        const matrix::Csr<ValueType, IndexType>* orig,                         \
-        matrix::Csr<ValueType, IndexType>* col_permuted)
+        matrix::view::csr<const ValueType, const IndexType> orig,              \
+        matrix::view::csr<ValueType, IndexType> col_permuted)
 
-#define GKO_DECLARE_CSR_CALC_NNZ_PER_ROW_IN_SPAN_KERNEL(ValueType, IndexType)  \
-    void calculate_nonzeros_per_row_in_span(                                   \
-        std::shared_ptr<const DefaultExecutor> exec,                           \
-        const matrix::Csr<ValueType, IndexType>* source, const span& row_span, \
-        const span& col_span, array<IndexType>& row_nnz)
+#define GKO_DECLARE_CSR_CALC_NNZ_PER_ROW_IN_SPAN_KERNEL(ValueType, IndexType) \
+    void calculate_nonzeros_per_row_in_span(                                  \
+        std::shared_ptr<const DefaultExecutor> exec,                          \
+        matrix::view::csr<const ValueType, const IndexType> source,           \
+        const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 
 #define GKO_DECLARE_CSR_CALC_NNZ_PER_ROW_IN_INDEX_SET_KERNEL(ValueType, \
                                                              IndexType) \
     void calculate_nonzeros_per_row_in_index_set(                       \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* source,                \
+        matrix::view::csr<const ValueType, const IndexType> source,     \
         const gko::index_set<IndexType>& row_index_set,                 \
         const gko::index_set<IndexType>& col_index_set, IndexType* row_nnz)
 
-#define GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_KERNEL(ValueType, IndexType)     \
-    void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,     \
-                           const matrix::Csr<ValueType, IndexType>* source, \
-                           gko::span row_span, gko::span col_span,          \
-                           matrix::Csr<ValueType, IndexType>* result)
+#define GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_KERNEL(ValueType, IndexType) \
+    void compute_submatrix(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                    \
+        matrix::view::csr<const ValueType, const IndexType> source,     \
+        gko::span row_span, gko::span col_span,                         \
+        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_FROM_INDEX_SET_KERNEL(ValueType, \
                                                                  IndexType) \
     void compute_submatrix_from_index_set(                                  \
         std::shared_ptr<const DefaultExecutor> exec,                        \
-        const matrix::Csr<ValueType, IndexType>* source,                    \
+        matrix::view::csr<const ValueType, const IndexType> source,         \
         const gko::index_set<IndexType>& row_index_set,                     \
         const gko::index_set<IndexType>& col_index_set,                     \
-        matrix::Csr<ValueType, IndexType>* result)
+        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_CSR_SORT_BY_COLUMN_INDEX(ValueType, IndexType)         \
     void sort_by_column_index(std::shared_ptr<const DefaultExecutor> exec, \
-                              matrix::Csr<ValueType, IndexType>* to_sort)
+                              matrix::view::csr<ValueType, IndexType> to_sort)
 
 #define GKO_DECLARE_CSR_IS_SORTED_BY_COLUMN_INDEX(ValueType, IndexType) \
     void is_sorted_by_column_index(                                     \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+        matrix::view::csr<const ValueType, const IndexType> to_check,   \
+        bool& is_sorted)
 
-#define GKO_DECLARE_CSR_EXTRACT_DIAGONAL(ValueType, IndexType)           \
-    void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,   \
-                          const matrix::Csr<ValueType, IndexType>* orig, \
-                          matrix::Diagonal<ValueType>* diag)
+#define GKO_DECLARE_CSR_EXTRACT_DIAGONAL(ValueType, IndexType)    \
+    void extract_diagonal(                                        \
+        std::shared_ptr<const DefaultExecutor> exec,              \
+        matrix::view::csr<const ValueType, const IndexType> orig, \
+        matrix::Diagonal<ValueType>* diag)
 
 #define GKO_DECLARE_CSR_SCALE_KERNEL(ValueType, IndexType)  \
     void scale(std::shared_ptr<const DefaultExecutor> exec, \
                matrix::view::dense<const ValueType> alpha,  \
-               matrix::Csr<ValueType, IndexType>* to_scale)
+               matrix::view::csr<ValueType, IndexType> to_scale)
 
 #define GKO_DECLARE_CSR_INV_SCALE_KERNEL(ValueType, IndexType)  \
     void inv_scale(std::shared_ptr<const DefaultExecutor> exec, \
                    matrix::view::dense<const ValueType> alpha,  \
-                   matrix::Csr<ValueType, IndexType>* to_scale)
+                   matrix::view::csr<ValueType, IndexType> to_scale)
 
 #define GKO_DECLARE_CSR_CHECK_DIAGONAL_ENTRIES_EXIST(ValueType, IndexType) \
     void check_diagonal_entries_exist(                                     \
         std::shared_ptr<const DefaultExecutor> exec,                       \
-        const matrix::Csr<ValueType, IndexType>* mtx, bool& has_all_diags)
+        matrix::view::csr<const ValueType, const IndexType> mtx,           \
+        bool& has_all_diags)
 
 #define GKO_DECLARE_CSR_ADD_SCALED_IDENTITY_KERNEL(ValueType, IndexType)  \
     void add_scaled_identity(std::shared_ptr<const DefaultExecutor> exec, \
                              matrix::view::dense<const ValueType> alpha,  \
                              matrix::view::dense<const ValueType> beta,   \
-                             matrix::Csr<ValueType, IndexType>* mtx)
+                             matrix::view::csr<ValueType, IndexType> mtx)
 
 #define GKO_DECLARE_CSR_BUILD_LOOKUP_OFFSETS_KERNEL(IndexType)               \
     void build_lookup_offsets(std::shared_ptr<const DefaultExecutor> exec,   \
@@ -286,10 +299,11 @@ namespace kernels {
                           IndexType sample_size, IndexType* result)
 
 
-#define GKO_DECLARE_CSR_ROW_WISE_ABSOLUTE_SUM(ValueType, IndexType)           \
-    void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,   \
-                               const matrix::Csr<ValueType, IndexType>* orig, \
-                               array<ValueType>& sum)
+#define GKO_DECLARE_CSR_ROW_WISE_ABSOLUTE_SUM(ValueType, IndexType) \
+    void row_wise_absolute_sum(                                     \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> orig,   \
+        array<ValueType>& sum)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                        \

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -24,40 +24,42 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_CSR_SPMV_KERNEL(MatrixValueType, InputValueType, \
-                                    OutputValueType, IndexType)      \
-    void spmv(std::shared_ptr<const DefaultExecutor> exec,           \
-              const matrix::csr::spmv_strategy strategy,             \
-              const IndexType max_nnz_per_row,                       \
-              const matrix::Csr<MatrixValueType, IndexType>* a,      \
-              matrix::view::dense<const InputValueType> b,           \
+#define GKO_DECLARE_CSR_SPMV_KERNEL(MatrixValueType, InputValueType,       \
+                                    OutputValueType, IndexType)            \
+    void spmv(std::shared_ptr<const DefaultExecutor> exec,                 \
+              const matrix::csr::spmv_strategy strategy,                   \
+              const IndexType max_nnz_per_row,                             \
+              matrix::view::csr<const MatrixValueType, const IndexType> a, \
+              matrix::view::dense<const InputValueType> b,                 \
               matrix::view::dense<OutputValueType> c)
 
 #define GKO_DECLARE_CSR_ADVANCED_SPMV_KERNEL(MatrixValueType, InputValueType, \
                                              OutputValueType, IndexType)      \
-    void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,           \
-                       const matrix::csr::spmv_strategy strategy,             \
-                       const IndexType max_nnz_per_row,                       \
-                       matrix::view::dense<const MatrixValueType> alpha,      \
-                       const matrix::Csr<MatrixValueType, IndexType>* a,      \
-                       matrix::view::dense<const InputValueType> b,           \
-                       matrix::view::dense<const OutputValueType> beta,       \
-                       matrix::view::dense<OutputValueType> c)
+    void advanced_spmv(                                                       \
+        std::shared_ptr<const DefaultExecutor> exec,                          \
+        const matrix::csr::spmv_strategy strategy,                            \
+        const IndexType max_nnz_per_row,                                      \
+        matrix::view::dense<const MatrixValueType> alpha,                     \
+        matrix::view::csr<const MatrixValueType, const IndexType> a,          \
+        matrix::view::dense<const InputValueType> b,                          \
+        matrix::view::dense<const OutputValueType> beta,                      \
+        matrix::view::dense<OutputValueType> c)
 
-#define GKO_DECLARE_CSR_SPGEMM_KERNEL(ValueType, IndexType)  \
-    void spgemm(std::shared_ptr<const DefaultExecutor> exec, \
-                const matrix::Csr<ValueType, IndexType>* a,  \
-                const matrix::Csr<ValueType, IndexType>* b,  \
+#define GKO_DECLARE_CSR_SPGEMM_KERNEL(ValueType, IndexType)            \
+    void spgemm(std::shared_ptr<const DefaultExecutor> exec,           \
+                matrix::view::csr<const ValueType, const IndexType> a, \
+                matrix::view::csr<const ValueType, const IndexType> b, \
                 matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
-#define GKO_DECLARE_CSR_ADVANCED_SPGEMM_KERNEL(ValueType, IndexType)  \
-    void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec, \
-                         matrix::view::dense<const ValueType> alpha,  \
-                         const matrix::Csr<ValueType, IndexType>* a,  \
-                         const matrix::Csr<ValueType, IndexType>* b,  \
-                         matrix::view::dense<const ValueType> beta,   \
-                         const matrix::Csr<ValueType, IndexType>* d,  \
-                         matrix::CsrBuilder<ValueType, IndexType>* c_builder)
+#define GKO_DECLARE_CSR_ADVANCED_SPGEMM_KERNEL(ValueType, IndexType) \
+    void advanced_spgemm(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                 \
+        matrix::view::dense<const ValueType> alpha,                  \
+        matrix::view::csr<const ValueType, const IndexType> a,       \
+        matrix::view::csr<const ValueType, const IndexType> b,       \
+        matrix::view::dense<const ValueType> beta,                   \
+        matrix::view::csr<const ValueType, const IndexType> d,       \
+        matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
 #define GKO_DECLARE_CSR_SPGEMM_REUSE_KERNEL(ValueType, IndexType)            \
     void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,           \
@@ -77,12 +79,12 @@ namespace kernels {
         const matrix::csr::lookup_data<IndexType>& c_lookup,               \
         matrix::view::csr<ValueType, IndexType> c)
 
-#define GKO_DECLARE_CSR_SPGEAM_KERNEL(ValueType, IndexType)  \
-    void spgeam(std::shared_ptr<const DefaultExecutor> exec, \
-                matrix::view::dense<const ValueType> alpha,  \
-                const matrix::Csr<ValueType, IndexType>* a,  \
-                matrix::view::dense<const ValueType> beta,   \
-                const matrix::Csr<ValueType, IndexType>* b,  \
+#define GKO_DECLARE_CSR_SPGEAM_KERNEL(ValueType, IndexType)            \
+    void spgeam(std::shared_ptr<const DefaultExecutor> exec,           \
+                matrix::view::dense<const ValueType> alpha,            \
+                matrix::view::csr<const ValueType, const IndexType> a, \
+                matrix::view::dense<const ValueType> beta,             \
+                matrix::view::csr<const ValueType, const IndexType> b, \
                 matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
 #define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)            \

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -58,23 +58,23 @@ namespace kernels {
                          const matrix::Csr<ValueType, IndexType>* d,  \
                          matrix::Csr<ValueType, IndexType>* c)
 
-#define GKO_DECLARE_CSR_SPGEMM_REUSE_KERNEL(ValueType, IndexType)          \
-    void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,         \
-                      const matrix::Csr<ValueType, IndexType>* a,          \
-                      const matrix::Csr<ValueType, IndexType>* b,          \
-                      const matrix::csr::lookup_data<IndexType>& c_lookup, \
-                      matrix::Csr<ValueType, IndexType>* c)
+#define GKO_DECLARE_CSR_SPGEMM_REUSE_KERNEL(ValueType, IndexType)            \
+    void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,           \
+                      matrix::view::csr<const ValueType, const IndexType> a, \
+                      matrix::view::csr<const ValueType, const IndexType> b, \
+                      const matrix::csr::lookup_data<IndexType>& c_lookup,   \
+                      matrix::view::csr<ValueType, IndexType> c)
 
 #define GKO_DECLARE_CSR_ADVANCED_SPGEMM_REUSE_KERNEL(ValueType, IndexType) \
     void advanced_spgemm_reuse(                                            \
         std::shared_ptr<const DefaultExecutor> exec,                       \
         matrix::view::dense<const ValueType> alpha,                        \
-        const matrix::Csr<ValueType, IndexType>* a,                        \
-        const matrix::Csr<ValueType, IndexType>* b,                        \
+        matrix::view::csr<const ValueType, const IndexType> a,             \
+        matrix::view::csr<const ValueType, const IndexType> b,             \
         matrix::view::dense<const ValueType> beta,                         \
-        const matrix::Csr<ValueType, IndexType>* d,                        \
+        matrix::view::csr<const ValueType, const IndexType> d,             \
         const matrix::csr::lookup_data<IndexType>& c_lookup,               \
-        matrix::Csr<ValueType, IndexType>* c)
+        matrix::view::csr<ValueType, IndexType> c)
 
 #define GKO_DECLARE_CSR_SPGEAM_KERNEL(ValueType, IndexType)  \
     void spgeam(std::shared_ptr<const DefaultExecutor> exec, \
@@ -84,110 +84,119 @@ namespace kernels {
                 const matrix::Csr<ValueType, IndexType>* b,  \
                 matrix::Csr<ValueType, IndexType>* c)
 
-#define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)  \
-    void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec, \
-                        matrix::view::dense<const ValueType> alpha,  \
-                        const matrix::Csr<ValueType, IndexType>* a,  \
-                        matrix::view::dense<const ValueType> beta,   \
-                        const matrix::Csr<ValueType, IndexType>* b,  \
-                        matrix::Csr<ValueType, IndexType>* c)
+#define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)            \
+    void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,           \
+                        matrix::view::dense<const ValueType> alpha,            \
+                        matrix::view::csr<const ValueType, const IndexType> a, \
+                        matrix::view::dense<const ValueType> beta,             \
+                        matrix::view::csr<const ValueType, const IndexType> b, \
+                        matrix::view::csr<ValueType, IndexType> c)
 
-#define GKO_DECLARE_CSR_FILL_IN_DENSE_KERNEL(ValueType, IndexType)      \
-    void fill_in_dense(std::shared_ptr<const DefaultExecutor> exec,     \
-                       const matrix::Csr<ValueType, IndexType>* source, \
-                       matrix::view::dense<ValueType> result)
+#define GKO_DECLARE_CSR_FILL_IN_DENSE_KERNEL(ValueType, IndexType)  \
+    void fill_in_dense(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> source, \
+        matrix::view::dense<ValueType> result)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_ELL_KERNEL(ValueType, IndexType)      \
-    void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,     \
-                        const matrix::Csr<ValueType, IndexType>* source, \
-                        matrix::view::ell<ValueType, IndexType> result)
+#define GKO_DECLARE_CSR_CONVERT_TO_ELL_KERNEL(ValueType, IndexType) \
+    void convert_to_ell(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> source, \
+        matrix::view::ell<ValueType, IndexType> result)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_FBCSR_KERNEL(ValueType, IndexType)      \
-    void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* source, \
-                          int block_size, array<IndexType>& row_ptrs,      \
-                          array<IndexType>& col_idxs,                      \
-                          array<ValueType>& values)
+#define GKO_DECLARE_CSR_CONVERT_TO_FBCSR_KERNEL(ValueType, IndexType) \
+    void convert_to_fbcsr(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        matrix::view::csr<const ValueType, const IndexType> source,   \
+        int block_size, array<IndexType>& row_ptrs,                   \
+        array<IndexType>& col_idxs, array<ValueType>& values)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_HYBRID_KERNEL(ValueType, IndexType)      \
-    void convert_to_hybrid(std::shared_ptr<const DefaultExecutor> exec,     \
-                           const matrix::Csr<ValueType, IndexType>* source, \
-                           const int64* coo_row_ptrs,                       \
-                           matrix::Hybrid<ValueType, IndexType>* result)
+#define GKO_DECLARE_CSR_CONVERT_TO_HYBRID_KERNEL(ValueType, IndexType) \
+    void convert_to_hybrid(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                   \
+        matrix::view::csr<const ValueType, const IndexType> source,    \
+        const int64* coo_row_ptrs,                                     \
+        matrix::Hybrid<ValueType, IndexType>* result)
 
-#define GKO_DECLARE_CSR_CONVERT_TO_SELLP_KERNEL(ValueType, IndexType)      \
-    void convert_to_sellp(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* source, \
-                          matrix::view::sellp<ValueType, IndexType> result)
+#define GKO_DECLARE_CSR_CONVERT_TO_SELLP_KERNEL(ValueType, IndexType) \
+    void convert_to_sellp(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        matrix::view::csr<const ValueType, const IndexType> source,   \
+        matrix::view::sellp<ValueType, IndexType> result)
 
-#define GKO_DECLARE_CSR_TRANSPOSE_KERNEL(ValueType, IndexType)    \
-    void transpose(std::shared_ptr<const DefaultExecutor> exec,   \
-                   const matrix::Csr<ValueType, IndexType>* orig, \
-                   matrix::Csr<ValueType, IndexType>* trans)
+#define GKO_DECLARE_CSR_TRANSPOSE_KERNEL(ValueType, IndexType)               \
+    void transpose(std::shared_ptr<const DefaultExecutor> exec,              \
+                   matrix::view::csr<const ValueType, const IndexType> orig, \
+                   matrix::view::csr<ValueType, IndexType> trans)
 
-#define GKO_DECLARE_CSR_CONJ_TRANSPOSE_KERNEL(ValueType, IndexType)    \
-    void conj_transpose(std::shared_ptr<const DefaultExecutor> exec,   \
-                        const matrix::Csr<ValueType, IndexType>* orig, \
-                        matrix::Csr<ValueType, IndexType>* trans)
+#define GKO_DECLARE_CSR_CONJ_TRANSPOSE_KERNEL(ValueType, IndexType) \
+    void conj_transpose(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> orig,   \
+        matrix::view::csr<ValueType, IndexType> trans)
 
-#define GKO_DECLARE_CSR_INV_SYMM_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_symm_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                          const IndexType* permutation_indices,          \
-                          const matrix::Csr<ValueType, IndexType>* orig, \
-                          matrix::Csr<ValueType, IndexType>* permuted)
+#define GKO_DECLARE_CSR_INV_SYMM_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_symm_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                  \
+        const IndexType* permutation_indices,                         \
+        matrix::view::csr<const ValueType, const IndexType> orig,     \
+        matrix::view::csr<ValueType, IndexType> permuted)
 
-#define GKO_DECLARE_CSR_ROW_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void row_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                     const IndexType* permutation_indices,          \
-                     const matrix::Csr<ValueType, IndexType>* orig, \
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+#define GKO_DECLARE_CSR_ROW_PERMUTE_KERNEL(ValueType, IndexType)               \
+    void row_permute(std::shared_ptr<const DefaultExecutor> exec,              \
+                     const IndexType* permutation_indices,                     \
+                     matrix::view::csr<const ValueType, const IndexType> orig, \
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 
-#define GKO_DECLARE_CSR_INV_ROW_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_row_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                         const IndexType* permutation_indices,          \
-                         const matrix::Csr<ValueType, IndexType>* orig, \
-                         matrix::Csr<ValueType, IndexType>* row_permuted)
+#define GKO_DECLARE_CSR_INV_ROW_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_row_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                 \
+        const IndexType* permutation_indices,                        \
+        matrix::view::csr<const ValueType, const IndexType> orig,    \
+        matrix::view::csr<ValueType, IndexType> row_permuted)
 
-#define GKO_DECLARE_CSR_INV_COL_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_col_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                         const IndexType* permutation_indices,          \
-                         const matrix::Csr<ValueType, IndexType>* orig, \
-                         matrix::Csr<ValueType, IndexType>* col_permuted)
+#define GKO_DECLARE_CSR_INV_COL_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_col_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                 \
+        const IndexType* permutation_indices,                        \
+        matrix::view::csr<const ValueType, const IndexType> orig,    \
+        matrix::view::csr<ValueType, IndexType> col_permuted)
 
-#define GKO_DECLARE_CSR_INV_NONSYMM_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                             const IndexType* row_permutation_indices,      \
-                             const IndexType* column_permutation_indices,   \
-                             const matrix::Csr<ValueType, IndexType>* orig, \
-                             matrix::Csr<ValueType, IndexType>* permuted)
+#define GKO_DECLARE_CSR_INV_NONSYMM_PERMUTE_KERNEL(ValueType, IndexType) \
+    void inv_nonsymm_permute(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                     \
+        const IndexType* row_permutation_indices,                        \
+        const IndexType* column_permutation_indices,                     \
+        matrix::view::csr<const ValueType, const IndexType> orig,        \
+        matrix::view::csr<ValueType, IndexType> permuted)
 
-#define GKO_DECLARE_CSR_INV_SYMM_SCALE_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void inv_symm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                                const ValueType* scale,                        \
-                                const IndexType* permutation_indices,          \
-                                const matrix::Csr<ValueType, IndexType>* orig, \
-                                matrix::Csr<ValueType, IndexType>* permuted)
+#define GKO_DECLARE_CSR_INV_SYMM_SCALE_PERMUTE_KERNEL(ValueType, IndexType)  \
+    void inv_symm_scale_permute(                                             \
+        std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
+        const IndexType* permutation_indices,                                \
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> permuted)
 
-#define GKO_DECLARE_CSR_ROW_SCALE_PERMUTE_KERNEL(ValueType, IndexType)    \
-    void row_scale_permute(std::shared_ptr<const DefaultExecutor> exec,   \
-                           const ValueType* scale,                        \
-                           const IndexType* permutation_indices,          \
-                           const matrix::Csr<ValueType, IndexType>* orig, \
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+#define GKO_DECLARE_CSR_ROW_SCALE_PERMUTE_KERNEL(ValueType, IndexType)       \
+    void row_scale_permute(                                                  \
+        std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
+        const IndexType* permutation_indices,                                \
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> row_permuted)
 
 #define GKO_DECLARE_CSR_INV_ROW_SCALE_PERMUTE_KERNEL(ValueType, IndexType)   \
     void inv_row_scale_permute(                                              \
         std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
         const IndexType* permutation_indices,                                \
-        const matrix::Csr<ValueType, IndexType>* orig,                       \
-        matrix::Csr<ValueType, IndexType>* row_permuted)
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> row_permuted)
 
 #define GKO_DECLARE_CSR_INV_COL_SCALE_PERMUTE_KERNEL(ValueType, IndexType)   \
     void inv_col_scale_permute(                                              \
         std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale, \
         const IndexType* permutation_indices,                                \
-        const matrix::Csr<ValueType, IndexType>* orig,                       \
-        matrix::Csr<ValueType, IndexType>* col_permuted)
+        matrix::view::csr<const ValueType, const IndexType> orig,            \
+        matrix::view::csr<ValueType, IndexType> col_permuted)
 
 #define GKO_DECLARE_CSR_INV_NONSYMM_SCALE_PERMUTE_KERNEL(ValueType, IndexType) \
     void inv_nonsymm_scale_permute(                                            \
@@ -195,72 +204,76 @@ namespace kernels {
         const ValueType* row_scale, const IndexType* row_permutation_indices,  \
         const ValueType* column_scale,                                         \
         const IndexType* column_permutation_indices,                           \
-        const matrix::Csr<ValueType, IndexType>* orig,                         \
-        matrix::Csr<ValueType, IndexType>* col_permuted)
+        matrix::view::csr<const ValueType, const IndexType> orig,              \
+        matrix::view::csr<ValueType, IndexType> col_permuted)
 
-#define GKO_DECLARE_CSR_CALC_NNZ_PER_ROW_IN_SPAN_KERNEL(ValueType, IndexType)  \
-    void calculate_nonzeros_per_row_in_span(                                   \
-        std::shared_ptr<const DefaultExecutor> exec,                           \
-        const matrix::Csr<ValueType, IndexType>* source, const span& row_span, \
-        const span& col_span, array<IndexType>& row_nnz)
+#define GKO_DECLARE_CSR_CALC_NNZ_PER_ROW_IN_SPAN_KERNEL(ValueType, IndexType) \
+    void calculate_nonzeros_per_row_in_span(                                  \
+        std::shared_ptr<const DefaultExecutor> exec,                          \
+        matrix::view::csr<const ValueType, const IndexType> source,           \
+        const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 
 #define GKO_DECLARE_CSR_CALC_NNZ_PER_ROW_IN_INDEX_SET_KERNEL(ValueType, \
                                                              IndexType) \
     void calculate_nonzeros_per_row_in_index_set(                       \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* source,                \
+        matrix::view::csr<const ValueType, const IndexType> source,     \
         const gko::index_set<IndexType>& row_index_set,                 \
         const gko::index_set<IndexType>& col_index_set, IndexType* row_nnz)
 
-#define GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_KERNEL(ValueType, IndexType)     \
-    void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,     \
-                           const matrix::Csr<ValueType, IndexType>* source, \
-                           gko::span row_span, gko::span col_span,          \
-                           matrix::Csr<ValueType, IndexType>* result)
+#define GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_KERNEL(ValueType, IndexType) \
+    void compute_submatrix(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                    \
+        matrix::view::csr<const ValueType, const IndexType> source,     \
+        gko::span row_span, gko::span col_span,                         \
+        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_FROM_INDEX_SET_KERNEL(ValueType, \
                                                                  IndexType) \
     void compute_submatrix_from_index_set(                                  \
         std::shared_ptr<const DefaultExecutor> exec,                        \
-        const matrix::Csr<ValueType, IndexType>* source,                    \
+        matrix::view::csr<const ValueType, const IndexType> source,         \
         const gko::index_set<IndexType>& row_index_set,                     \
         const gko::index_set<IndexType>& col_index_set,                     \
-        matrix::Csr<ValueType, IndexType>* result)
+        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_CSR_SORT_BY_COLUMN_INDEX(ValueType, IndexType)         \
     void sort_by_column_index(std::shared_ptr<const DefaultExecutor> exec, \
-                              matrix::Csr<ValueType, IndexType>* to_sort)
+                              matrix::view::csr<ValueType, IndexType> to_sort)
 
 #define GKO_DECLARE_CSR_IS_SORTED_BY_COLUMN_INDEX(ValueType, IndexType) \
     void is_sorted_by_column_index(                                     \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+        matrix::view::csr<const ValueType, const IndexType> to_check,   \
+        bool& is_sorted)
 
-#define GKO_DECLARE_CSR_EXTRACT_DIAGONAL(ValueType, IndexType)           \
-    void extract_diagonal(std::shared_ptr<const DefaultExecutor> exec,   \
-                          const matrix::Csr<ValueType, IndexType>* orig, \
-                          matrix::Diagonal<ValueType>* diag)
+#define GKO_DECLARE_CSR_EXTRACT_DIAGONAL(ValueType, IndexType)    \
+    void extract_diagonal(                                        \
+        std::shared_ptr<const DefaultExecutor> exec,              \
+        matrix::view::csr<const ValueType, const IndexType> orig, \
+        matrix::Diagonal<ValueType>* diag)
 
 #define GKO_DECLARE_CSR_SCALE_KERNEL(ValueType, IndexType)  \
     void scale(std::shared_ptr<const DefaultExecutor> exec, \
                matrix::view::dense<const ValueType> alpha,  \
-               matrix::Csr<ValueType, IndexType>* to_scale)
+               matrix::view::csr<ValueType, IndexType> to_scale)
 
 #define GKO_DECLARE_CSR_INV_SCALE_KERNEL(ValueType, IndexType)  \
     void inv_scale(std::shared_ptr<const DefaultExecutor> exec, \
                    matrix::view::dense<const ValueType> alpha,  \
-                   matrix::Csr<ValueType, IndexType>* to_scale)
+                   matrix::view::csr<ValueType, IndexType> to_scale)
 
 #define GKO_DECLARE_CSR_CHECK_DIAGONAL_ENTRIES_EXIST(ValueType, IndexType) \
     void check_diagonal_entries_exist(                                     \
         std::shared_ptr<const DefaultExecutor> exec,                       \
-        const matrix::Csr<ValueType, IndexType>* mtx, bool& has_all_diags)
+        matrix::view::csr<const ValueType, const IndexType> mtx,           \
+        bool& has_all_diags)
 
 #define GKO_DECLARE_CSR_ADD_SCALED_IDENTITY_KERNEL(ValueType, IndexType)  \
     void add_scaled_identity(std::shared_ptr<const DefaultExecutor> exec, \
                              matrix::view::dense<const ValueType> alpha,  \
                              matrix::view::dense<const ValueType> beta,   \
-                             matrix::Csr<ValueType, IndexType>* mtx)
+                             matrix::view::csr<ValueType, IndexType> mtx)
 
 #define GKO_DECLARE_CSR_BUILD_LOOKUP_OFFSETS_KERNEL(IndexType)               \
     void build_lookup_offsets(std::shared_ptr<const DefaultExecutor> exec,   \
@@ -285,10 +298,11 @@ namespace kernels {
                           IndexType sample_size, IndexType* result)
 
 
-#define GKO_DECLARE_CSR_ROW_WISE_ABSOLUTE_SUM(ValueType, IndexType)           \
-    void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,   \
-                               const matrix::Csr<ValueType, IndexType>* orig, \
-                               array<ValueType>& sum)
+#define GKO_DECLARE_CSR_ROW_WISE_ABSOLUTE_SUM(ValueType, IndexType) \
+    void row_wise_absolute_sum(                                     \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> orig,   \
+        array<ValueType>& sum)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                        \

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -84,12 +84,12 @@ namespace kernels {
                 const matrix::Csr<ValueType, IndexType>* b,  \
                 matrix::Csr<ValueType, IndexType>* c)
 
-#define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)            \
-    void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec,           \
-                        matrix::view::dense<const ValueType> alpha,            \
-                        matrix::view::csr<const ValueType, const IndexType> a, \
-                        matrix::view::dense<const ValueType> beta,             \
-                        matrix::view::csr<const ValueType, const IndexType> b, \
+#define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)  \
+    void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec, \
+                        matrix::view::dense<const ValueType> alpha,  \
+                        const matrix::Csr<ValueType, IndexType>* a,  \
+                        matrix::view::dense<const ValueType> beta,   \
+                        const matrix::Csr<ValueType, IndexType>* b,  \
                         matrix::view::csr<ValueType, IndexType> c)
 
 #define GKO_DECLARE_CSR_FILL_IN_DENSE_KERNEL(ValueType, IndexType)  \

--- a/core/matrix/dense.cpp
+++ b/core/matrix/dense.cpp
@@ -757,7 +757,7 @@ void Dense<ValueType>::convert_impl(Csr<ValueType, IndexType>* result) const
         tmp->values_.resize_and_reset(nnz);
         tmp->set_size(this->get_size());
         exec->run(dense::make_convert_to_csr(this->get_const_device_view(),
-                                             tmp.get()));
+                                             tmp->get_device_view()));
     }
     result->make_srow();
 }

--- a/core/matrix/dense_kernels.hpp
+++ b/core/matrix/dense_kernels.hpp
@@ -154,7 +154,7 @@ namespace kernels {
 #define GKO_DECLARE_DENSE_CONVERT_TO_CSR_KERNEL(ValueType, IndexType) \
     void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,  \
                         matrix::view::dense<const ValueType> source,  \
-                        matrix::Csr<ValueType, IndexType>* other)
+                        matrix::view::csr<ValueType, IndexType> other)
 
 #define GKO_DECLARE_DENSE_CONVERT_TO_ELL_KERNEL(ValueType, IndexType) \
     void convert_to_ell(std::shared_ptr<const DefaultExecutor> exec,  \

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -43,14 +43,20 @@ void Diagonal<ValueType>::apply_impl(const LinOp* b, LinOp* x) const
 
     if (dynamic_cast<const Csr<ValueType, int32>*>(b) &&
         dynamic_cast<Csr<ValueType, int32>*>(x)) {
-        exec->run(
-            diagonal::make_apply_to_csr(this, as<Csr<ValueType, int32>>(b),
-                                        as<Csr<ValueType, int32>>(x), false));
+        auto b_csr = as<Csr<ValueType, int32>>(b);
+        auto x_csr = as<Csr<ValueType, int32>>(x);
+        x_csr->copy_from(b_csr);
+        exec->run(diagonal::make_apply_to_csr(this,
+                                              b_csr->get_const_device_view(),
+                                              x_csr->get_device_view(), false));
     } else if (dynamic_cast<const Csr<ValueType, int64>*>(b) &&
                dynamic_cast<Csr<ValueType, int64>*>(x)) {
-        exec->run(
-            diagonal::make_apply_to_csr(this, as<Csr<ValueType, int64>>(b),
-                                        as<Csr<ValueType, int64>>(x), false));
+        auto b_csr = as<Csr<ValueType, int64>>(b);
+        auto x_csr = as<Csr<ValueType, int64>>(x);
+        x_csr->copy_from(b_csr);
+        exec->run(diagonal::make_apply_to_csr(this,
+                                              b_csr->get_const_device_view(),
+                                              x_csr->get_device_view(), false));
     } else {
         precision_dispatch_real_complex<ValueType>(
             [this, &exec](auto dense_b, auto dense_x) {
@@ -70,12 +76,20 @@ void Diagonal<ValueType>::rapply_impl(const LinOp* b, LinOp* x) const
 
     if (dynamic_cast<const Csr<ValueType, int32>*>(b) &&
         dynamic_cast<Csr<ValueType, int32>*>(x)) {
+        auto b_csr = as<Csr<ValueType, int32>>(b);
+        auto x_csr = as<Csr<ValueType, int32>>(x);
+        // TODO: combine copy and diag apply together
+        x_csr->copy_from(b_csr);
         exec->run(diagonal::make_right_apply_to_csr(
-            this, as<Csr<ValueType, int32>>(b), as<Csr<ValueType, int32>>(x)));
+            this, b_csr->get_const_device_view(), x_csr->get_device_view()));
     } else if (dynamic_cast<const Csr<ValueType, int64>*>(b) &&
                dynamic_cast<Csr<ValueType, int64>*>(x)) {
+        auto b_csr = as<Csr<ValueType, int64>>(b);
+        auto x_csr = as<Csr<ValueType, int64>>(x);
+        // TODO: combine copy and diag apply together
+        x_csr->copy_from(b_csr);
         exec->run(diagonal::make_right_apply_to_csr(
-            this, as<Csr<ValueType, int64>>(b), as<Csr<ValueType, int64>>(x)));
+            this, b_csr->get_const_device_view(), x_csr->get_device_view()));
     } else {
         // no real-to-complex conversion, as this would require doubling the
         // diagonal entries for the complex-to-real columns
@@ -97,14 +111,20 @@ void Diagonal<ValueType>::inverse_apply_impl(const LinOp* b, LinOp* x) const
 
     if (dynamic_cast<const Csr<ValueType, int32>*>(b) &&
         dynamic_cast<Csr<ValueType, int32>*>(x)) {
-        exec->run(
-            diagonal::make_apply_to_csr(this, as<Csr<ValueType, int32>>(b),
-                                        as<Csr<ValueType, int32>>(x), true));
+        auto b_csr = as<Csr<ValueType, int32>>(b);
+        auto x_csr = as<Csr<ValueType, int32>>(x);
+        x_csr->copy_from(b_csr);
+        exec->run(diagonal::make_apply_to_csr(this,
+                                              b_csr->get_const_device_view(),
+                                              x_csr->get_device_view(), true));
     } else if (dynamic_cast<const Csr<ValueType, int64>*>(b) &&
                dynamic_cast<Csr<ValueType, int64>*>(x)) {
-        exec->run(
-            diagonal::make_apply_to_csr(this, as<Csr<ValueType, int64>>(b),
-                                        as<Csr<ValueType, int64>>(x), true));
+        auto b_csr = as<Csr<ValueType, int64>>(b);
+        auto x_csr = as<Csr<ValueType, int64>>(x);
+        x_csr->copy_from(b_csr);
+        exec->run(diagonal::make_apply_to_csr(this,
+                                              b_csr->get_const_device_view(),
+                                              x_csr->get_device_view(), true));
     } else {
         precision_dispatch_real_complex<ValueType>(
             [this, &exec](auto dense_b, auto dense_x) {

--- a/core/matrix/diagonal.cpp
+++ b/core/matrix/diagonal.cpp
@@ -214,7 +214,7 @@ void Diagonal<ValueType>::convert_to(Csr<ValueType, int32>* result) const
         tmp->col_idxs_.resize_and_reset(this->get_size()[0]);
         tmp->values_.resize_and_reset(this->get_size()[0]);
         tmp->set_size(this->get_size());
-        exec->run(diagonal::make_convert_to_csr(this, tmp.get()));
+        exec->run(diagonal::make_convert_to_csr(this, tmp->get_device_view()));
     }
     result->make_srow();
 }
@@ -237,7 +237,7 @@ void Diagonal<ValueType>::convert_to(Csr<ValueType, int64>* result) const
         tmp->col_idxs_.resize_and_reset(this->get_size()[0]);
         tmp->values_.resize_and_reset(this->get_size()[0]);
         tmp->set_size(this->get_size());
-        exec->run(diagonal::make_convert_to_csr(this, tmp.get()));
+        exec->run(diagonal::make_convert_to_csr(this, tmp->get_device_view()));
     }
     result->make_srow();
 }

--- a/core/matrix/diagonal_kernels.hpp
+++ b/core/matrix/diagonal_kernels.hpp
@@ -51,7 +51,7 @@ namespace kernels {
 #define GKO_DECLARE_DIAGONAL_CONVERT_TO_CSR_KERNEL(ValueType, IndexType) \
     void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,     \
                         const matrix::Diagonal<ValueType>* source,       \
-                        matrix::Csr<ValueType, IndexType>* result)
+                        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_DIAGONAL_CONJ_TRANSPOSE_KERNEL(ValueType)        \
     void conj_transpose(std::shared_ptr<const DefaultExecutor> exec, \

--- a/core/matrix/diagonal_kernels.hpp
+++ b/core/matrix/diagonal_kernels.hpp
@@ -30,17 +30,18 @@ namespace kernels {
                               matrix::view::dense<const ValueType> b,      \
                               matrix::view::dense<ValueType> c)
 
-#define GKO_DECLARE_DIAGONAL_APPLY_TO_CSR_KERNEL(ValueType, IndexType) \
-    void apply_to_csr(std::shared_ptr<const DefaultExecutor> exec,     \
-                      const matrix::Diagonal<ValueType>* a,            \
-                      const matrix::Csr<ValueType, IndexType>* b,      \
-                      matrix::Csr<ValueType, IndexType>* c, bool inverse)
+#define GKO_DECLARE_DIAGONAL_APPLY_TO_CSR_KERNEL(ValueType, IndexType)       \
+    void apply_to_csr(std::shared_ptr<const DefaultExecutor> exec,           \
+                      const matrix::Diagonal<ValueType>* a,                  \
+                      matrix::view::csr<const ValueType, const IndexType> b, \
+                      matrix::view::csr<ValueType, IndexType> c, bool inverse)
 
 #define GKO_DECLARE_DIAGONAL_RIGHT_APPLY_TO_CSR_KERNEL(ValueType, IndexType) \
-    void right_apply_to_csr(std::shared_ptr<const DefaultExecutor> exec,     \
-                            const matrix::Diagonal<ValueType>* a,            \
-                            const matrix::Csr<ValueType, IndexType>* b,      \
-                            matrix::Csr<ValueType, IndexType>* c)
+    void right_apply_to_csr(                                                 \
+        std::shared_ptr<const DefaultExecutor> exec,                         \
+        const matrix::Diagonal<ValueType>* a,                                \
+        matrix::view::csr<const ValueType, const IndexType> b,               \
+        matrix::view::csr<ValueType, IndexType> c)
 
 #define GKO_DECLARE_DIAGONAL_FILL_IN_MATRIX_DATA_KERNEL(ValueType, IndexType) \
     void fill_in_matrix_data(                                                 \

--- a/core/matrix/ell.cpp
+++ b/core/matrix/ell.cpp
@@ -260,8 +260,8 @@ void Ell<ValueType, IndexType>::convert_to(
         tmp->col_idxs_.resize_and_reset(nnz);
         tmp->values_.resize_and_reset(nnz);
         tmp->set_size(this->get_size());
-        exec->run(
-            ell::make_convert_to_csr(this->get_const_device_view(), tmp.get()));
+        exec->run(ell::make_convert_to_csr(this->get_const_device_view(),
+                                           tmp->get_device_view()));
     }
     result->make_srow();
 }

--- a/core/matrix/ell_kernels.hpp
+++ b/core/matrix/ell_kernels.hpp
@@ -62,7 +62,7 @@ namespace kernels {
     void convert_to_csr(                                            \
         std::shared_ptr<const DefaultExecutor> exec,                \
         matrix::view::ell<const ValueType, const IndexType> source, \
-        matrix::Csr<ValueType, IndexType>* result)
+        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_ELL_COUNT_NONZEROS_PER_ROW_KERNEL(ValueType, IndexType) \
     void count_nonzeros_per_row(                                            \

--- a/core/matrix/fbcsr.cpp
+++ b/core/matrix/fbcsr.cpp
@@ -243,7 +243,7 @@ void Fbcsr<ValueType, IndexType>::convert_to(
         tmp->col_idxs_.resize_and_reset(this->get_num_stored_elements());
         tmp->values_.resize_and_reset(this->get_num_stored_elements());
         tmp->set_size(this->get_size());
-        exec->run(fbcsr::make_convert_to_csr(this, tmp.get()));
+        exec->run(fbcsr::make_convert_to_csr(this, tmp->get_device_view()));
     }
     result->make_srow();
 }

--- a/core/matrix/fbcsr_kernels.hpp
+++ b/core/matrix/fbcsr_kernels.hpp
@@ -50,7 +50,7 @@ namespace kernels {
 #define GKO_DECLARE_FBCSR_CONVERT_TO_CSR_KERNEL(ValueType, IndexType)      \
     void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,       \
                         const matrix::Fbcsr<ValueType, IndexType>* source, \
-                        matrix::Csr<ValueType, IndexType>* result)
+                        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_FBCSR_TRANSPOSE_KERNEL(ValueType, IndexType)    \
     void transpose(std::shared_ptr<const DefaultExecutor> exec,     \

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -334,7 +334,7 @@ void Hybrid<ValueType, IndexType>::convert_to(
         tmp->set_size(this->get_size());
         exec->run(hybrid::make_convert_to_csr(
             this->get_const_device_view(), ell_row_ptrs.get_const_data(),
-            coo_row_ptrs.get_const_data(), tmp.get()));
+            coo_row_ptrs.get_const_data(), tmp->get_device_view()));
     }
     result->make_srow();
 }

--- a/core/matrix/hybrid.cpp
+++ b/core/matrix/hybrid.cpp
@@ -317,7 +317,7 @@ void Hybrid<ValueType, IndexType>::convert_to(
         tmp->set_size(this->get_size());
         exec->run(hybrid::make_convert_to_csr(
             this, ell_row_ptrs.get_const_data(), coo_row_ptrs.get_const_data(),
-            tmp.get()));
+            tmp->get_device_view()));
     }
     result->make_srow();
 }

--- a/core/matrix/hybrid_kernels.hpp
+++ b/core/matrix/hybrid_kernels.hpp
@@ -37,7 +37,7 @@ namespace kernels {
         std::shared_ptr<const DefaultExecutor> exec,                   \
         matrix::view::hybrid<const ValueType, const IndexType> source, \
         const IndexType* ell_row_ptrs, const IndexType* coo_row_ptrs,  \
-        matrix::Csr<ValueType, IndexType>* result)
+        matrix::view::csr<ValueType, IndexType> result)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                     \

--- a/core/matrix/hybrid_kernels.hpp
+++ b/core/matrix/hybrid_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,7 +37,7 @@ namespace kernels {
                         const matrix::Hybrid<ValueType, IndexType>* source, \
                         const IndexType* ell_row_ptrs,                      \
                         const IndexType* coo_row_ptrs,                      \
-                        matrix::Csr<ValueType, IndexType>* result)
+                        matrix::view::csr<ValueType, IndexType> result)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                     \

--- a/core/matrix/sellp.cpp
+++ b/core/matrix/sellp.cpp
@@ -314,7 +314,7 @@ void Sellp<ValueType, IndexType>::convert_to(
         tmp->values_.resize_and_reset(nnz);
         tmp->set_size(this->get_size());
         exec->run(sellp::make_convert_to_csr(this->get_const_device_view(),
-                                             tmp.get()));
+                                             tmp->get_device_view()));
     }
     result->make_srow();
 }

--- a/core/matrix/sellp_kernels.hpp
+++ b/core/matrix/sellp_kernels.hpp
@@ -56,7 +56,7 @@ namespace kernels {
     void convert_to_csr(                                              \
         std::shared_ptr<const DefaultExecutor> exec,                  \
         matrix::view::sellp<const ValueType, const IndexType> source, \
-        matrix::Csr<ValueType, IndexType>* result)
+        matrix::view::csr<ValueType, IndexType> result)
 
 #define GKO_DECLARE_SELLP_COUNT_NONZEROS_PER_ROW_KERNEL(ValueType, IndexType) \
     void count_nonzeros_per_row(                                              \

--- a/core/multigrid/pgm.cpp
+++ b/core/multigrid/pgm.cpp
@@ -216,7 +216,8 @@ Pgm<ValueType, IndexType>::generate_local(
     for (int i = 0; i < parameters_.max_iterations; i++) {
         // Find the strongest neighbor of each row
         exec->run(pgm::make_find_strongest_neighbor(
-            weight_mtx.get(), diag.get(), agg_, strongest_neighbor));
+            weight_mtx->get_const_device_view(), diag.get(), agg_,
+            strongest_neighbor));
         // Match edges
         exec->run(pgm::make_match_edge(strongest_neighbor, agg_));
         // Get the num_unagg
@@ -236,8 +237,9 @@ Pgm<ValueType, IndexType>::generate_local(
     }
     if (num_unagg != 0) {
         // Assign all left points
-        exec->run(pgm::make_assign_to_exist_agg(weight_mtx.get(), diag.get(),
-                                                agg_, intermediate_agg));
+        exec->run(
+            pgm::make_assign_to_exist_agg(weight_mtx->get_const_device_view(),
+                                          diag.get(), agg_, intermediate_agg));
     }
     IndexType num_agg = 0;
     // Renumber the index

--- a/core/multigrid/pgm_kernels.hpp
+++ b/core/multigrid/pgm_kernels.hpp
@@ -59,14 +59,14 @@ namespace pgm {
 #define GKO_DECLARE_PGM_FIND_STRONGEST_NEIGHBOR(ValueType, IndexType)   \
     void find_strongest_neighbor(                                       \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* weight_mtx,            \
+        matrix::view::csr<const ValueType, const IndexType> weight_mtx, \
         const matrix::Diagonal<ValueType>* diag, array<IndexType>& agg, \
         array<IndexType>& strongest_neighbor)
 
 #define GKO_DECLARE_PGM_ASSIGN_TO_EXIST_AGG(ValueType, IndexType)       \
     void assign_to_exist_agg(                                           \
         std::shared_ptr<const DefaultExecutor> exec,                    \
-        const matrix::Csr<ValueType, IndexType>* weight_mtx,            \
+        matrix::view::csr<const ValueType, const IndexType> weight_mtx, \
         const matrix::Diagonal<ValueType>* diag, array<IndexType>& agg, \
         array<IndexType>& intermediate_agg)
 

--- a/core/multigrid/rs.cpp
+++ b/core/multigrid/rs.cpp
@@ -61,7 +61,8 @@ void Rs<ValueType, IndexType>::generate()
     }
     array<bool> is_m_matrix_array(exec, 1);
     if (!parameters_.skip_m_matrix_check) {
-        exec->run(rs::make_check_m_matrix(rs_op, is_m_matrix_array));
+        exec->run(rs::make_check_m_matrix(rs_op->get_const_device_view(),
+                                          is_m_matrix_array));
         if (!exec->copy_val_to_host(is_m_matrix_array.get_const_data())) {
             GKO_NOT_SUPPORTED(
                 "RS coarsening requires an M-matrix (strictly positive "
@@ -80,8 +81,8 @@ void Rs<ValueType, IndexType>::generate()
     // 0 = undecided, 1 = C, -1 = F,
     // then extract coarse dims
     exec->run(rs::make_compute_soc_and_run_rs(
-        rs_op, parameters_.strength_threshold, is_strong, lambda, cf_marker,
-        coarse_dim));
+        rs_op->get_const_device_view(), parameters_.strength_threshold,
+        is_strong, lambda, cf_marker, coarse_dim));
     const size_type coarse_dim_size = static_cast<size_type>(coarse_dim);
 
     // fill in coarse_rows and fine_to_coarse, build prolongation using
@@ -90,8 +91,8 @@ void Rs<ValueType, IndexType>::generate()
     array<IndexType> fine_to_coarse(exec, fine_dim);
     array<IndexType> prolong_row_ptrs(exec, fine_dim + 1);
     exec->run(rs::make_fill_coarse_and_compute_prolong_row_ptrs(
-        cf_marker, coarse_rows, fine_to_coarse, rs_op, is_strong,
-        prolong_row_ptrs));
+        cf_marker, coarse_rows, fine_to_coarse, rs_op->get_const_device_view(),
+        is_strong, prolong_row_ptrs));
 
     IndexType prolong_nnz =
         exec->copy_val_to_host(prolong_row_ptrs.get_const_data() + fine_dim);
@@ -104,8 +105,8 @@ void Rs<ValueType, IndexType>::generate()
                     prolong_op->get_row_ptrs());
 
     exec->run(rs::make_compute_interpolation(
-        rs_op, is_strong.get_const_data(), cf_marker,
-        fine_to_coarse.get_const_data(), prolong_op.get()));
+        rs_op->get_const_device_view(), is_strong.get_const_data(), cf_marker,
+        fine_to_coarse.get_const_data(), prolong_op->get_device_view()));
 
     // build restriction as R = P^T
     auto restrict_op = share(as<csr_type>(prolong_op->transpose()));

--- a/core/multigrid/rs_kernels.hpp
+++ b/core/multigrid/rs_kernels.hpp
@@ -21,16 +21,17 @@ namespace gko {
 namespace kernels {
 namespace rs {
 
-#define GKO_DECLARE_RS_CHECK_M_MATRIX_KERNEL(ValueType, IndexType)       \
-    void check_m_matrix(std::shared_ptr<const DefaultExecutor> exec,     \
-                        const matrix::Csr<ValueType, IndexType>* matrix, \
-                        array<bool>& is_m_matrix_array)
+#define GKO_DECLARE_RS_CHECK_M_MATRIX_KERNEL(ValueType, IndexType)  \
+    void check_m_matrix(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                \
+        matrix::view::csr<const ValueType, const IndexType> matrix, \
+        array<bool>& is_m_matrix_array)
 
-#define GKO_DECLARE_RS_COMPUTE_SOC_AND_RUN_RS_KERNEL(ValueType, IndexType) \
-    void compute_soc_and_run_rs(                                           \
-        std::shared_ptr<const DefaultExecutor> exec,                       \
-        const matrix::Csr<ValueType, IndexType>* A, double theta,          \
-        array<bool>& is_strong, array<IndexType>& lambda,                  \
+#define GKO_DECLARE_RS_COMPUTE_SOC_AND_RUN_RS_KERNEL(ValueType, IndexType)   \
+    void compute_soc_and_run_rs(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                         \
+        matrix::view::csr<const ValueType, const IndexType> A, double theta, \
+        array<bool>& is_strong, array<IndexType>& lambda,                    \
         array<IndexType>& cf_marker, IndexType& coarse_dim)
 
 #define GKO_DECLARE_RS_FILL_COARSE_AND_COMPUTE_PROLONG_ROW_PTRS_KERNEL(   \
@@ -39,15 +40,16 @@ namespace rs {
         std::shared_ptr<const DefaultExecutor> exec,                      \
         const array<IndexType>& cf_marker, array<IndexType>& coarse_rows, \
         array<IndexType>& fine_to_coarse,                                 \
-        const matrix::Csr<ValueType, IndexType>* A,                       \
+        matrix::view::csr<const ValueType, const IndexType> A,            \
         const array<bool>& is_strong, array<IndexType>& row_ptrs)
 
-#define GKO_DECLARE_RS_COMPUTE_INTERPOLATION_KERNEL(ValueType, IndexType)   \
-    void compute_interpolation(                                             \
-        std::shared_ptr<const DefaultExecutor> exec,                        \
-        const matrix::Csr<ValueType, IndexType>* A, const bool* is_strong,  \
-        const array<IndexType>& cf_marker, const IndexType* fine_to_coarse, \
-        matrix::Csr<ValueType, IndexType>* P)
+#define GKO_DECLARE_RS_COMPUTE_INTERPOLATION_KERNEL(ValueType, IndexType) \
+    void compute_interpolation(                                           \
+        std::shared_ptr<const DefaultExecutor> exec,                      \
+        matrix::view::csr<const ValueType, const IndexType> A,            \
+        const bool* is_strong, const array<IndexType>& cf_marker,         \
+        const IndexType* fine_to_coarse,                                  \
+        matrix::view::csr<ValueType, IndexType> P)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                           \

--- a/core/preconditioner/batch_jacobi.cpp
+++ b/core/preconditioner/batch_jacobi.cpp
@@ -76,9 +76,9 @@ void Jacobi<ValueType, IndexType>::detect_blocks(
     const gko::matrix::Csr<ValueType, IndexType>* first_system)
 {
     this->block_pointers_.resize_and_reset(first_system->get_size()[0] + 1);
-    this->get_executor()->run(
-        jacobi::make_find_blocks(first_system, parameters_.max_block_size,
-                                 num_blocks_, this->block_pointers_));
+    this->get_executor()->run(jacobi::make_find_blocks(
+        first_system->get_const_device_view(), parameters_.max_block_size,
+        num_blocks_, this->block_pointers_));
 }
 
 
@@ -161,7 +161,7 @@ void Jacobi<ValueType, IndexType>::generate_precond(
     // corresponding to different batch entries are obtained by just filling in
     // values based on the common pattern.
     exec->run(jacobi::make_extract_common_blocks_pattern(
-        first_sys_csr.get(), num_blocks_,
+        first_sys_csr->get_const_device_view(), num_blocks_,
         blocks_cumulative_offsets_.get_const_data(),
         block_pointers_.get_const_data(), map_block_to_row_.get_const_data(),
         block_nnz_idxs.get_data()));

--- a/core/preconditioner/batch_jacobi_kernels.hpp
+++ b/core/preconditioner/batch_jacobi_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -37,7 +37,7 @@ namespace kernels {
                                                               IndexType)       \
     void extract_common_blocks_pattern(                                        \
         std::shared_ptr<const DefaultExecutor> exec,                           \
-        const matrix::Csr<ValueType, IndexType>* first_sys_csr,                \
+        matrix::view::csr<const ValueType, const IndexType> first_sys_csr,     \
         const size_type num_blocks, const IndexType* cumulative_block_storage, \
         const IndexType* block_pointers, const IndexType* map_block_to_row,    \
         IndexType* blocks_pattern)

--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -144,7 +144,7 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
         // Extract lower triangular part: compute non-zeros
         array<IndexType> inverted_row_ptrs{exec, num_rows + 1};
         exec->run(isai::make_initialize_row_ptrs_l(
-            to_invert.get(), inverted_row_ptrs.get_data()));
+            to_invert->get_const_device_view(), inverted_row_ptrs.get_data()));
 
         // Get nnz from device memory
         auto inverted_nnz =
@@ -158,7 +158,8 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             std::move(inverted_col_idxs), std::move(inverted_row_ptrs)));
 
         // Extract lower factor: columns and values
-        exec->run(isai::make_initialize_l(to_invert.get(), inverted_base.get(),
+        exec->run(isai::make_initialize_l(to_invert->get_const_device_view(),
+                                          inverted_base->get_device_view(),
                                           false));
 
         inverted = power == 1
@@ -175,12 +176,14 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
 
     if (is_general || is_spd) {
         exec->run(isai::make_generate_general_inverse(
-            to_invert.get(), inverted.get(), excess_block_ptrs.get_data(),
-            excess_row_ptrs_full.get_data(), is_spd));
+            to_invert->get_const_device_view(), inverted->get_device_view(),
+            excess_block_ptrs.get_data(), excess_row_ptrs_full.get_data(),
+            is_spd));
     } else {
         exec->run(isai::make_generate_tri_inverse(
-            to_invert.get(), inverted.get(), excess_block_ptrs.get_data(),
-            excess_row_ptrs_full.get_data(), is_lower));
+            to_invert->get_const_device_view(), inverted->get_device_view(),
+            excess_block_ptrs.get_data(), excess_row_ptrs_full.get_data(),
+            is_lower));
     }
 
     auto host_excess_block_ptrs_array =
@@ -217,10 +220,12 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             auto excess_rhs = Dense::create(exec, dim<2>(excess_dim, 1));
             auto excess_solution = Dense::create(exec, dim<2>(excess_dim, 1));
             exec->run(isai::make_generate_excess_system(
-                to_invert.get(), inverted.get(),
+                to_invert->get_const_device_view(),
+                inverted->get_const_device_view(),
                 excess_block_ptrs.get_const_data(),
-                excess_row_ptrs_full.get_const_data(), excess_system.get(),
-                excess_rhs->get_device_view(), excess_start, block));
+                excess_row_ptrs_full.get_const_data(),
+                excess_system->get_device_view(), excess_rhs->get_device_view(),
+                excess_start, block));
             // solve it after transposing
             auto system_copy = gko::clone(exec->get_master(), excess_system);
             auto rhs_copy = gko::clone(exec->get_master(), excess_rhs);
@@ -258,8 +263,8 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             // and copy the results back to the original ISAI
             exec->run(isai::make_scatter_excess_solution(
                 excess_block_ptrs.get_const_data(),
-                excess_solution->get_const_device_view(), inverted.get(),
-                excess_start, block));
+                excess_solution->get_const_device_view(),
+                inverted->get_device_view(), excess_start, block));
         }
     }
 

--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -143,7 +143,7 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
         // Extract lower triangular part: compute non-zeros
         array<IndexType> inverted_row_ptrs{exec, num_rows + 1};
         exec->run(isai::make_initialize_row_ptrs_l(
-            to_invert.get(), inverted_row_ptrs.get_data()));
+            to_invert->get_const_device_view(), inverted_row_ptrs.get_data()));
 
         // Get nnz from device memory
         auto inverted_nnz =
@@ -157,7 +157,8 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             std::move(inverted_col_idxs), std::move(inverted_row_ptrs)));
 
         // Extract lower factor: columns and values
-        exec->run(isai::make_initialize_l(to_invert.get(), inverted_base.get(),
+        exec->run(isai::make_initialize_l(to_invert->get_const_device_view(),
+                                          inverted_base->get_device_view(),
                                           false));
 
         inverted = power == 1
@@ -174,12 +175,14 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
 
     if (is_general || is_spd) {
         exec->run(isai::make_generate_general_inverse(
-            to_invert.get(), inverted.get(), excess_block_ptrs.get_data(),
-            excess_row_ptrs_full.get_data(), is_spd));
+            to_invert->get_const_device_view(), inverted->get_device_view(),
+            excess_block_ptrs.get_data(), excess_row_ptrs_full.get_data(),
+            is_spd));
     } else {
         exec->run(isai::make_generate_tri_inverse(
-            to_invert.get(), inverted.get(), excess_block_ptrs.get_data(),
-            excess_row_ptrs_full.get_data(), is_lower));
+            to_invert->get_const_device_view(), inverted->get_device_view(),
+            excess_block_ptrs.get_data(), excess_row_ptrs_full.get_data(),
+            is_lower));
     }
 
     auto host_excess_block_ptrs_array =
@@ -216,10 +219,12 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             auto excess_rhs = Dense::create(exec, dim<2>(excess_dim, 1));
             auto excess_solution = Dense::create(exec, dim<2>(excess_dim, 1));
             exec->run(isai::make_generate_excess_system(
-                to_invert.get(), inverted.get(),
+                to_invert->get_const_device_view(),
+                inverted->get_const_device_view(),
                 excess_block_ptrs.get_const_data(),
-                excess_row_ptrs_full.get_const_data(), excess_system.get(),
-                excess_rhs->get_device_view(), excess_start, block));
+                excess_row_ptrs_full.get_const_data(),
+                excess_system->get_device_view(), excess_rhs->get_device_view(),
+                excess_start, block));
             // solve it after transposing
             auto system_copy = gko::clone(exec->get_master(), excess_system);
             auto rhs_copy = gko::clone(exec->get_master(), excess_rhs);
@@ -257,8 +262,8 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             // and copy the results back to the original ISAI
             exec->run(isai::make_scatter_excess_solution(
                 excess_block_ptrs.get_const_data(),
-                excess_solution->get_const_device_view(), inverted.get(),
-                excess_start, block));
+                excess_solution->get_const_device_view(),
+                inverted->get_device_view(), excess_start, block));
         }
     }
 

--- a/core/preconditioner/isai_kernels.hpp
+++ b/core/preconditioner/isai_kernels.hpp
@@ -16,27 +16,27 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_ISAI_GENERATE_TRI_INVERSE_KERNEL(ValueType, IndexType)    \
-    void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,    \
-                              const matrix::Csr<ValueType, IndexType>* input, \
-                              matrix::Csr<ValueType, IndexType>* inverse,     \
-                              IndexType* excess_rhs_ptrs,                     \
-                              IndexType* excess_nz_ptrs, bool lower)
+#define GKO_DECLARE_ISAI_GENERATE_TRI_INVERSE_KERNEL(ValueType, IndexType) \
+    void generate_tri_inverse(                                             \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> input,         \
+        matrix::view::csr<ValueType, IndexType> inverse,                   \
+        IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs, bool lower)
 
 #define GKO_DECLARE_ISAI_GENERATE_GENERAL_INVERSE_KERNEL(ValueType, IndexType) \
     void generate_general_inverse(                                             \
         std::shared_ptr<const DefaultExecutor> exec,                           \
-        const matrix::Csr<ValueType, IndexType>* input,                        \
-        matrix::Csr<ValueType, IndexType>* inverse,                            \
+        matrix::view::csr<const ValueType, const IndexType> input,             \
+        matrix::view::csr<ValueType, IndexType> inverse,                       \
         IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs, bool spd)
 
 #define GKO_DECLARE_ISAI_GENERATE_EXCESS_SYSTEM_KERNEL(ValueType, IndexType) \
     void generate_excess_system(                                             \
         std::shared_ptr<const DefaultExecutor> exec,                         \
-        const matrix::Csr<ValueType, IndexType>* input,                      \
-        const matrix::Csr<ValueType, IndexType>* inverse,                    \
+        matrix::view::csr<const ValueType, const IndexType> input,           \
+        matrix::view::csr<const ValueType, const IndexType> inverse,         \
         const IndexType* excess_rhs_ptrs, const IndexType* excess_nz_ptrs,   \
-        matrix::Csr<ValueType, IndexType>* excess_system,                    \
+        matrix::view::csr<ValueType, IndexType> excess_system,               \
         matrix::view::dense<ValueType> excess_rhs, size_type e_start,        \
         size_type e_end)
 
@@ -51,7 +51,7 @@ namespace kernels {
         std::shared_ptr<const DefaultExecutor> exec,                          \
         const IndexType* excess_rhs_ptrs,                                     \
         matrix::view::dense<const ValueType> excess_solution,                 \
-        matrix::Csr<ValueType, IndexType>* inverse, size_type e_start,        \
+        matrix::view::csr<ValueType, IndexType> inverse, size_type e_start,   \
         size_type e_end)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                        \

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -326,9 +326,9 @@ void Jacobi<ValueType, IndexType>::detect_blocks(
 {
     parameters_.block_pointers.resize_and_reset(system_matrix->get_size()[0] +
                                                 1);
-    this->get_executor()->run(
-        jacobi::make_find_blocks(system_matrix, parameters_.max_block_size,
-                                 num_blocks_, parameters_.block_pointers));
+    this->get_executor()->run(jacobi::make_find_blocks(
+        system_matrix->get_const_device_view(), parameters_.max_block_size,
+        num_blocks_, parameters_.block_pointers));
     blocks_.resize_and_reset(
         storage_scheme_.compute_storage_space(num_blocks_));
 }
@@ -347,7 +347,8 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             auto csr_mtx = convert_to_with_sorting<const csr_type>(
                 exec, system_matrix, skip_sorting);
             auto diagonal = share(csr_mtx->extract_diagonal());
-            exec->run(jacobi::make_scalar_l1(csr_mtx.get(), diagonal.get()));
+            exec->run(jacobi::make_scalar_l1(csr_mtx->get_const_device_view(),
+                                             diagonal.get()));
             diag = diagonal;
         } else {
             diag = share(as<DiagonalLinOpExtractable>(system_matrix)
@@ -386,8 +387,9 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             exec->run(jacobi::make_add_diagonal_elements(
                 matrix::make_builder_unique_ptr(changed_mtx).get(), true));
             // block_pointers has larger size than actual num_blocks_
-            exec->run(jacobi::make_block_l1(
-                num_blocks_, parameters_.block_pointers, changed_mtx.get()));
+            exec->run(jacobi::make_block_l1(num_blocks_,
+                                            parameters_.block_pointers,
+                                            changed_mtx->get_device_view()));
             csr_mtx = changed_mtx;
         }
         const auto all_block_opt =
@@ -408,9 +410,9 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             conditioning_.resize_and_reset(num_blocks_);
         }
         exec->run(jacobi::make_generate(
-            csr_mtx.get(), num_blocks_, parameters_.max_block_size,
-            parameters_.accuracy, storage_scheme_, conditioning_, precisions,
-            parameters_.block_pointers, blocks_));
+            csr_mtx->get_const_device_view(), num_blocks_,
+            parameters_.max_block_size, parameters_.accuracy, storage_scheme_,
+            conditioning_, precisions, parameters_.block_pointers, blocks_));
     }
 }
 

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -326,9 +326,9 @@ void Jacobi<ValueType, IndexType>::detect_blocks(
 {
     parameters_.block_pointers.resize_and_reset(system_matrix->get_size()[0] +
                                                 1);
-    this->get_executor()->run(
-        jacobi::make_find_blocks(system_matrix, parameters_.max_block_size,
-                                 num_blocks_, parameters_.block_pointers));
+    this->get_executor()->run(jacobi::make_find_blocks(
+        system_matrix->get_const_device_view(), parameters_.max_block_size,
+        num_blocks_, parameters_.block_pointers));
     blocks_.resize_and_reset(
         storage_scheme_.compute_storage_space(num_blocks_));
 }
@@ -347,7 +347,8 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             auto csr_mtx = convert_to_with_sorting<const csr_type>(
                 exec, system_matrix, skip_sorting);
             auto diagonal = share(csr_mtx->extract_diagonal());
-            exec->run(jacobi::make_scalar_l1(csr_mtx.get(), diagonal.get()));
+            exec->run(jacobi::make_scalar_l1(csr_mtx->get_const_device_view(),
+                                             diagonal.get()));
             diag = diagonal;
         } else {
             diag = share(as<DiagonalLinOpExtractable>(system_matrix)
@@ -384,8 +385,9 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             exec->run(
                 jacobi::make_add_diagonal_elements(changed_mtx.get(), true));
             // block_pointers has larger size than actual num_blocks_
-            exec->run(jacobi::make_block_l1(
-                num_blocks_, parameters_.block_pointers, changed_mtx.get()));
+            exec->run(jacobi::make_block_l1(num_blocks_,
+                                            parameters_.block_pointers,
+                                            changed_mtx->get_device_view()));
             csr_mtx = changed_mtx;
         }
         const auto all_block_opt =
@@ -406,9 +408,9 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             conditioning_.resize_and_reset(num_blocks_);
         }
         exec->run(jacobi::make_generate(
-            csr_mtx.get(), num_blocks_, parameters_.max_block_size,
-            parameters_.accuracy, storage_scheme_, conditioning_, precisions,
-            parameters_.block_pointers, blocks_));
+            csr_mtx->get_const_device_view(), num_blocks_,
+            parameters_.max_block_size, parameters_.accuracy, storage_scheme_,
+            conditioning_, precisions, parameters_.block_pointers, blocks_));
     }
 }
 

--- a/core/preconditioner/jacobi_kernels.hpp
+++ b/core/preconditioner/jacobi_kernels.hpp
@@ -16,16 +16,17 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_JACOBI_FIND_BLOCKS_KERNEL(ValueType, IndexType)          \
-    void find_blocks(std::shared_ptr<const DefaultExecutor> exec,            \
-                     const matrix::Csr<ValueType, IndexType>* system_matrix, \
-                     uint32 max_block_size, size_type& num_blocks,           \
-                     array<IndexType>& block_pointers)
+#define GKO_DECLARE_JACOBI_FIND_BLOCKS_KERNEL(ValueType, IndexType)        \
+    void find_blocks(                                                      \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
+        uint32 max_block_size, size_type& num_blocks,                      \
+        array<IndexType>& block_pointers)
 
 #define GKO_DECLARE_JACOBI_GENERATE_KERNEL(ValueType, IndexType)           \
     void generate(                                                         \
         std::shared_ptr<const DefaultExecutor> exec,                       \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,            \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
         size_type num_blocks, uint32 max_block_size,                       \
         remove_complex<ValueType> accuracy,                                \
         const preconditioner::block_interleaved_storage_scheme<IndexType>& \
@@ -126,16 +127,16 @@ namespace kernels {
                                const array<precision_reduction>& source,    \
                                array<precision_reduction>& precisions)
 
-#define GKO_DECLARE_JACOBI_SCALAR_L1_KERNEL(ValueType, IndexType) \
-    void scalar_l1(std::shared_ptr<const DefaultExecutor> exec,   \
-                   const matrix::Csr<ValueType, IndexType>* csr,  \
+#define GKO_DECLARE_JACOBI_SCALAR_L1_KERNEL(ValueType, IndexType)           \
+    void scalar_l1(std::shared_ptr<const DefaultExecutor> exec,             \
+                   matrix::view::csr<const ValueType, const IndexType> csr, \
                    matrix::Diagonal<ValueType>* diag)
 
 #define GKO_DECLARE_JACOBI_BLOCK_L1_KERNEL(ValueType, IndexType) \
     void block_l1(std::shared_ptr<const DefaultExecutor> exec,   \
                   size_type num_blocks,                          \
                   const array<IndexType>& block_pointers,        \
-                  matrix::Csr<ValueType, IndexType>* csr)
+                  matrix::view::csr<ValueType, IndexType> csr)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                  \
     template <typename ValueType, typename IndexType>                 \

--- a/core/preconditioner/sor.cpp
+++ b/core/preconditioner/sor.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -105,7 +105,8 @@ std::unique_ptr<LinOp> Sor<ValueType, IndexType>::generate_impl(
         array<index_type> l_row_ptrs{exec, size[0] + 1};
         array<index_type> u_row_ptrs{exec, size[0] + 1};
         exec->run(make_initialize_row_ptrs_l_u(
-            csr_matrix.get(), l_row_ptrs.get_data(), u_row_ptrs.get_data()));
+            csr_matrix->get_const_device_view(), l_row_ptrs.get_data(),
+            u_row_ptrs.get_data()));
         const auto l_nnz =
             static_cast<size_type>(get_element(l_row_ptrs, size[0]));
         const auto u_nnz =
@@ -121,9 +122,9 @@ std::unique_ptr<LinOp> Sor<ValueType, IndexType>::generate_impl(
 
         // fill l_mtx with 1/w (D + wL)
         // fill u_mtx with 1/(1-w) (D + wU)
-        exec->run(make_initialize_weighted_l_u(csr_matrix.get(),
-                                               parameters_.relaxation_factor,
-                                               l_mtx.get(), u_mtx.get()));
+        exec->run(make_initialize_weighted_l_u(
+            csr_matrix->get_const_device_view(), parameters_.relaxation_factor,
+            l_mtx->get_device_view(), u_mtx->get_device_view()));
 
         // scale u_mtx with D^-1
         auto diag = csr_matrix->extract_diagonal();
@@ -138,8 +139,8 @@ std::unique_ptr<LinOp> Sor<ValueType, IndexType>::generate_impl(
         return composition_type::create(std::move(u_trs), std::move(l_trs));
     } else {
         array<index_type> l_row_ptrs{exec, size[0] + 1};
-        exec->run(make_initialize_row_ptrs_l(csr_matrix.get(),
-                                             l_row_ptrs.get_data()));
+        exec->run(make_initialize_row_ptrs_l(
+            csr_matrix->get_const_device_view(), l_row_ptrs.get_data()));
         const auto l_nnz =
             static_cast<size_type>(get_element(l_row_ptrs, size[0]));
 
@@ -150,7 +151,8 @@ std::unique_ptr<LinOp> Sor<ValueType, IndexType>::generate_impl(
 
         // fill l_mtx with 1/w * (D + wL)
         exec->run(make_initialize_weighted_l(
-            csr_matrix.get(), parameters_.relaxation_factor, l_mtx.get()));
+            csr_matrix->get_const_device_view(), parameters_.relaxation_factor,
+            l_mtx->get_device_view()));
 
         // invert the triangular matrices with triangular solvers
         auto l_trs = l_trs_factory->generate(std::move(l_mtx));

--- a/core/preconditioner/sor_kernels.hpp
+++ b/core/preconditioner/sor_kernels.hpp
@@ -16,21 +16,21 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_SOR_INITIALIZE_WEIGHTED_L(ValueType, IndexType) \
-    void initialize_weighted_l(                                     \
-        std::shared_ptr<const DefaultExecutor> exec,                \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,     \
-        remove_complex<ValueType> weight,                           \
-        matrix::Csr<ValueType, IndexType>* l_factor)
+#define GKO_DECLARE_SOR_INITIALIZE_WEIGHTED_L(ValueType, IndexType)        \
+    void initialize_weighted_l(                                            \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
+        remove_complex<ValueType> weight,                                  \
+        matrix::view::csr<ValueType, IndexType> l_factor)
 
 
-#define GKO_DECLARE_SOR_INITIALIZE_WEIGHTED_L_U(ValueType, IndexType) \
-    void initialize_weighted_l_u(                                     \
-        std::shared_ptr<const DefaultExecutor> exec,                  \
-        const matrix::Csr<ValueType, IndexType>* system_matrix,       \
-        remove_complex<ValueType> weight,                             \
-        matrix::Csr<ValueType, IndexType>* l_factor,                  \
-        matrix::Csr<ValueType, IndexType>* u_factor)
+#define GKO_DECLARE_SOR_INITIALIZE_WEIGHTED_L_U(ValueType, IndexType)      \
+    void initialize_weighted_l_u(                                          \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        matrix::view::csr<const ValueType, const IndexType> system_matrix, \
+        remove_complex<ValueType> weight,                                  \
+        matrix::view::csr<ValueType, IndexType> l_factor,                  \
+        matrix::view::csr<ValueType, IndexType> u_factor)
 
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                             \

--- a/core/reorder/mc64.cpp
+++ b/core/reorder/mc64.cpp
@@ -31,17 +31,18 @@ namespace mc64 {
 
 
 template <typename ValueType, typename IndexType>
-void initialize_weights(const matrix::Csr<ValueType, IndexType>* host_mtx,
-                        array<remove_complex<ValueType>>& weights_array,
-                        array<remove_complex<ValueType>>& dual_u_array,
-                        array<remove_complex<ValueType>>& row_maxima_array,
-                        gko::experimental::reorder::mc64_strategy strategy)
+void initialize_weights(
+    matrix::view::csr<const ValueType, const IndexType> host_mtx,
+    array<remove_complex<ValueType>>& weights_array,
+    array<remove_complex<ValueType>>& dual_u_array,
+    array<remove_complex<ValueType>>& row_maxima_array,
+    gko::experimental::reorder::mc64_strategy strategy)
 {
     const auto inf = std::numeric_limits<remove_complex<ValueType>>::infinity();
-    const auto num_rows = host_mtx->get_size()[0];
-    const auto row_ptrs = host_mtx->get_const_row_ptrs();
-    const auto col_idxs = host_mtx->get_const_col_idxs();
-    const auto values = host_mtx->get_const_values();
+    const auto num_rows = host_mtx.size[0];
+    const auto row_ptrs = host_mtx.row_ptrs;
+    const auto col_idxs = host_mtx.col_idxs;
+    const auto values = host_mtx.values;
     auto weights = weights_array.get_data();
     auto dual_u = dual_u_array.get_data();
     auto row_maxima = row_maxima_array.get_data();
@@ -425,17 +426,17 @@ void augment_matching(const matrix::Csr<ValueType, IndexType>* host_mtx,
 
 
 template <typename ValueType, typename IndexType>
-void compute_scaling(const matrix::Csr<ValueType, IndexType>* host_mtx,
-                     const array<remove_complex<ValueType>>& weights_array,
-                     const array<remove_complex<ValueType>>& dual_u_array,
-                     const array<remove_complex<ValueType>>& row_maxima_array,
-                     const array<IndexType>& permutation,
-                     const array<IndexType>& matched_idxs_array,
-                     mc64_strategy strategy, ValueType* row_scaling,
-                     ValueType* col_scaling)
+void compute_scaling(
+    matrix::view::csr<const ValueType, const IndexType> host_mtx,
+    const array<remove_complex<ValueType>>& weights_array,
+    const array<remove_complex<ValueType>>& dual_u_array,
+    const array<remove_complex<ValueType>>& row_maxima_array,
+    const array<IndexType>& permutation,
+    const array<IndexType>& matched_idxs_array, mc64_strategy strategy,
+    ValueType* row_scaling, ValueType* col_scaling)
 {
     const auto inf = std::numeric_limits<remove_complex<ValueType>>::infinity();
-    const auto num_rows = host_mtx->get_size()[0];
+    const auto num_rows = host_mtx.size[0];
     const auto weights = weights_array.get_const_data();
     const auto dual_u = dual_u_array.get_const_data();
     const auto row_maxima = row_maxima_array.get_const_data();
@@ -550,8 +551,9 @@ std::unique_ptr<LinOp> Mc64<ValueType, IndexType>::generate_impl(
     const auto col_idxs = mtx->get_const_col_idxs();
 
     if (num_rows > 0) {
-        exec->run(make_initialize_weights(mtx.get(), weights, dual_u,
-                                          row_maxima, parameters_.strategy));
+        exec->run(make_initialize_weights(mtx->get_const_device_view(), weights,
+                                          dual_u, row_maxima,
+                                          parameters_.strategy));
 
         // Compute an initial maximum matching from the nonzero entries for
         // which the reduced weight (W(i, j) - u(j) - v(i)) is zero. Here, W is
@@ -568,9 +570,9 @@ std::unique_ptr<LinOp> Mc64<ValueType, IndexType>::generate_impl(
             this->get_parameters().tolerance));
 
         exec->run(make_compute_scaling(
-            mtx.get(), weights, dual_u, row_maxima, permutation, matched_idxs,
-            parameters_.strategy, row_scaling.get_data(),
-            col_scaling.get_data()));
+            mtx->get_const_device_view(), weights, dual_u, row_maxima,
+            permutation, matched_idxs, parameters_.strategy,
+            row_scaling.get_data(), col_scaling.get_data()));
     }
 
     array<index_type> identity_permutation{exec, num_rows};

--- a/core/reorder/mc64.hpp
+++ b/core/reorder/mc64.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,7 +21,7 @@ namespace mc64 {
 
 #define GKO_DECLARE_MC64_INITIALIZE_WEIGHTS(ValueType, IndexType) \
     void initialize_weights(                                      \
-        const matrix::Csr<ValueType, IndexType>* mtx,             \
+        matrix::view::csr<const ValueType, const IndexType> mtx,  \
         array<remove_complex<ValueType>>& weights_array,          \
         array<remove_complex<ValueType>>& dual_u_array,           \
         array<remove_complex<ValueType>>& row_maxima_array,       \
@@ -51,7 +51,7 @@ namespace mc64 {
 
 #define GKO_DECLARE_MC64_COMPUTE_SCALING(ValueType, IndexType)              \
     void compute_scaling(                                                   \
-        const matrix::Csr<ValueType, IndexType>* mtx,                       \
+        matrix::view::csr<const ValueType, const IndexType> mtx,            \
         const array<remove_complex<ValueType>>& weights_array,              \
         const array<remove_complex<ValueType>>& dual_u_array,               \
         const array<remove_complex<ValueType>>& row_maxima_array,           \

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -125,9 +125,9 @@ void LowerTrs<ValueType, IndexType>::generate()
 {
     if (this->get_system_matrix()) {
         this->get_executor()->run(lower_trs::make_generate(
-            this->get_system_matrix().get(), this->solve_struct_,
-            this->get_parameters().unit_diagonal, parameters_.algorithm,
-            parameters_.num_rhs));
+            this->get_system_matrix()->get_const_device_view(),
+            this->solve_struct_, this->get_parameters().unit_diagonal,
+            parameters_.algorithm, parameters_.num_rhs));
     }
 }
 
@@ -169,8 +169,9 @@ void LowerTrs<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
                     ws::transposed_x, gko::transpose(dense_x->get_size()));
             }
             exec->run(lower_trs::make_solve(
-                this->get_system_matrix().get(), this->solve_struct_.get(),
-                this->get_parameters().unit_diagonal, parameters_.algorithm,
+                this->get_system_matrix()->get_const_device_view(),
+                this->solve_struct_.get(), this->get_parameters().unit_diagonal,
+                parameters_.algorithm,
                 trans_b ? optional_view{trans_b->get_device_view()}
                         : optional_view{},
                 trans_x ? optional_view{trans_x->get_device_view()}

--- a/core/solver/lower_trs_kernels.hpp
+++ b/core/solver/lower_trs_kernels.hpp
@@ -29,20 +29,20 @@ namespace lower_trs {
 
 #define GKO_DECLARE_LOWER_TRS_GENERATE_KERNEL(ValueType, IndexType)           \
     void generate(std::shared_ptr<const DefaultExecutor> exec,                \
-                  const matrix::Csr<ValueType, IndexType>* matrix,            \
+                  matrix::view::csr<const ValueType, const IndexType> matrix, \
                   std::shared_ptr<solver::SolveStruct>& solve_struct,         \
                   bool unit_diag, const solver::trisolve_algorithm algorithm, \
                   const size_type num_rhs)
 
 
-#define GKO_DECLARE_LOWER_TRS_SOLVE_KERNEL(ValueType, IndexType)        \
-    void solve(std::shared_ptr<const DefaultExecutor> exec,             \
-               const matrix::Csr<ValueType, IndexType>* matrix,         \
-               const solver::SolveStruct* solve_struct, bool unit_diag, \
-               const solver::trisolve_algorithm algorithm,              \
-               std::optional<matrix::view::dense<ValueType>> trans_b,   \
-               std::optional<matrix::view::dense<ValueType>> trans_x,   \
-               matrix::view::dense<const ValueType> b,                  \
+#define GKO_DECLARE_LOWER_TRS_SOLVE_KERNEL(ValueType, IndexType)           \
+    void solve(std::shared_ptr<const DefaultExecutor> exec,                \
+               matrix::view::csr<const ValueType, const IndexType> matrix, \
+               const solver::SolveStruct* solve_struct, bool unit_diag,    \
+               const solver::trisolve_algorithm algorithm,                 \
+               std::optional<matrix::view::dense<ValueType>> trans_b,      \
+               std::optional<matrix::view::dense<ValueType>> trans_x,      \
+               matrix::view::dense<const ValueType> b,                     \
                matrix::view::dense<ValueType> x)
 
 

--- a/core/solver/upper_trs.cpp
+++ b/core/solver/upper_trs.cpp
@@ -126,9 +126,9 @@ void UpperTrs<ValueType, IndexType>::generate()
 {
     if (this->get_system_matrix()) {
         this->get_executor()->run(upper_trs::make_generate(
-            this->get_system_matrix().get(), this->solve_struct_,
-            this->get_parameters().unit_diagonal, parameters_.algorithm,
-            parameters_.num_rhs));
+            this->get_system_matrix()->get_const_device_view(),
+            this->solve_struct_, this->get_parameters().unit_diagonal,
+            parameters_.algorithm, parameters_.num_rhs));
     }
 }
 
@@ -170,8 +170,9 @@ void UpperTrs<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
                     ws::transposed_x, gko::transpose(dense_x->get_size()));
             }
             exec->run(upper_trs::make_solve(
-                this->get_system_matrix().get(), this->solve_struct_.get(),
-                this->get_parameters().unit_diagonal, parameters_.algorithm,
+                this->get_system_matrix()->get_const_device_view(),
+                this->solve_struct_.get(), this->get_parameters().unit_diagonal,
+                parameters_.algorithm,
                 trans_b ? optional_view{trans_b->get_device_view()}
                         : optional_view{},
                 trans_x ? optional_view{trans_x->get_device_view()}

--- a/core/solver/upper_trs_kernels.hpp
+++ b/core/solver/upper_trs_kernels.hpp
@@ -29,20 +29,20 @@ namespace upper_trs {
 
 #define GKO_DECLARE_UPPER_TRS_GENERATE_KERNEL(ValueType, IndexType)           \
     void generate(std::shared_ptr<const DefaultExecutor> exec,                \
-                  const matrix::Csr<ValueType, IndexType>* matrix,            \
+                  matrix::view::csr<const ValueType, const IndexType> matrix, \
                   std::shared_ptr<solver::SolveStruct>& solve_struct,         \
                   bool unit_diag, const solver::trisolve_algorithm algorithm, \
                   const size_type num_rhs)
 
 
-#define GKO_DECLARE_UPPER_TRS_SOLVE_KERNEL(ValueType, IndexType)        \
-    void solve(std::shared_ptr<const DefaultExecutor> exec,             \
-               const matrix::Csr<ValueType, IndexType>* matrix,         \
-               const solver::SolveStruct* solve_struct, bool unit_diag, \
-               const solver::trisolve_algorithm algorithm,              \
-               std::optional<matrix::view::dense<ValueType>> trans_b,   \
-               std::optional<matrix::view::dense<ValueType>> trans_x,   \
-               matrix::view::dense<const ValueType> b,                  \
+#define GKO_DECLARE_UPPER_TRS_SOLVE_KERNEL(ValueType, IndexType)           \
+    void solve(std::shared_ptr<const DefaultExecutor> exec,                \
+               matrix::view::csr<const ValueType, const IndexType> matrix, \
+               const solver::SolveStruct* solve_struct, bool unit_diag,    \
+               const solver::trisolve_algorithm algorithm,                 \
+               std::optional<matrix::view::dense<ValueType>> trans_b,      \
+               std::optional<matrix::view::dense<ValueType>> trans_x,      \
+               matrix::view::dense<const ValueType> b,                     \
                matrix::view::dense<ValueType> x)
 
 

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -115,6 +115,30 @@ TYPED_TEST(Csr, CanBeEmpty)
 }
 
 
+TYPED_TEST(Csr, CanCreateDeviceView)
+{
+    auto view = this->mtx->get_device_view();
+
+    EXPECT_EQ(view.size, this->mtx->get_size());
+    EXPECT_EQ(view.num_stored_elements, this->mtx->get_num_stored_elements());
+    EXPECT_EQ(view.values, this->mtx->get_values());
+    EXPECT_EQ(view.row_ptrs, this->mtx->get_row_ptrs());
+    EXPECT_EQ(view.col_idxs, this->mtx->get_col_idxs());
+}
+
+
+TYPED_TEST(Csr, CanCreateConstDeviceView)
+{
+    auto view = this->mtx->get_const_device_view();
+
+    EXPECT_EQ(view.size, this->mtx->get_size());
+    EXPECT_EQ(view.num_stored_elements, this->mtx->get_num_stored_elements());
+    EXPECT_EQ(view.values, this->mtx->get_values());
+    EXPECT_EQ(view.row_ptrs, this->mtx->get_row_ptrs());
+    EXPECT_EQ(view.col_idxs, this->mtx->get_col_idxs());
+}
+
+
 TYPED_TEST(Csr, CanBeCreatedFromExistingData)
 {
     using Mtx = typename TestFixture::Mtx;

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -105,6 +105,30 @@ TYPED_TEST(Csr, CanBeEmpty)
     auto mtx = Mtx::create(this->exec);
 
     this->assert_empty(mtx.get());
+}
+
+
+TYPED_TEST(Csr, CanCreateDeviceView)
+{
+    auto view = this->mtx->get_device_view();
+
+    EXPECT_EQ(view.size, this->mtx->get_size());
+    EXPECT_EQ(view.num_stored_elements, this->mtx->get_num_stored_elements());
+    EXPECT_EQ(view.values, this->mtx->get_values());
+    EXPECT_EQ(view.row_ptrs, this->mtx->get_row_ptrs());
+    EXPECT_EQ(view.col_idxs, this->mtx->get_col_idxs());
+}
+
+
+TYPED_TEST(Csr, CanCreateConstDeviceView)
+{
+    auto view = this->mtx->get_const_device_view();
+
+    EXPECT_EQ(view.size, this->mtx->get_size());
+    EXPECT_EQ(view.num_stored_elements, this->mtx->get_num_stored_elements());
+    EXPECT_EQ(view.values, this->mtx->get_values());
+    EXPECT_EQ(view.row_ptrs, this->mtx->get_row_ptrs());
+    EXPECT_EQ(view.col_idxs, this->mtx->get_col_idxs());
 }
 
 

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -119,10 +119,8 @@ TYPED_TEST(CsrView, AccessWorks)
     std::vector<value_type> values{1, 2, 3};
     std::vector<index_type> row_ptrs{0, 1, 2};
     std::vector<index_type> col_idxs{1, 0, 2};
-    std::vector<index_type> srow{0, 2};
     gko::matrix::view::csr<value_type, index_type> view{
-        gko::dim<2>{3, 3}, 3, values.data(), row_ptrs.data(),
-        col_idxs.data(),   2, srow.data()};
+        gko::dim<2>{3, 3}, 3, values.data(), row_ptrs.data(), col_idxs.data()};
     auto const_view = view.as_const();
 
     ASSERT_EQ(view.size, gko::dim<2>(3, 3));
@@ -135,8 +133,6 @@ TYPED_TEST(CsrView, AccessWorks)
     ASSERT_EQ(const_view.values, view.values);
     ASSERT_EQ(const_view.row_ptrs, view.row_ptrs);
     ASSERT_EQ(const_view.col_idxs, view.col_idxs);
-    ASSERT_EQ(view.num_srow_elements, 2);
-    ASSERT_EQ(view.srow, srow.data());
 }
 
 

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -119,8 +119,10 @@ TYPED_TEST(CsrView, AccessWorks)
     std::vector<value_type> values{1, 2, 3};
     std::vector<index_type> row_ptrs{0, 1, 2};
     std::vector<index_type> col_idxs{1, 0, 2};
+    std::vector<index_type> srow{0, 2};
     gko::matrix::view::csr<value_type, index_type> view{
-        gko::dim<2>{3, 3}, 3, values.data(), row_ptrs.data(), col_idxs.data()};
+        gko::dim<2>{3, 3}, 3, values.data(), row_ptrs.data(),
+        col_idxs.data(),   2, srow.data()};
     auto const_view = view.as_const();
 
     ASSERT_EQ(view.size, gko::dim<2>(3, 3));
@@ -133,6 +135,8 @@ TYPED_TEST(CsrView, AccessWorks)
     ASSERT_EQ(const_view.values, view.values);
     ASSERT_EQ(const_view.row_ptrs, view.row_ptrs);
     ASSERT_EQ(const_view.col_idxs, view.col_idxs);
+    ASSERT_EQ(view.num_srow_elements, 2);
+    ASSERT_EQ(view.srow, srow.data());
 }
 
 

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -100,6 +100,43 @@ TYPED_TEST(CooView, AccessWorks)
 
 
 template <typename ValueIndexType>
+class CsrView : public ::testing::Test {
+protected:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+};
+
+TYPED_TEST_SUITE(CsrView, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
+
+
+TYPED_TEST(CsrView, AccessWorks)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    std::vector<value_type> values{1, 2, 3};
+    std::vector<index_type> row_ptrs{0, 1, 2};
+    std::vector<index_type> col_idxs{1, 0, 2};
+    gko::matrix::view::csr<value_type, index_type> view{
+        gko::dim<2>{3, 3}, 3, values.data(), row_ptrs.data(), col_idxs.data()};
+    auto const_view = view.as_const();
+
+    ASSERT_EQ(view.size, gko::dim<2>(3, 3));
+    ASSERT_EQ(view.num_stored_elements, 3);
+    ASSERT_EQ(view.values, values.data());
+    ASSERT_EQ(view.row_ptrs, row_ptrs.data());
+    ASSERT_EQ(view.col_idxs, col_idxs.data());
+    ASSERT_EQ(const_view.size, view.size);
+    ASSERT_EQ(const_view.num_stored_elements, view.num_stored_elements);
+    ASSERT_EQ(const_view.values, view.values);
+    ASSERT_EQ(const_view.row_ptrs, view.row_ptrs);
+    ASSERT_EQ(const_view.col_idxs, view.col_idxs);
+}
+
+
+template <typename ValueIndexType>
 class EllView : public ::testing::Test {
 public:
     using value_type =

--- a/cuda/preconditioner/batch_jacobi_kernels.cu
+++ b/cuda/preconditioner/batch_jacobi_kernels.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -82,20 +82,19 @@ GKO_INSTANTIATE_FOR_INT32_TYPE(
 template <typename ValueType, typename IndexType>
 void extract_common_blocks_pattern(
     std::shared_ptr<const DefaultExecutor> exec,
-    const gko::matrix::Csr<ValueType, IndexType>* first_sys_csr,
+    matrix::view::csr<const ValueType, const IndexType> first_sys_csr,
     const size_type num_blocks, const IndexType* cumulative_block_storage,
     const IndexType* block_pointers, const IndexType* map_block_to_row,
     IndexType* blocks_pattern)
 {
-    const auto nrows = first_sys_csr->get_size()[0];
+    const auto nrows = first_sys_csr.size[0];
     dim3 block(default_block_size);
     dim3 grid(ceildiv(nrows * config::warp_size, default_block_size));
 
     batch_single_kernels::extract_common_block_pattern_kernel<<<
         grid, block, 0, exec->get_stream()>>>(
-        static_cast<int>(nrows), first_sys_csr->get_const_row_ptrs(),
-        first_sys_csr->get_const_col_idxs(), num_blocks,
-        cumulative_block_storage, block_pointers, map_block_to_row,
+        static_cast<int>(nrows), first_sys_csr.row_ptrs, first_sys_csr.col_idxs,
+        num_blocks, cumulative_block_storage, block_pointers, map_block_to_row,
         blocks_pattern);
 }
 

--- a/cuda/solver/common_trs_kernels.cuh
+++ b/cuda/solver/common_trs_kernels.cuh
@@ -62,7 +62,7 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
     array<char> work;
 
     CudaSolveStruct(std::shared_ptr<const gko::CudaExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* matrix,
+                    matrix::view::csr<const ValueType, const IndexType> matrix,
                     size_type num_rhs, bool is_upper, bool unit_diag)
         : handle{exec->get_sparselib_handle()},
           spsm_descr{},
@@ -75,12 +75,11 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
         }
         sparselib::pointer_mode_guard pm_guard(handle);
         spsm_descr = sparselib::create_spsm_descr();
-        descr_a = sparselib::create_csr(
-            matrix->get_size()[0], matrix->get_size()[1],
-            matrix->get_num_stored_elements(),
-            const_cast<IndexType*>(matrix->get_const_row_ptrs()),
-            const_cast<IndexType*>(matrix->get_const_col_idxs()),
-            const_cast<ValueType*>(matrix->get_const_values()));
+        descr_a = sparselib::create_csr(matrix.size[0], matrix.size[1],
+                                        matrix.num_stored_elements,
+                                        const_cast<IndexType*>(matrix.row_ptrs),
+                                        const_cast<IndexType*>(matrix.col_idxs),
+                                        const_cast<ValueType*>(matrix.values));
         sparselib::set_attribute<cusparseFillMode_t>(
             descr_a, CUSPARSE_SPMAT_FILL_MODE,
             is_upper ? CUSPARSE_FILL_MODE_UPPER : CUSPARSE_FILL_MODE_LOWER);
@@ -88,15 +87,15 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
             descr_a, CUSPARSE_SPMAT_DIAG_TYPE,
             unit_diag ? CUSPARSE_DIAG_TYPE_UNIT : CUSPARSE_DIAG_TYPE_NON_UNIT);
 
-        const auto rows = matrix->get_size()[0];
+        const auto rows = matrix.size[0];
         // workaround suggested by NVIDIA engineers: for some reason
         // cusparse needs non-nullptr input vectors even for analysis
         // also make sure they are aligned by 16 bytes
         auto descr_b = sparselib::create_dnmat(
-            dim<2>{matrix->get_size()[0], num_rhs}, matrix->get_size()[1],
+            dim<2>{matrix.size[0], num_rhs}, matrix.size[1],
             reinterpret_cast<ValueType*>(0xDEAD0));
         auto descr_c = sparselib::create_dnmat(
-            dim<2>{matrix->get_size()[0], num_rhs}, matrix->get_size()[1],
+            dim<2>{matrix.size[0], num_rhs}, matrix.size[1],
             reinterpret_cast<ValueType*>(0xDEAF0));
 
         auto work_size = sparselib::spsm_buffer_size(
@@ -116,7 +115,7 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
         sparselib::destroy(descr_c);
     }
 
-    void solve(const matrix::Csr<ValueType, IndexType>*,
+    void solve(matrix::view::csr<const ValueType, const IndexType>,
                matrix::view::dense<const ValueType> input,
                matrix::view::dense<ValueType> output) const
     {
@@ -182,7 +181,7 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
     mutable array<char> work;
 
     CudaSolveStruct(std::shared_ptr<const gko::CudaExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* matrix,
+                    matrix::view::csr<const ValueType, const IndexType> matrix,
                     size_type num_rhs, bool is_upper, bool unit_diag)
         : exec{exec},
           handle{exec->get_sparselib_handle()},
@@ -215,10 +214,9 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
         // prevent compiler issues with gnu/llvm 9
         sparselib::buffer_size_ext(
             handle, algorithm, SPARSELIB_OPERATION_NON_TRANSPOSE,
-            SPARSELIB_OPERATION_TRANSPOSE, matrix->get_size()[0], num_rhs,
-            matrix->get_num_stored_elements(), one<ValueType>(), factor_descr,
-            matrix->get_const_values(), matrix->get_const_row_ptrs(),
-            matrix->get_const_col_idxs(),
+            SPARSELIB_OPERATION_TRANSPOSE, matrix.size[0], num_rhs,
+            matrix.num_stored_elements, one<ValueType>(), factor_descr,
+            matrix.values, matrix.row_ptrs, matrix.col_idxs,
             static_cast<const ValueType*>(nullptr), num_rhs, solve_info, policy,
             &work_size);
 
@@ -227,15 +225,14 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
 
         sparselib::csrsm2_analysis(
             handle, algorithm, SPARSELIB_OPERATION_NON_TRANSPOSE,
-            SPARSELIB_OPERATION_TRANSPOSE, matrix->get_size()[0], num_rhs,
-            matrix->get_num_stored_elements(), one<ValueType>(), factor_descr,
-            matrix->get_const_values(), matrix->get_const_row_ptrs(),
-            matrix->get_const_col_idxs(),
+            SPARSELIB_OPERATION_TRANSPOSE, matrix.size[0], num_rhs,
+            matrix.num_stored_elements, one<ValueType>(), factor_descr,
+            matrix.values, matrix.row_ptrs, matrix.col_idxs,
             static_cast<const ValueType*>(nullptr), num_rhs, solve_info, policy,
             work.get_data());
     }
 
-    void solve(const matrix::Csr<ValueType, IndexType>* matrix,
+    void solve(matrix::view::csr<const ValueType, const IndexType> matrix,
                matrix::view::dense<const ValueType> input,
                matrix::view::dense<ValueType> output) const
     {
@@ -254,11 +251,10 @@ struct CudaSolveStruct : gko::solver::SolveStruct {
         dense::copy(exec, input, output);
         sparselib::csrsm2_solve(
             handle, algorithm, SPARSELIB_OPERATION_NON_TRANSPOSE,
-            SPARSELIB_OPERATION_TRANSPOSE, matrix->get_size()[0], output.stride,
-            matrix->get_num_stored_elements(), one<ValueType>(), factor_descr,
-            matrix->get_const_values(), matrix->get_const_row_ptrs(),
-            matrix->get_const_col_idxs(), output.values, output.stride,
-            solve_info, policy, work.get_data());
+            SPARSELIB_OPERATION_TRANSPOSE, matrix.size[0], output.stride,
+            matrix.num_stored_elements, one<ValueType>(), factor_descr,
+            matrix.values, matrix.row_ptrs, matrix.col_idxs, output.values,
+            output.stride, solve_info, policy, work.get_data());
     }
 
     ~CudaSolveStruct()
@@ -295,12 +291,12 @@ void should_perform_transpose_kernel(std::shared_ptr<const CudaExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate_kernel(std::shared_ptr<const CudaExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* matrix,
+                     matrix::view::csr<const ValueType, const IndexType> matrix,
                      std::shared_ptr<solver::SolveStruct>& solve_struct,
                      const gko::size_type num_rhs, bool is_upper,
                      bool unit_diag)
 {
-    if (matrix->get_size()[0] == 0) {
+    if (matrix.size[0] == 0) {
         return;
     }
     if (sparselib::is_supported<ValueType, IndexType>::value) {
@@ -314,12 +310,12 @@ void generate_kernel(std::shared_ptr<const CudaExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void solve_kernel(std::shared_ptr<const CudaExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* matrix,
+                  matrix::view::csr<const ValueType, const IndexType> matrix,
                   const solver::SolveStruct* solve_struct,
                   matrix::view::dense<const ValueType> b,
                   matrix::view::dense<ValueType> x)
 {
-    if (matrix->get_size()[0] == 0 || b.size[1] == 0) {
+    if (matrix.size[0] == 0 || b.size[1] == 0) {
         return;
     }
     using vec = matrix::Dense<ValueType>;
@@ -599,16 +595,15 @@ __global__ void sptrsv_init_kernel(bool* const nan_produced,
 
 
 template <bool is_upper, typename ValueType, typename IndexType>
-void sptrsv_naive_caching(std::shared_ptr<const CudaExecutor> exec,
-                          const matrix::Csr<ValueType, IndexType>* matrix,
-                          bool unit_diag,
-                          matrix::view::dense<const ValueType> b,
-                          matrix::view::dense<ValueType> x)
+void sptrsv_naive_caching(
+    std::shared_ptr<const CudaExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> matrix, bool unit_diag,
+    matrix::view::dense<const ValueType> b, matrix::view::dense<ValueType> x)
 {
     // Pre-Volta GPUs may deadlock due to missing independent thread scheduling.
     const auto is_fallback_required = exec->get_major_version() < 7;
 
-    const auto n = matrix->get_size()[0];
+    const auto n = matrix.size[0];
     const auto nrhs = b.size[1];
 
     // Initialize x to all NaNs.
@@ -626,16 +621,14 @@ void sptrsv_naive_caching(std::shared_ptr<const CudaExecutor> exec,
     if (is_fallback_required) {
         sptrsv_naive_legacy_kernel<is_upper>
             <<<grid_size, block_size, 0, exec->get_stream()>>>(
-                matrix->get_const_row_ptrs(), matrix->get_const_col_idxs(),
-                as_device_type(matrix->get_const_values()),
+                matrix.row_ptrs, matrix.col_idxs, as_device_type(matrix.values),
                 as_device_type(b.values), b.stride, as_device_type(x.values),
                 x.stride, n, nrhs, unit_diag, nan_produced.get_data(),
                 atomic_counter.get_data());
     } else {
         sptrsv_naive_caching_kernel<is_upper>
             <<<grid_size, block_size, 0, exec->get_stream()>>>(
-                matrix->get_const_row_ptrs(), matrix->get_const_col_idxs(),
-                as_device_type(matrix->get_const_values()),
+                matrix.row_ptrs, matrix.col_idxs, as_device_type(matrix.values),
                 as_device_type(b.values), b.stride, as_device_type(x.values),
                 x.stride, n, nrhs, unit_diag, nan_produced.get_data(),
                 atomic_counter.get_data());

--- a/cuda/solver/lower_trs_kernels.cu
+++ b/cuda/solver/lower_trs_kernels.cu
@@ -40,7 +40,7 @@ void should_perform_transpose(std::shared_ptr<const CudaExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const CudaExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -57,7 +57,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const CudaExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/cuda/solver/upper_trs_kernels.cu
+++ b/cuda/solver/upper_trs_kernels.cu
@@ -40,7 +40,7 @@ void should_perform_transpose(std::shared_ptr<const CudaExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const CudaExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -57,7 +57,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const CudaExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/dpcpp/factorization/cholesky_kernels.dp.cpp
+++ b/dpcpp/factorization/cholesky_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -27,17 +27,17 @@ namespace cholesky {
 
 template <typename ValueType, typename IndexType>
 void symbolic_count(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* mtx,
+                    matrix::view::csr<const ValueType, const IndexType> mtx,
                     const factorization::elimination_forest<IndexType>& forest,
                     IndexType* row_nnz, array<IndexType>& tmp_storage)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto mtx_nnz = mtx->get_num_stored_elements();
+    const auto num_rows = mtx.size[0];
+    const auto mtx_nnz = mtx.num_stored_elements;
     tmp_storage.resize_and_reset(mtx_nnz + num_rows);
     const auto postorder_cols = tmp_storage.get_data();
     const auto lower_ends = postorder_cols + mtx_nnz;
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto cols = mtx->get_const_col_idxs();
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto cols = mtx.col_idxs;
     const auto inv_postorder = forest.inv_postorder.get_const_data();
     const auto postorder_parent = forest.postorder_parents.get_const_data();
     auto queue = exec->get_queue();
@@ -96,21 +96,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void symbolic_factorize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
     const factorization::elimination_forest<IndexType>& forest,
-    matrix::Csr<ValueType, IndexType>* l_factor,
+    matrix::view::csr<ValueType, IndexType> l_factor,
     const array<IndexType>& tmp_storage)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto mtx_nnz = mtx->get_num_stored_elements();
+    const auto num_rows = mtx.size[0];
+    const auto mtx_nnz = mtx.num_stored_elements;
     const auto postorder_cols = tmp_storage.get_const_data();
     const auto lower_ends = postorder_cols + mtx_nnz;
-    const auto row_ptrs = mtx->get_const_row_ptrs();
+    const auto row_ptrs = mtx.row_ptrs;
     const auto postorder = forest.postorder.get_const_data();
     const auto inv_postorder = forest.inv_postorder.get_const_data();
     const auto postorder_parent = forest.postorder_parents.get_const_data();
-    const auto out_row_ptrs = l_factor->get_const_row_ptrs();
-    const auto out_cols = l_factor->get_col_idxs();
+    const auto out_row_ptrs = l_factor.row_ptrs;
+    const auto out_cols = l_factor.col_idxs;
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx_id) {
             const auto row = idx_id[0];
@@ -143,13 +143,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
-                const IndexType* factor_lookup_offsets,
-                const int64* factor_lookup_descs,
-                const int32* factor_lookup_storage, IndexType* diag_idxs,
-                IndexType* transpose_idxs,
-                matrix::Csr<ValueType, IndexType>* factors) GKO_NOT_IMPLEMENTED;
+void initialize(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    const IndexType* factor_lookup_offsets, const int64* factor_lookup_descs,
+    const int32* factor_lookup_storage, IndexType* diag_idxs,
+    IndexType* transpose_idxs,
+    matrix::view::csr<ValueType, IndexType> factors) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CHOLESKY_INITIALIZE);
 
@@ -160,8 +160,8 @@ void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const int32* lookup_storage, const IndexType* diag_idxs,
                const IndexType* transpose_idxs,
                const factorization::elimination_forest<IndexType>& forest,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage) GKO_NOT_IMPLEMENTED;
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CHOLESKY_FACTORIZE);
 

--- a/dpcpp/factorization/elimination_forest_kernels.dp.cpp
+++ b/dpcpp/factorization/elimination_forest_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -32,7 +32,7 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void from_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* factors,
+                 matrix::view::csr<const ValueType, const IndexType> factors,
                  gko::factorization::elimination_forest<IndexType>& forest)
     GKO_NOT_IMPLEMENTED;
 

--- a/dpcpp/factorization/factorization_kernels.dp.cpp
+++ b/dpcpp/factorization/factorization_kernels.dp.cpp
@@ -491,10 +491,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const dim3 block_size{default_block_size, 1, 1};
     const uint32 number_blocks =
@@ -503,10 +503,8 @@ void initialize_row_ptrs_l_u(
 
     kernel::count_nnz_per_l_u_row(
         grid_dim, block_size, 0, exec->get_queue(), num_rows,
-        system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(),
-        as_device_type(system_matrix->get_const_values()), l_row_ptrs,
-        u_row_ptrs);
+        system_matrix.row_ptrs, system_matrix.col_idxs,
+        as_device_type(system_matrix.values), l_row_ptrs, u_row_ptrs);
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
     components::prefix_sum_nonnegative(exec, u_row_ptrs, num_rows + 1);
@@ -517,24 +515,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const DpcppExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const DpcppExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const dim3 block_size{default_block_size, 1, 1};
     const dim3 grid_dim{static_cast<uint32>(ceildiv(
                             num_rows, static_cast<size_type>(block_size.x))),
                         1, 1};
 
     kernel::initialize_l_u(grid_dim, block_size, 0, exec->get_queue(), num_rows,
-                           system_matrix->get_const_row_ptrs(),
-                           system_matrix->get_const_col_idxs(),
-                           system_matrix->get_const_values(),
-                           csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-                           csr_l->get_values(), csr_u->get_const_row_ptrs(),
-                           csr_u->get_col_idxs(), csr_u->get_values());
+                           system_matrix.row_ptrs, system_matrix.col_idxs,
+                           system_matrix.values, csr_l.row_ptrs, csr_l.col_idxs,
+                           csr_l.values, csr_u.row_ptrs, csr_u.col_idxs,
+                           csr_u.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -544,10 +541,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const dim3 block_size{default_block_size, 1, 1};
     const uint32 number_blocks =
@@ -556,9 +553,8 @@ void initialize_row_ptrs_l(
 
     kernel::count_nnz_per_l_row(
         grid_dim, block_size, 0, exec->get_queue(), num_rows,
-        system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(),
-        as_device_type(system_matrix->get_const_values()), l_row_ptrs);
+        system_matrix.row_ptrs, system_matrix.col_idxs,
+        as_device_type(system_matrix.values), l_row_ptrs);
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
 }
@@ -568,22 +564,22 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const DpcppExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const DpcppExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const dim3 block_size{default_block_size, 1, 1};
     const dim3 grid_dim{static_cast<uint32>(ceildiv(
                             num_rows, static_cast<size_type>(block_size.x))),
                         1, 1};
 
     kernel::initialize_l(grid_dim, block_size, 0, exec->get_queue(), num_rows,
-                         system_matrix->get_const_row_ptrs(),
-                         system_matrix->get_const_col_idxs(),
-                         as_device_type(system_matrix->get_const_values()),
-                         csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-                         as_device_type(csr_l->get_values()), diag_sqrt);
+                         system_matrix.row_ptrs, system_matrix.col_idxs,
+                         as_device_type(system_matrix.values), csr_l.row_ptrs,
+                         csr_l.col_idxs, as_device_type(csr_l.values),
+                         diag_sqrt);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -593,8 +589,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup,
     bool& valid) GKO_NOT_IMPLEMENTED;
 

--- a/dpcpp/factorization/factorization_kernels.dp.cpp
+++ b/dpcpp/factorization/factorization_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -491,10 +491,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const dim3 block_size{default_block_size, 1, 1};
     const uint32 number_blocks =
@@ -503,10 +503,8 @@ void initialize_row_ptrs_l_u(
 
     kernel::count_nnz_per_l_u_row(
         grid_dim, block_size, 0, exec->get_queue(), num_rows,
-        system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(),
-        as_device_type(system_matrix->get_const_values()), l_row_ptrs,
-        u_row_ptrs);
+        system_matrix.row_ptrs, system_matrix.col_idxs,
+        as_device_type(system_matrix.values), l_row_ptrs, u_row_ptrs);
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
     components::prefix_sum_nonnegative(exec, u_row_ptrs, num_rows + 1);
@@ -517,24 +515,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const DpcppExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const DpcppExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const dim3 block_size{default_block_size, 1, 1};
     const dim3 grid_dim{static_cast<uint32>(ceildiv(
                             num_rows, static_cast<size_type>(block_size.x))),
                         1, 1};
 
     kernel::initialize_l_u(grid_dim, block_size, 0, exec->get_queue(), num_rows,
-                           system_matrix->get_const_row_ptrs(),
-                           system_matrix->get_const_col_idxs(),
-                           system_matrix->get_const_values(),
-                           csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-                           csr_l->get_values(), csr_u->get_const_row_ptrs(),
-                           csr_u->get_col_idxs(), csr_u->get_values());
+                           system_matrix.row_ptrs, system_matrix.col_idxs,
+                           system_matrix.values, csr_l.row_ptrs, csr_l.col_idxs,
+                           csr_l.values, csr_u.row_ptrs, csr_u.col_idxs,
+                           csr_u.values);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -544,10 +541,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
 
     const dim3 block_size{default_block_size, 1, 1};
     const uint32 number_blocks =
@@ -556,9 +553,8 @@ void initialize_row_ptrs_l(
 
     kernel::count_nnz_per_l_row(
         grid_dim, block_size, 0, exec->get_queue(), num_rows,
-        system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(),
-        as_device_type(system_matrix->get_const_values()), l_row_ptrs);
+        system_matrix.row_ptrs, system_matrix.col_idxs,
+        as_device_type(system_matrix.values), l_row_ptrs);
 
     components::prefix_sum_nonnegative(exec, l_row_ptrs, num_rows + 1);
 }
@@ -568,22 +564,22 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const DpcppExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const DpcppExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const dim3 block_size{default_block_size, 1, 1};
     const dim3 grid_dim{static_cast<uint32>(ceildiv(
                             num_rows, static_cast<size_type>(block_size.x))),
                         1, 1};
 
     kernel::initialize_l(grid_dim, block_size, 0, exec->get_queue(), num_rows,
-                         system_matrix->get_const_row_ptrs(),
-                         system_matrix->get_const_col_idxs(),
-                         as_device_type(system_matrix->get_const_values()),
-                         csr_l->get_const_row_ptrs(), csr_l->get_col_idxs(),
-                         as_device_type(csr_l->get_values()), diag_sqrt);
+                         system_matrix.row_ptrs, system_matrix.col_idxs,
+                         as_device_type(system_matrix.values), csr_l.row_ptrs,
+                         csr_l.col_idxs, as_device_type(csr_l.values),
+                         diag_sqrt);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -593,8 +589,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup,
     bool& valid) GKO_NOT_IMPLEMENTED;
 

--- a/dpcpp/factorization/ic_kernels.dp.cpp
+++ b/dpcpp/factorization/ic_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,7 +18,8 @@ namespace ic_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ic(std::shared_ptr<const DefaultExecutor> exec,
-                  matrix::Csr<ValueType, IndexType>* m) GKO_NOT_IMPLEMENTED;
+                  matrix::view::csr<ValueType, IndexType> m)
+    GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_IC_SPARSELIB_IC_KERNEL);

--- a/dpcpp/factorization/ilu_kernels.dp.cpp
+++ b/dpcpp/factorization/ilu_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,7 +18,8 @@ namespace ilu_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ilu(std::shared_ptr<const DefaultExecutor> exec,
-                   matrix::Csr<ValueType, IndexType>* m) GKO_NOT_IMPLEMENTED;
+                   matrix::view::csr<ValueType, IndexType> m)
+    GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ILU_SPARSELIB_ILU_KERNEL);

--- a/dpcpp/factorization/lu_kernels.dp.cpp
+++ b/dpcpp/factorization/lu_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -25,12 +25,12 @@ namespace lu_factorization {
 
 
 template <typename ValueType, typename IndexType>
-void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
-                const IndexType* factor_lookup_offsets,
-                const int64* factor_lookup_descs,
-                const int32* factor_lookup_storage, IndexType* diag_idxs,
-                matrix::Csr<ValueType, IndexType>* factors) GKO_NOT_IMPLEMENTED;
+void initialize(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    const IndexType* factor_lookup_offsets, const int64* factor_lookup_descs,
+    const int32* factor_lookup_storage, IndexType* diag_idxs,
+    matrix::view::csr<ValueType, IndexType> factors) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_LU_INITIALIZE);
 
@@ -39,8 +39,8 @@ template <typename ValueType, typename IndexType>
 void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const IndexType* lookup_offsets, const int64* lookup_descs,
                const int32* lookup_storage, const IndexType* diag_idxs,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage) GKO_NOT_IMPLEMENTED;
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_LU_FACTORIZE);
 
@@ -52,7 +52,7 @@ void symbolic_factorize_simple(std::shared_ptr<const DefaultExecutor> exec,
                                const IndexType* lookup_offsets,
                                const int64* lookup_descs,
                                const int32* lookup_storage,
-                               matrix::Csr<float, IndexType>* factors,
+                               matrix::view::csr<float, IndexType> factors,
                                IndexType* out_row_nnz) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_LU_SYMMETRIC_FACTORIZE_SIMPLE);
@@ -61,7 +61,7 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_LU_SYMMETRIC_FACTORIZE_SIMPLE);
 template <typename IndexType>
 void symbolic_factorize_simple_finalize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<float, IndexType>* factors,
+    matrix::view::csr<const float, const IndexType> factors,
     IndexType* out_col_idxs) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(

--- a/dpcpp/factorization/par_ic_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ic_kernels.dp.cpp
@@ -121,12 +121,12 @@ void ic_sweep(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 
 template <typename ValueType, typename IndexType>
 void init_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 matrix::Csr<ValueType, IndexType>* l)
+                 matrix::view::csr<ValueType, IndexType> l)
 {
-    auto num_rows = l->get_size()[0];
+    auto num_rows = l.size[0];
     auto num_blocks = ceildiv(num_rows, default_block_size);
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_vals = as_device_type(l->get_values());
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_vals = as_device_type(l.values);
     kernel::ic_init(num_blocks, default_block_size, 0, exec->get_queue(),
                     l_row_ptrs, l_vals, num_rows);
 }
@@ -139,17 +139,16 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type iterations,
                     matrix::view::coo<const ValueType, const IndexType> a_lower,
-                    matrix::Csr<ValueType, IndexType>* l)
+                    matrix::view::csr<ValueType, IndexType> l)
 {
-    auto nnz = l->get_num_stored_elements();
+    auto nnz = l.num_stored_elements;
     auto num_blocks = ceildiv(nnz, default_block_size);
     for (size_type i = 0; i < iterations; ++i) {
         kernel::ic_sweep(num_blocks, default_block_size, 0, exec->get_queue(),
                          a_lower.row_idxs, a_lower.col_idxs,
-                         as_device_type(a_lower.values),
-                         l->get_const_row_ptrs(), l->get_const_col_idxs(),
-                         as_device_type(l->get_values()),
-                         static_cast<IndexType>(l->get_num_stored_elements()));
+                         as_device_type(a_lower.values), l.row_ptrs, l.col_idxs,
+                         as_device_type(l.values),
+                         static_cast<IndexType>(l.num_stored_elements));
     }
 }
 

--- a/dpcpp/factorization/par_ict_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ict_kernels.dp.cpp
@@ -394,24 +394,24 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
-    auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(llh.size[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     auto l_new = l_new_builder->get_matrix();
-    auto llh_row_ptrs = llh->get_const_row_ptrs();
-    auto llh_col_idxs = llh->get_const_col_idxs();
-    auto llh_vals = as_device_type(llh->get_const_values());
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = as_device_type(a->get_const_values());
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = as_device_type(l->get_const_values());
+    auto llh_row_ptrs = llh.row_ptrs;
+    auto llh_col_idxs = llh.col_idxs;
+    auto llh_vals = as_device_type(llh.values);
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = as_device_type(a.values);
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = as_device_type(l.values);
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     // count non-zeros per row
     kernel::ict_tri_spgeam_nnz<subgroup_size>(
@@ -444,20 +444,18 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 template <int subgroup_size, typename ValueType, typename IndexType>
 void compute_factor(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements());
+    auto total_nnz = static_cast<IndexType>(l.num_stored_elements);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(total_nnz, block_size);
     kernel::ict_sweep<subgroup_size>(
-        num_blocks, default_block_size, 0, exec->get_queue(),
-        a->get_const_row_ptrs(), a->get_const_col_idxs(),
-        as_device_type(a->get_const_values()), l->get_const_row_ptrs(),
-        l_coo.row_idxs, l->get_const_col_idxs(),
-        as_device_type(l->get_values()),
-        static_cast<IndexType>(l->get_num_stored_elements()));
+        num_blocks, default_block_size, 0, exec->get_queue(), a.row_ptrs,
+        a.col_idxs, as_device_type(a.values), l.row_ptrs, l_coo.row_idxs,
+        l.col_idxs, as_device_type(l.values),
+        static_cast<IndexType>(l.num_stored_elements));
 }
 
 
@@ -469,14 +467,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_factor, compute_factor);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        llh->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = llh.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),
@@ -494,12 +491,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = 2 * l->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = 2 * l.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_compute_factor(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ict_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ict_kernels.dp.cpp
@@ -394,24 +394,24 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(llh.size[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
-    auto llh_row_ptrs = llh->get_const_row_ptrs();
-    auto llh_col_idxs = llh->get_const_col_idxs();
-    auto llh_vals = as_device_type(llh->get_const_values());
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = as_device_type(a->get_const_values());
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = as_device_type(l->get_const_values());
+    auto llh_row_ptrs = llh.row_ptrs;
+    auto llh_col_idxs = llh.col_idxs;
+    auto llh_vals = as_device_type(llh.values);
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = as_device_type(a.values);
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = as_device_type(l.values);
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     // count non-zeros per row
     kernel::ict_tri_spgeam_nnz<subgroup_size>(
@@ -444,20 +444,18 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 template <int subgroup_size, typename ValueType, typename IndexType>
 void compute_factor(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements());
+    auto total_nnz = static_cast<IndexType>(l.num_stored_elements);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(total_nnz, block_size);
     kernel::ict_sweep<subgroup_size>(
-        num_blocks, default_block_size, 0, exec->get_queue(),
-        a->get_const_row_ptrs(), a->get_const_col_idxs(),
-        as_device_type(a->get_const_values()), l->get_const_row_ptrs(),
-        l_coo.row_idxs, l->get_const_col_idxs(),
-        as_device_type(l->get_values()),
-        static_cast<IndexType>(l->get_num_stored_elements()));
+        num_blocks, default_block_size, 0, exec->get_queue(), a.row_ptrs,
+        a.col_idxs, as_device_type(a.values), l.row_ptrs, l_coo.row_idxs,
+        l.col_idxs, as_device_type(l.values),
+        static_cast<IndexType>(l.num_stored_elements));
 }
 
 
@@ -469,14 +467,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_factor, compute_factor);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        llh->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = llh.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),
@@ -493,12 +490,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType> l_coo)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = 2 * l->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = 2 * l.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_compute_factor(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ict_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ict_kernels.dp.cpp
@@ -394,21 +394,21 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> llh,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* llh,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = static_cast<IndexType>(llh.size[0]);
+    auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
-    auto llh_row_ptrs = llh.row_ptrs;
-    auto llh_col_idxs = llh.col_idxs;
-    auto llh_vals = as_device_type(llh.values);
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto a_vals = as_device_type(a.values);
+    auto llh_row_ptrs = llh->get_const_row_ptrs();
+    auto llh_col_idxs = llh->get_const_col_idxs();
+    auto llh_vals = as_device_type(llh->get_const_values());
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto a_vals = as_device_type(a->get_const_values());
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = as_device_type(l.values);
@@ -467,13 +467,14 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_factor, compute_factor);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> llh,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* llh,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a.size[0];
-    auto total_nnz = llh.num_stored_elements + a.num_stored_elements;
+    auto num_rows = a->get_size()[0];
+    auto total_nnz =
+        llh->get_num_stored_elements() + a->get_num_stored_elements();
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilu_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilu_kernels.dp.cpp
@@ -104,8 +104,8 @@ template <typename ValueType, typename IndexType>
 void compute_l_u_factors(
     std::shared_ptr<const DpcppExecutor> exec, size_type iterations,
     matrix::view::coo<const ValueType, const IndexType> system_matrix,
-    matrix::Csr<ValueType, IndexType>* l_factor,
-    matrix::Csr<ValueType, IndexType>* u_factor)
+    matrix::view::csr<ValueType, IndexType> l_factor,
+    matrix::view::csr<ValueType, IndexType> u_factor)
 {
     iterations = (iterations == 0) ? 10 : iterations;
     const auto num_elements = system_matrix.num_stored_elements;
@@ -118,11 +118,10 @@ void compute_l_u_factors(
         kernel::compute_l_u_factors(
             grid_dim, block_size, 0, exec->get_queue(), num_elements,
             system_matrix.row_idxs, system_matrix.col_idxs,
-            as_device_type(system_matrix.values),
-            l_factor->get_const_row_ptrs(), l_factor->get_const_col_idxs(),
-            as_device_type(l_factor->get_values()),
-            u_factor->get_const_row_ptrs(), u_factor->get_const_col_idxs(),
-            as_device_type(u_factor->get_values()));
+            as_device_type(system_matrix.values), l_factor.row_ptrs,
+            l_factor.col_idxs, as_device_type(l_factor.values),
+            u_factor.row_ptrs, u_factor.col_idxs,
+            as_device_type(u_factor.values));
     }
 }
 

--- a/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
@@ -55,13 +55,13 @@ template <int subgroup_size, typename ValueType, typename IndexType>
 void threshold_filter_approx(
     syn::value_list<int, subgroup_size>,
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>* tmp, remove_complex<ValueType>* threshold,
     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
     matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     using AbsType = remove_complex<ValueType>;
     constexpr auto bucket_count = kernel::searchtree_width;
     auto max_num_threads = ceildiv(size, items_per_thread);
@@ -102,11 +102,11 @@ void threshold_filter_approx(
     }
 
     // filter the elements
-    auto old_row_ptrs = m->get_const_row_ptrs();
-    auto old_col_idxs = m->get_const_col_idxs();
-    auto old_vals = as_device_type(m->get_const_values());
+    auto old_row_ptrs = m.row_ptrs;
+    auto old_col_idxs = m.col_idxs;
+    auto old_vals = as_device_type(m.values);
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(m->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(m.size[0]);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto m_out = m_out_builder->get_matrix();
@@ -149,13 +149,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter_approx,
 template <typename ValueType, typename IndexType>
 void threshold_filter_approx(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
     matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto num_rows = m->get_size()[0];
-    auto total_nnz = m->get_num_stored_elements();
+    auto num_rows = m.size[0];
+    auto total_nnz = m.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter_approx(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_approx_filter_kernel.dp.cpp
@@ -52,16 +52,16 @@ using compiled_kernels = syn::value_list<int, 1, 16, 32>;
 
 
 template <int subgroup_size, typename ValueType, typename IndexType>
-void threshold_filter_approx(syn::value_list<int, subgroup_size>,
-                             std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>* tmp,
-                             remove_complex<ValueType>* threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    syn::value_list<int, subgroup_size>,
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
+    array<ValueType>* tmp, remove_complex<ValueType>* threshold,
+    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     using AbsType = remove_complex<ValueType>;
     constexpr auto bucket_count = kernel::searchtree_width;
     auto max_num_threads = ceildiv(size, items_per_thread);
@@ -102,11 +102,11 @@ void threshold_filter_approx(syn::value_list<int, subgroup_size>,
     }
 
     // filter the elements
-    auto old_row_ptrs = m->get_const_row_ptrs();
-    auto old_col_idxs = m->get_const_col_idxs();
-    auto old_vals = as_device_type(m->get_const_values());
+    auto old_row_ptrs = m.row_ptrs;
+    auto old_col_idxs = m.col_idxs;
+    auto old_vals = as_device_type(m.values);
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(m->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(m.size[0]);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto new_row_ptrs = m_out->get_row_ptrs();
@@ -147,15 +147,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter_approx,
 
 
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto num_rows = m->get_size()[0];
-    auto total_nnz = m->get_num_stored_elements();
+    auto num_rows = m.size[0];
+    auto total_nnz = m.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter_approx(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
@@ -52,16 +52,16 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void threshold_filter(syn::value_list<int, subgroup_size>,
                       std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto old_row_ptrs = a->get_const_row_ptrs();
-    auto old_col_idxs = a->get_const_col_idxs();
-    auto old_vals = as_device_type(a->get_const_values());
+    auto old_row_ptrs = a.row_ptrs;
+    auto old_col_idxs = a.col_idxs;
+    auto old_vals = as_device_type(a.values);
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(a->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(a.size[0]);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto m_out = m_out_builder->get_matrix();
@@ -105,13 +105,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter, threshold_filter);
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
@@ -52,16 +52,16 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void threshold_filter(syn::value_list<int, subgroup_size>,
                       std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto old_row_ptrs = a->get_const_row_ptrs();
-    auto old_col_idxs = a->get_const_col_idxs();
-    auto old_vals = as_device_type(a->get_const_values());
+    auto old_row_ptrs = a.row_ptrs;
+    auto old_col_idxs = a.col_idxs;
+    auto old_vals = as_device_type(a.values);
     // compute nnz for each row
-    auto num_rows = static_cast<IndexType>(a->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(a.size[0]);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, block_size);
     auto new_row_ptrs = m_out->get_row_ptrs();
@@ -105,13 +105,13 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter, threshold_filter);
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* a,
+                      matrix::view::csr<const ValueType, const IndexType> a,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz = a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_threshold_filter(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilut_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilut_kernels.dp.cpp
@@ -35,7 +35,7 @@ namespace par_ilut_factorization {
 
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp,
                       array<remove_complex<ValueType>>&,
                       remove_complex<ValueType>& threshold) GKO_NOT_IMPLEMENTED;
@@ -52,7 +52,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* m,
+                     matrix::view::csr<const ValueType, const IndexType> m,
                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred) GKO_NOT_IMPLEMENTED;
@@ -60,7 +60,7 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       remove_complex<ValueType> threshold,
                       matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo,
@@ -77,9 +77,9 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 template <typename ValueType, typename IndexType>
 void threshold_filter_approx(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
-    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::view::csr<ValueType, IndexType> m_out,
     matrix::Coo<ValueType, IndexType>* m_out_coo) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -88,12 +88,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
+                         matrix::view::csr<const ValueType, const IndexType> a,
+                         matrix::view::csr<ValueType, IndexType> l,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u,
+                         matrix::view::csr<ValueType, IndexType> u,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+                         matrix::view::csr<ValueType, IndexType> u_csc)
     GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -102,10 +102,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
                     matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
     GKO_NOT_IMPLEMENTED;

--- a/dpcpp/factorization/par_ilut_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilut_kernels.dp.cpp
@@ -35,7 +35,7 @@ namespace par_ilut_factorization {
 
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp,
                       array<remove_complex<ValueType>>&,
                       remove_complex<ValueType>& threshold) GKO_NOT_IMPLEMENTED;
@@ -52,17 +52,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* m,
-                     matrix::Csr<ValueType, IndexType>* m_out,
+                     matrix::view::csr<const ValueType, const IndexType> m,
+                     matrix::view::csr<ValueType, IndexType> m_out,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred) GKO_NOT_IMPLEMENTED;
 
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::view::csr<ValueType, IndexType> m_out,
                       matrix::Coo<ValueType, IndexType>* m_out_coo,
                       bool) GKO_NOT_IMPLEMENTED;
 
@@ -77,9 +77,9 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 template <typename ValueType, typename IndexType>
 void threshold_filter_approx(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
-    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::view::csr<ValueType, IndexType> m_out,
     matrix::Coo<ValueType, IndexType>* m_out_coo) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -88,12 +88,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
+                         matrix::view::csr<const ValueType, const IndexType> a,
+                         matrix::view::csr<ValueType, IndexType> l,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u,
+                         matrix::view::csr<ValueType, IndexType> u,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+                         matrix::view::csr<ValueType, IndexType> u_csc)
     GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -102,12 +102,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
+                    matrix::view::csr<ValueType, IndexType> l_new,
+                    matrix::view::csr<ValueType, IndexType> u_new)
     GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/factorization/par_ilut_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilut_kernels.dp.cpp
@@ -102,8 +102,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> lu,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* lu,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::view::csr<ValueType, IndexType> l_new,

--- a/dpcpp/factorization/par_ilut_select_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_select_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -58,13 +58,13 @@ void sampleselect_filter(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp1,
                       array<remove_complex<ValueType>>& tmp2,
                       remove_complex<ValueType>& threshold)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     using AbsType = remove_complex<ValueType>;
     constexpr auto bucket_count = kernel::searchtree_width;
     auto max_num_threads = ceildiv(size, items_per_thread);

--- a/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
@@ -345,30 +345,30 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
                     matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
-    auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(lu.size[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     auto l_new = l_new_builder->get_matrix();
     auto u_new = u_new_builder->get_matrix();
-    auto lu_row_ptrs = lu->get_const_row_ptrs();
-    auto lu_col_idxs = lu->get_const_col_idxs();
-    auto lu_vals = as_device_type(lu->get_const_values());
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = as_device_type(a->get_const_values());
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = as_device_type(l->get_const_values());
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = as_device_type(u->get_const_values());
+    auto lu_row_ptrs = lu.row_ptrs;
+    auto lu_col_idxs = lu.col_idxs;
+    auto lu_vals = as_device_type(lu.values);
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = as_device_type(a.values);
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = as_device_type(l.values);
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = as_device_type(u.values);
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     // count non-zeros per row
@@ -412,16 +412,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
                     matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        lu->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = lu.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
@@ -345,24 +345,24 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> lu,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* lu,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = static_cast<IndexType>(lu.size[0]);
+    auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
     matrix::CsrBuilder<ValueType, IndexType> u_new_builder(u_new);
-    auto lu_row_ptrs = lu.row_ptrs;
-    auto lu_col_idxs = lu.col_idxs;
-    auto lu_vals = as_device_type(lu.values);
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto a_vals = as_device_type(a.values);
+    auto lu_row_ptrs = lu->get_const_row_ptrs();
+    auto lu_col_idxs = lu->get_const_col_idxs();
+    auto lu_vals = as_device_type(lu->get_const_values());
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto a_vals = as_device_type(a->get_const_values());
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = as_device_type(l.values);
@@ -413,15 +413,16 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> lu,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* lu,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a.size[0];
-    auto total_nnz = lu.num_stored_elements + a.num_stored_elements;
+    auto num_rows = a->get_size()[0];
+    auto total_nnz =
+        lu->get_num_stored_elements() + a->get_num_stored_elements();
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -345,30 +345,30 @@ namespace {
 template <int subgroup_size, typename ValueType, typename IndexType>
 void add_candidates(syn::value_list<int, subgroup_size>,
                     std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
+    auto num_rows = static_cast<IndexType>(lu.size[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
     matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
     matrix::CsrBuilder<ValueType, IndexType> u_new_builder(u_new);
-    auto lu_row_ptrs = lu->get_const_row_ptrs();
-    auto lu_col_idxs = lu->get_const_col_idxs();
-    auto lu_vals = as_device_type(lu->get_const_values());
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = as_device_type(a->get_const_values());
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = as_device_type(l->get_const_values());
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = as_device_type(u->get_const_values());
+    auto lu_row_ptrs = lu.row_ptrs;
+    auto lu_col_idxs = lu.col_idxs;
+    auto lu_vals = as_device_type(lu.values);
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = as_device_type(a.values);
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = as_device_type(l.values);
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = as_device_type(u.values);
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     // count non-zeros per row
@@ -388,6 +388,7 @@ void add_candidates(syn::value_list<int, subgroup_size>,
     l_new_builder.get_value_array().resize_and_reset(l_new_nnz);
     u_new_builder.get_col_idx_array().resize_and_reset(u_new_nnz);
     u_new_builder.get_value_array().resize_and_reset(u_new_nnz);
+
 
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = as_device_type(l_new->get_values());
@@ -412,16 +413,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_add_candidates, add_candidates);
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        lu->get_num_stored_elements() + a->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = lu.num_stored_elements + a.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_add_candidates(
         compiled_kernels(),

--- a/dpcpp/factorization/par_ilut_sweep_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_sweep_kernel.dp.cpp
@@ -166,28 +166,25 @@ template <int subgroup_size, typename ValueType, typename IndexType>
 void compute_l_u_factors(
     syn::value_list<int, subgroup_size>,
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
-    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<ValueType, IndexType> l,
     matrix::view::coo<const ValueType, const IndexType> l_coo,
-    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::csr<ValueType, IndexType> u,
     matrix::view::coo<const ValueType, const IndexType> u_coo,
-    matrix::Csr<ValueType, IndexType>* u_csc)
+    matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto total_nnz = static_cast<IndexType>(l->get_num_stored_elements() +
-                                            u->get_num_stored_elements());
+    auto total_nnz =
+        static_cast<IndexType>(l.num_stored_elements + u.num_stored_elements);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(total_nnz, block_size);
     kernel::sweep<subgroup_size>(
-        num_blocks, default_block_size, 0, exec->get_queue(),
-        a->get_const_row_ptrs(), a->get_const_col_idxs(),
-        as_device_type(a->get_const_values()), l->get_const_row_ptrs(),
-        l_coo.row_idxs, l->get_const_col_idxs(),
-        as_device_type(l->get_values()),
-        static_cast<IndexType>(l->get_num_stored_elements()), u_coo.row_idxs,
-        u_coo.col_idxs, as_device_type(u->get_values()),
-        u_csc->get_const_row_ptrs(), u_csc->get_const_col_idxs(),
-        as_device_type(u_csc->get_values()),
-        static_cast<IndexType>(u->get_num_stored_elements()));
+        num_blocks, default_block_size, 0, exec->get_queue(), a.row_ptrs,
+        a.col_idxs, as_device_type(a.values), l.row_ptrs, l_coo.row_idxs,
+        l.col_idxs, as_device_type(l.values),
+        static_cast<IndexType>(l.num_stored_elements), u_coo.row_idxs,
+        u_coo.col_idxs, as_device_type(u.values), u_csc.row_ptrs,
+        u_csc.col_idxs, as_device_type(u_csc.values),
+        static_cast<IndexType>(u.num_stored_elements));
 }
 
 GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_l_u_factors,
@@ -200,16 +197,15 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_compute_l_u_factors,
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
-    matrix::Csr<ValueType, IndexType>* l,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<ValueType, IndexType> l,
     matrix::view::coo<const ValueType, const IndexType> l_coo,
-    matrix::Csr<ValueType, IndexType>* u,
+    matrix::view::csr<ValueType, IndexType> u,
     matrix::view::coo<const ValueType, const IndexType> u_coo,
-    matrix::Csr<ValueType, IndexType>* u_csc)
+    matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto num_rows = a->get_size()[0];
-    auto total_nnz =
-        l->get_num_stored_elements() + u->get_num_stored_elements();
+    auto num_rows = a.size[0];
+    auto total_nnz = l.num_stored_elements + u.num_stored_elements;
     auto total_nnz_per_row = total_nnz / num_rows;
     select_compute_l_u_factors(
         compiled_kernels(),

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1242,8 +1242,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -1312,7 +1312,7 @@ template <int subgroup_size, typename MatrixValueType, typename InputValueType,
 void classical_spmv(
     syn::value_list<int, subgroup_size>,
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1329,7 +1329,7 @@ void classical_spmv(
         exec->get_num_subgroups() * classical_oversubscription;
     const auto nsg_in_group = spmv_block_size / subgroup_size;
     const auto gridx =
-        std::min(ceildiv(a->get_size()[0], spmv_block_size / subgroup_size),
+        std::min(ceildiv(a.size[0], spmv_block_size / subgroup_size),
                  int64(num_subgroup / nsg_in_group));
     const dim3 grid(gridx, b.size[1]);
     const dim3 block(spmv_block_size);
@@ -1342,19 +1342,17 @@ void classical_spmv(
     if (!alpha && !beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subgroup_size>(
-                grid, block, 0, exec->get_queue(), a->get_size()[0],
-                acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                a->get_const_row_ptrs(), acc::as_device_range(b_vals),
-                acc::as_device_range(c_vals));
+                grid, block, 0, exec->get_queue(), a.size[0],
+                acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
+                acc::as_device_range(b_vals), acc::as_device_range(c_vals));
         }
     } else if (alpha && beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subgroup_size>(
-                grid, block, 0, exec->get_queue(), a->get_size()[0],
+                grid, block, 0, exec->get_queue(), a.size[0],
                 as_device_type(alpha->values), acc::as_device_range(a_vals),
-                a->get_const_col_idxs(), a->get_const_row_ptrs(),
-                acc::as_device_range(b_vals), as_device_type(beta->values),
-                acc::as_device_range(c_vals));
+                a.col_idxs, a.row_ptrs, acc::as_device_range(b_vals),
+                as_device_type(beta->values), acc::as_device_range(c_vals));
         }
     } else {
         GKO_KERNEL_NOT_FOUND;
@@ -1395,7 +1393,8 @@ bool load_balance_spmv(
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(
+                    a->get_const_device_view());
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -1428,12 +1427,11 @@ bool load_balance_spmv(
 
 
 template <typename ValueType, typename IndexType>
-bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
-                                const ValueType host_alpha,
-                                const matrix::Csr<ValueType, IndexType>* a,
-                                matrix::view::dense<const ValueType> b,
-                                const ValueType host_beta,
-                                matrix::view::dense<ValueType> c)
+bool try_general_sparselib_spmv(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType host_alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::dense<const ValueType> b, const ValueType host_beta,
+    matrix::view::dense<ValueType> c)
 {
     constexpr bool try_sparselib =
         !is_complex<ValueType>() &&
@@ -1449,10 +1447,9 @@ bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
 #if INTEL_MKL_VERSION >= 20250300
             static_cast<std::int64_t>(a->get_num_stored_elements()),
 #endif
-            oneapi::mkl::index_base::zero,
-            const_cast<IndexType*>(a->get_const_row_ptrs()),
-            const_cast<IndexType*>(a->get_const_col_idxs()),
-            const_cast<ValueType*>(a->get_const_values()));
+            oneapi::mkl::index_base::zero, const_cast<IndexType*>(a.row_ptrs),
+            const_cast<IndexType*>(a.col_idxs),
+            const_cast<ValueType*>(a.values));
         if (b.size[1] == 1 && b.stride == 1) {
             oneapi::mkl::sparse::gemv(
                 *exec->get_queue(), oneapi::mkl::transpose::nontrans,
@@ -1480,7 +1477,7 @@ template <typename MatrixValueType, typename InputValueType,
               !std::is_same<MatrixValueType, OutputValueType>::value>>
 bool try_sparselib_spmv(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1497,7 +1494,7 @@ bool try_sparselib_spmv(
 template <typename ValueType, typename IndexType>
 bool try_sparselib_spmv(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::view::csr<const ValueType, const IndexType> a,
     matrix::view::dense<const ValueType> b, matrix::view::dense<ValueType> c,
     xstd::type_identity_t<std::optional<matrix::view::dense<const ValueType>>>
         alpha = {},
@@ -1554,7 +1551,8 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -1562,7 +1560,8 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c);
         }
     }
 }
@@ -1610,8 +1609,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical =
-                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c, alpha, beta);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -1619,8 +1618,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
-                alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c, alpha, beta);
         }
     }
 }
@@ -1691,12 +1690,12 @@ GKO_ENABLE_DEFAULT_HOST(compute_submatrix_idxs_and_vals,
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
-    const auto num_rows = source->get_size()[0];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
+    const auto num_rows = source.size[0];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
     auto grid_dim = ceildiv(row_span.length(), default_block_size);
     auto block_dim = default_block_size;
 
@@ -1712,7 +1711,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
     IndexType* row_nnz) GKO_NOT_IMPLEMENTED;
@@ -1722,27 +1721,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     const auto row_offset = row_span.begin;
     const auto col_offset = col_span.begin;
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
-    const auto row_ptrs = source->get_const_row_ptrs();
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
+    const auto row_ptrs = source.row_ptrs;
 
-    const auto num_nnz = source->get_num_stored_elements();
+    const auto num_nnz = source.num_stored_elements;
     auto grid_dim = ceildiv(num_rows, default_block_size);
     auto block_dim = default_block_size;
     kernel::compute_submatrix_idxs_and_vals(
         grid_dim, block_dim, 0, exec->get_queue(), num_rows, num_cols, num_nnz,
-        row_offset, col_offset, source->get_const_row_ptrs(),
-        source->get_const_col_idxs(),
-        as_device_type(source->get_const_values()),
-        result->get_const_row_ptrs(), result->get_col_idxs(),
-        as_device_type(result->get_values()));
+        row_offset, col_offset, source.row_ptrs, source.col_idxs,
+        as_device_type(source.values), result.row_ptrs, result.col_idxs,
+        as_device_type(result.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -1752,10 +1750,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result) GKO_NOT_IMPLEMENTED;
+    matrix::view::csr<ValueType, IndexType> result) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_FROM_INDEX_SET_KERNEL);
@@ -2164,21 +2162,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -2225,28 +2223,29 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
-    const auto d_vals = as_device_type(d->get_const_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
+    const auto d_vals = as_device_type(d.values);
     const auto palpha = as_device_type(alpha.values);
     const auto pbeta = as_device_type(beta.values);
     const auto lookup_storage_offsets =
@@ -2402,21 +2401,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const DpcppExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
-    const auto num_rows = a->get_size()[0];
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_row_ptrs = c->get_row_ptrs();
-    const auto c_vals = as_device_type(c->get_values());
+    const auto num_rows = a.size[0];
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto b_cols = b.col_idxs;
+    const auto b_vals = as_device_type(b.values);
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto c_vals = as_device_type(c.values);
     const auto alpha_vals = as_device_type(alpha.values);
     const auto beta_vals = as_device_type(beta.values);
     auto queue = exec->get_queue();
@@ -2457,15 +2456,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const DpcppExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
     const auto num_rows = result.size[0];
     const auto num_cols = result.size[1];
     const auto stride = result.stride;
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto vals = as_device_type(source->get_const_values());
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
+    const auto vals = as_device_type(source.values);
 
     auto grid_dim = ceildiv(num_rows, default_block_size);
     kernel::fill_in_dense(grid_dim, default_block_size, 0, exec->get_queue(),
@@ -2478,10 +2477,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
-                      array<ValueType>& values) GKO_NOT_IMPLEMENTED;
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
+    array<ValueType>& values) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_CONVERT_TO_FBCSR_KERNEL);
@@ -2489,21 +2489,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <bool conjugate, typename ValueType, typename IndexType>
 void generic_transpose(std::shared_ptr<const DpcppExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* trans)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> trans)
 {
-    const auto num_rows = orig->get_size()[0];
-    const auto num_cols = orig->get_size()[1];
+    const auto num_rows = orig.size[0];
+    const auto num_cols = orig.size[1];
     auto queue = exec->get_queue();
-    const auto row_ptrs = orig->get_const_row_ptrs();
-    const auto cols = orig->get_const_col_idxs();
-    const auto vals = as_device_type(orig->get_const_values());
+    const auto row_ptrs = orig.row_ptrs;
+    const auto cols = orig.col_idxs;
+    const auto vals = as_device_type(orig.values);
 
     array<IndexType> counts{exec, num_cols + 1};
     auto tmp_counts = counts.get_data();
-    auto out_row_ptrs = trans->get_row_ptrs();
-    auto out_cols = trans->get_col_idxs();
-    auto out_vals = as_device_type(trans->get_values());
+    auto out_row_ptrs = trans.row_ptrs;
+    auto out_cols = trans.col_idxs;
+    auto out_vals = as_device_type(trans.values);
     components::fill_array(exec, tmp_counts, num_cols, IndexType{});
 
     queue->submit([&](sycl::handler& cgh) {
@@ -2540,8 +2540,8 @@ void generic_transpose(std::shared_ptr<const DpcppExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const DpcppExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
     generic_transpose<false>(exec, orig, trans);
 }
@@ -2551,8 +2551,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_TRANSPOSE_KERNEL);
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const DpcppExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
     generic_transpose<true>(exec, orig, trans);
 }
@@ -2564,23 +2564,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const DpcppExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_symm_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), permuted->get_row_ptrs(),
-        permuted->get_col_idxs(), as_device_type(permuted->get_values()));
+        perm, orig.row_ptrs, orig.col_idxs, as_device_type(orig.values),
+        permuted.row_ptrs, permuted.col_idxs, as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2588,26 +2586,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const DpcppExecutor> exec,
-                         const IndexType* row_perm, const IndexType* col_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const IndexType* row_perm,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        row_perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, row_perm,
+                               orig.row_ptrs, permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_nonsymm_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        row_perm, col_perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        permuted->get_row_ptrs(), permuted->get_col_idxs(),
-        as_device_type(permuted->get_values()));
+        row_perm, col_perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), permuted.row_ptrs, permuted.col_idxs,
+        as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2617,24 +2614,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const DpcppExecutor> exec,
                  const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                           exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                           row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
-    row_permute_kernel(
-        copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), row_permuted->get_row_ptrs(),
-        row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+    row_permute_kernel(copy_num_blocks, default_block_size, 0,
+                       exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                       orig.col_idxs, as_device_type(orig.values),
+                       row_permuted.row_ptrs, row_permuted.col_idxs,
+                       as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2644,24 +2640,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const DpcppExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
-    inv_row_permute_kernel(
-        copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), row_permuted->get_row_ptrs(),
-        row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+    inv_row_permute_kernel(copy_num_blocks, default_block_size, 0,
+                           exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                           orig.col_idxs, as_device_type(orig.values),
+                           row_permuted.row_ptrs, row_permuted.col_idxs,
+                           as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2669,26 +2664,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_symm_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        as_device_type(scale), perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        permuted->get_row_ptrs(), permuted->get_col_idxs(),
-        as_device_type(permuted->get_values()));
+        as_device_type(scale), perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), permuted.row_ptrs, permuted.col_idxs,
+        as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2696,29 +2690,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        row_perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, row_perm,
+                               orig.row_ptrs, permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_nonsymm_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
         as_device_type(row_scale), row_perm, as_device_type(col_scale),
-        col_perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), permuted->get_row_ptrs(),
-        permuted->get_col_idxs(), as_device_type(permuted->get_values()));
+        col_perm, orig.row_ptrs, orig.col_idxs, as_device_type(orig.values),
+        permuted.row_ptrs, permuted.col_idxs, as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2728,24 +2719,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                           exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                           row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     row_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        as_device_type(scale), perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+        as_device_type(scale), perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), row_permuted.row_ptrs,
+        row_permuted.col_idxs, as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2753,26 +2743,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_row_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        as_device_type(scale), perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+        as_device_type(scale), perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), row_permuted.row_ptrs,
+        row_permuted.col_idxs, as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2781,12 +2771,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const DpcppExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    const auto num_rows = to_sort->get_size()[0];
-    const auto row_ptrs = to_sort->get_const_row_ptrs();
-    auto cols = to_sort->get_col_idxs();
-    auto vals = as_device_type(to_sort->get_values());
+    const auto num_rows = to_sort.size[0];
+    const auto row_ptrs = to_sort.row_ptrs;
+    auto cols = to_sort.col_idxs;
+    auto vals = as_device_type(to_sort.values);
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx) {
             const auto row = static_cast<size_type>(idx[0]);
@@ -2840,12 +2830,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
     array<bool> is_sorted_device_array{exec, {true}};
-    const auto num_rows = to_check->get_size()[0];
-    const auto row_ptrs = to_check->get_const_row_ptrs();
-    const auto cols = to_check->get_const_col_idxs();
+    const auto num_rows = to_check.size[0];
+    const auto row_ptrs = to_check.row_ptrs;
+    const auto cols = to_check.col_idxs;
     auto is_sorted_device = is_sorted_device_array.get_data();
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx) {
@@ -2871,17 +2862,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const DpcppExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto nnz = orig->get_num_stored_elements();
+    const auto nnz = orig.num_stored_elements;
     const auto diag_size = diag->get_size()[0];
     const auto num_blocks =
         ceildiv(config::warp_size * diag_size, default_block_size);
 
-    const auto orig_values = as_device_type(orig->get_const_values());
-    const auto orig_row_ptrs = orig->get_const_row_ptrs();
-    const auto orig_col_idxs = orig->get_const_col_idxs();
+    const auto orig_values = as_device_type(orig.values);
+    const auto orig_row_ptrs = orig.row_ptrs;
+    const auto orig_col_idxs = orig.col_idxs;
     auto diag_values = as_device_type(diag->get_values());
 
     kernel::extract_diagonal(num_blocks, default_block_size, 0,
@@ -2893,20 +2884,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_EXTRACT_DIAGONAL);
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const DpcppExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const DpcppExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
-    const auto num_diag = static_cast<IndexType>(
-        std::min(mtx->get_size()[0], mtx->get_size()[1]));
+    const auto num_diag =
+        static_cast<IndexType>(std::min(mtx.size[0], mtx.size[1]));
     if (num_diag > 0) {
         const IndexType num_blocks =
             ceildiv(num_diag, default_block_size / config::warp_size);
         array<bool> has_diags(exec, {true});
         kernel::check_diagonal_entries(
             num_blocks, default_block_size, 0, exec->get_queue(), num_diag,
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            has_diags.get_data());
+            mtx.row_ptrs, mtx.col_idxs, has_diags.get_data());
         has_all_diags = get_element(has_diags, 0);
     } else {
         has_all_diags = true;
@@ -2921,19 +2912,19 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const DpcppExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = mtx->get_size()[0];
+    const auto nrows = mtx.size[0];
     if (nrows == 0) {
         return;
     }
     const auto nthreads = nrows * config::warp_size;
     const auto nblocks = ceildiv(nthreads, default_block_size);
-    kernel::add_scaled_identity(
-        nblocks, default_block_size, 0, exec->get_queue(),
-        as_device_type(alpha.values), as_device_type(beta.values),
-        static_cast<IndexType>(nrows), mtx->get_const_row_ptrs(),
-        mtx->get_const_col_idxs(), as_device_type(mtx->get_values()));
+    kernel::add_scaled_identity(nblocks, default_block_size, 0,
+                                exec->get_queue(), as_device_type(alpha.values),
+                                as_device_type(beta.values),
+                                static_cast<IndexType>(nrows), mtx.row_ptrs,
+                                mtx.col_idxs, as_device_type(mtx.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1220,7 +1220,7 @@ template <int items_per_thread, typename MatrixValueType,
 void merge_path_spmv(
     syn::value_list<int, items_per_thread>,
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1232,7 +1232,7 @@ void merge_path_spmv(
 {
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
-    const IndexType total = a->get_size()[0] + a->get_num_stored_elements();
+    const IndexType total = a.size[0] + a.num_stored_elements;
     const IndexType grid_num =
         ceildiv(total, spmv_block_size * items_per_thread);
     const dim3 grid = grid_num;
@@ -1242,8 +1242,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a.device_view);
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -1258,11 +1258,11 @@ void merge_path_spmv(
             if (grid_num > 0) {
                 csr::kernel::abstract_merge_path_spmv<items_per_thread>(
                     grid, block, 0, exec->get_queue(),
-                    static_cast<IndexType>(a->get_size()[0]),
-                    acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                    a->get_const_row_ptrs(), a->get_const_srow(),
-                    acc::as_device_range(b_vals), acc::as_device_range(c_vals),
-                    row_out.get_data(), as_device_type(val_out.get_data()));
+                    static_cast<IndexType>(a.size[0]),
+                    acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
+                    a.srow, acc::as_device_range(b_vals),
+                    acc::as_device_range(c_vals), row_out.get_data(),
+                    as_device_type(val_out.get_data()));
             }
             csr::kernel::abstract_reduce(
                 1, spmv_block_size, 0, exec->get_queue(), grid_num,
@@ -1273,12 +1273,12 @@ void merge_path_spmv(
             if (grid_num > 0) {
                 csr::kernel::abstract_merge_path_spmv<items_per_thread>(
                     grid, block, 0, exec->get_queue(),
-                    static_cast<IndexType>(a->get_size()[0]),
+                    static_cast<IndexType>(a.size[0]),
                     as_device_type(alpha->values), acc::as_device_range(a_vals),
-                    a->get_const_col_idxs(), a->get_const_row_ptrs(),
-                    a->get_const_srow(), acc::as_device_range(b_vals),
-                    as_device_type(beta->values), acc::as_device_range(c_vals),
-                    row_out.get_data(), as_device_type(val_out.get_data()));
+                    a.col_idxs, a.row_ptrs, a.srow,
+                    acc::as_device_range(b_vals), as_device_type(beta->values),
+                    acc::as_device_range(c_vals), row_out.get_data(),
+                    as_device_type(val_out.get_data()));
             }
             csr::kernel::abstract_reduce(
                 1, spmv_block_size, 0, exec->get_queue(), grid_num,
@@ -1366,7 +1366,7 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 bool load_balance_spmv(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1388,13 +1388,12 @@ bool load_balance_spmv(
         } else {
             dense::fill(exec, c, zero<OutputValueType>());
         }
-        const IndexType nwarps = a->get_num_srow_elements();
+        const IndexType nwarps = a.num_srow_elements;
         if (nwarps > 0) {
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(
-                    a->get_const_device_view());
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -1402,21 +1401,19 @@ bool load_balance_spmv(
                 if (csr_grid.x > 0 && csr_grid.y > 0) {
                     csr::kernel::abstract_spmv(
                         csr_grid, csr_block, 0, exec->get_queue(), nwarps,
-                        static_cast<IndexType>(a->get_size()[0]),
+                        static_cast<IndexType>(a.size[0]),
                         as_device_type(alpha->values),
-                        acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                        a->get_const_row_ptrs(), a->get_const_srow(),
-                        acc::as_device_range(b_vals),
+                        acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
+                        a.srow, acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
             } else {
                 if (csr_grid.x > 0 && csr_grid.y > 0) {
                     csr::kernel::abstract_spmv(
                         csr_grid, csr_block, 0, exec->get_queue(), nwarps,
-                        static_cast<IndexType>(a->get_size()[0]),
-                        acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                        a->get_const_row_ptrs(), a->get_const_srow(),
-                        acc::as_device_range(b_vals),
+                        static_cast<IndexType>(a.size[0]),
+                        acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
+                        a.const_srow, acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
             }
@@ -1521,7 +1518,7 @@ template <typename MatrixValueType, typename InputValueType,
 void spmv(std::shared_ptr<const DpcppExecutor> exec,
           const matrix::csr::spmv_strategy strategy,
           const IndexType max_nnz_per_row,
-          const matrix::Csr<MatrixValueType, IndexType>* a,
+          matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
 {
@@ -1551,8 +1548,7 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -1560,8 +1556,7 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
         }
     }
 }
@@ -1576,7 +1571,7 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                    const matrix::csr::spmv_strategy strategy,
                    const IndexType max_nnz_per_row,
                    matrix::view::dense<const MatrixValueType> alpha,
-                   const matrix::Csr<MatrixValueType, IndexType>* a,
+                   matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,
                    matrix::view::dense<const OutputValueType> beta,
                    matrix::view::dense<OutputValueType> c)
@@ -1609,8 +1604,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c, alpha, beta);
+            use_classical =
+                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
             host_kernel::select_classical_spmv(
@@ -1618,8 +1613,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_nnz_per_row](int compiled_info) {
                     return max_nnz_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c, alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
+                alpha, beta);
         }
     }
 }
@@ -1948,17 +1943,17 @@ auto spgemm_multiway_merge(size_type row,
 
 template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const DpcppExecutor> exec,
-            const matrix::Csr<ValueType, IndexType>* a,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> a,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto num_rows = a->get_size()[0];
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto b_vals = as_device_type(b->get_const_values());
+    auto num_rows = a.size[0];
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto b_cols = b.col_idxs;
+    const auto b_vals = as_device_type(b.values);
     auto c = c_builder->get_matrix();
     auto c_row_ptrs = c->get_row_ptrs();
     auto queue = exec->get_queue();
@@ -2026,20 +2021,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEMM_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spgemm(std::shared_ptr<const DpcppExecutor> exec,
                      matrix::view::dense<const ValueType> alpha,
-                     const matrix::Csr<ValueType, IndexType>* a,
-                     const matrix::Csr<ValueType, IndexType>* b,
+                     matrix::view::csr<const ValueType, const IndexType> a,
+                     matrix::view::csr<const ValueType, const IndexType> b,
                      matrix::view::dense<const ValueType> beta,
-                     const matrix::Csr<ValueType, IndexType>* d,
+                     matrix::view::csr<const ValueType, const IndexType> d,
                      matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto c = c_builder->get_matrix();
-    auto num_rows = a->get_size()[0];
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto b_vals = as_device_type(b->get_const_values());
+    auto num_rows = a.size[0];
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto b_cols = b.col_idxs;
+    const auto b_vals = as_device_type(b.values);
     const auto d_row_ptrs = d->get_const_row_ptrs();
     const auto d_cols = d->get_const_col_idxs();
     const auto d_vals = as_device_type(d->get_const_values());
@@ -2313,17 +2308,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void spgeam(std::shared_ptr<const DpcppExecutor> exec,
             matrix::view::dense<const ValueType> alpha,
-            const matrix::Csr<ValueType, IndexType>* a,
+            matrix::view::csr<const ValueType, const IndexType> a,
             matrix::view::dense<const ValueType> beta,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
-    const auto num_rows = a->get_size()[0];
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto b_cols = b->get_const_col_idxs();
+    const auto num_rows = a.size[0];
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto b_cols = b.col_idxs;
     auto c = c_builder->get_matrix();
     auto c_row_ptrs = c->get_row_ptrs();
     auto queue = exec->get_queue();
@@ -2359,8 +2354,8 @@ void spgeam(std::shared_ptr<const DpcppExecutor> exec,
     auto c_cols = c_col_idxs_array.get_data();
     auto c_vals = as_device_type(c_vals_array.get_data());
 
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
     const auto alpha_vals = as_device_type(alpha.values);
     const auto beta_vals = as_device_type(beta.values);
 

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -353,9 +353,8 @@ template <int items_per_thread, typename matrix_accessor,
 void merge_path_spmv(
     const IndexType num_rows, acc::range<matrix_accessor> val,
     const IndexType* __restrict__ col_idxs,
-    const IndexType* __restrict__ row_ptrs, const IndexType* __restrict__ srow,
-    acc::range<input_accessor> b, acc::range<output_accessor> c,
-    IndexType* __restrict__ row_out,
+    const IndexType* __restrict__ row_ptrs, acc::range<input_accessor> b,
+    acc::range<output_accessor> c, IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out,
     Alpha_op alpha_op, Beta_op beta_op, sycl::nd_item<3> item_ct1,
     sycl::local_accessor<IndexType, 1> shared_row_ptrs)
@@ -431,16 +430,15 @@ template <int items_per_thread, typename matrix_accessor,
 void abstract_merge_path_spmv(
     const IndexType num_rows, acc::range<matrix_accessor> val,
     const IndexType* __restrict__ col_idxs,
-    const IndexType* __restrict__ row_ptrs, const IndexType* __restrict__ srow,
-    acc::range<input_accessor> b, acc::range<output_accessor> c,
-    IndexType* __restrict__ row_out,
+    const IndexType* __restrict__ row_ptrs, acc::range<input_accessor> b,
+    acc::range<output_accessor> c, IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out,
     sycl::nd_item<3> item_ct1,
     sycl::local_accessor<IndexType, 1> shared_row_ptrs)
 {
     using type = typename output_accessor::arithmetic_type;
     merge_path_spmv<items_per_thread>(
-        num_rows, val, col_idxs, row_ptrs, srow, b, c, row_out, val_out,
+        num_rows, val, col_idxs, row_ptrs, b, c, row_out, val_out,
         [](const type& x) { return x; },
         [](const type& x) { return zero<type>(); }, item_ct1, shared_row_ptrs);
 }
@@ -450,7 +448,7 @@ template <int items_per_thread, typename matrix_accessor,
 void abstract_merge_path_spmv(
     dim3 grid, dim3 block, size_type dynamic_shared_memory, sycl::queue* queue,
     const IndexType num_rows, acc::range<matrix_accessor> val,
-    const IndexType* col_idxs, const IndexType* row_ptrs, const IndexType* srow,
+    const IndexType* col_idxs, const IndexType* row_ptrs,
     acc::range<input_accessor> b, acc::range<output_accessor> c,
     IndexType* row_out, typename output_accessor::arithmetic_type* val_out)
 {
@@ -461,7 +459,7 @@ void abstract_merge_path_spmv(
         cgh.parallel_for(sycl_nd_range(grid, block),
                          [=](sycl::nd_item<3> item_ct1) {
                              abstract_merge_path_spmv<items_per_thread>(
-                                 num_rows, val, col_idxs, row_ptrs, srow, b, c,
+                                 num_rows, val, col_idxs, row_ptrs, b, c,
                                  row_out, val_out, item_ct1, shared_row_ptrs);
                          });
     });
@@ -474,8 +472,7 @@ void abstract_merge_path_spmv(
     const IndexType num_rows,
     const typename matrix_accessor::storage_type* __restrict__ alpha,
     acc::range<matrix_accessor> val, const IndexType* __restrict__ col_idxs,
-    const IndexType* __restrict__ row_ptrs, const IndexType* __restrict__ srow,
-    acc::range<input_accessor> b,
+    const IndexType* __restrict__ row_ptrs, acc::range<input_accessor> b,
     const typename output_accessor::storage_type* __restrict__ beta,
     acc::range<output_accessor> c, IndexType* __restrict__ row_out,
     typename output_accessor::arithmetic_type* __restrict__ val_out,
@@ -487,13 +484,13 @@ void abstract_merge_path_spmv(
     const type beta_val = static_cast<type>(beta[0]);
     if (is_zero(beta_val)) {
         merge_path_spmv<items_per_thread>(
-            num_rows, val, col_idxs, row_ptrs, srow, b, c, row_out, val_out,
+            num_rows, val, col_idxs, row_ptrs, b, c, row_out, val_out,
             [&alpha_val](const type& x) { return alpha_val * x; },
             [](const type& x) { return zero<type>(); }, item_ct1,
             shared_row_ptrs);
     } else {
         merge_path_spmv<items_per_thread>(
-            num_rows, val, col_idxs, row_ptrs, srow, b, c, row_out, val_out,
+            num_rows, val, col_idxs, row_ptrs, b, c, row_out, val_out,
             [&alpha_val](const type& x) { return alpha_val * x; },
             [&beta_val](const type& x) { return beta_val * x; }, item_ct1,
             shared_row_ptrs);
@@ -507,8 +504,7 @@ void abstract_merge_path_spmv(
     const IndexType num_rows,
     const typename matrix_accessor::storage_type* alpha,
     acc::range<matrix_accessor> val, const IndexType* col_idxs,
-    const IndexType* row_ptrs, const IndexType* srow,
-    acc::range<input_accessor> b,
+    const IndexType* row_ptrs, acc::range<input_accessor> b,
     const typename output_accessor::storage_type* beta,
     acc::range<output_accessor> c, IndexType* row_out,
     typename output_accessor::arithmetic_type* val_out)
@@ -520,7 +516,7 @@ void abstract_merge_path_spmv(
         cgh.parallel_for(
             sycl_nd_range(grid, block), [=](sycl::nd_item<3> item_ct1) {
                 abstract_merge_path_spmv<items_per_thread>(
-                    num_rows, alpha, val, col_idxs, row_ptrs, srow, b, beta, c,
+                    num_rows, alpha, val, col_idxs, row_ptrs, b, beta, c,
                     row_out, val_out, item_ct1, shared_row_ptrs);
             });
     });
@@ -1260,9 +1256,8 @@ void merge_path_spmv(
                     grid, block, 0, exec->get_queue(),
                     static_cast<IndexType>(a.size[0]),
                     acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
-                    a.srow, acc::as_device_range(b_vals),
-                    acc::as_device_range(c_vals), row_out.get_data(),
-                    as_device_type(val_out.get_data()));
+                    acc::as_device_range(b_vals), acc::as_device_range(c_vals),
+                    row_out.get_data(), as_device_type(val_out.get_data()));
             }
             csr::kernel::abstract_reduce(
                 1, spmv_block_size, 0, exec->get_queue(), grid_num,
@@ -1275,10 +1270,9 @@ void merge_path_spmv(
                     grid, block, 0, exec->get_queue(),
                     static_cast<IndexType>(a.size[0]),
                     as_device_type(alpha->values), acc::as_device_range(a_vals),
-                    a.col_idxs, a.row_ptrs, a.srow,
-                    acc::as_device_range(b_vals), as_device_type(beta->values),
-                    acc::as_device_range(c_vals), row_out.get_data(),
-                    as_device_type(val_out.get_data()));
+                    a.col_idxs, a.row_ptrs, acc::as_device_range(b_vals),
+                    as_device_type(beta->values), acc::as_device_range(c_vals),
+                    row_out.get_data(), as_device_type(val_out.get_data()));
             }
             csr::kernel::abstract_reduce(
                 1, spmv_block_size, 0, exec->get_queue(), grid_num,
@@ -1365,7 +1359,8 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_classical_spmv, classical_spmv);
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 bool load_balance_spmv(
-    std::shared_ptr<const DpcppExecutor> exec,
+    std::shared_ptr<const DpcppExecutor> exec, size_type num_srow_elements,
+    const IndexType* srow,
     matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
@@ -1388,7 +1383,7 @@ bool load_balance_spmv(
         } else {
             dense::fill(exec, c, zero<OutputValueType>());
         }
-        const IndexType nwarps = a.num_srow_elements;
+        const IndexType nwarps = num_srow_elements;
         if (nwarps > 0) {
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
@@ -1404,7 +1399,7 @@ bool load_balance_spmv(
                         static_cast<IndexType>(a.size[0]),
                         as_device_type(alpha->values),
                         acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
-                        a.srow, acc::as_device_range(b_vals),
+                        srow, acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
             } else {
@@ -1413,7 +1408,7 @@ bool load_balance_spmv(
                         csr_grid, csr_block, 0, exec->get_queue(), nwarps,
                         static_cast<IndexType>(a.size[0]),
                         acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
-                        a.const_srow, acc::as_device_range(b_vals),
+                        srow, acc::as_device_range(b_vals),
                         acc::as_device_range(c_vals));
                 }
             }
@@ -1517,7 +1512,8 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const DpcppExecutor> exec,
           const matrix::csr::spmv_strategy strategy,
-          const IndexType max_nnz_per_row,
+          const IndexType max_nnz_per_row, size_type num_srow_elements,
+          const IndexType* srow,
           matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
@@ -1546,7 +1542,8 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
     } else {
         bool use_classical = true;
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
-            use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
+            use_classical = !host_kernel::load_balance_spmv(
+                exec, num_srow_elements, srow, a, b, c);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
@@ -1569,7 +1566,8 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                    const matrix::csr::spmv_strategy strategy,
-                   const IndexType max_nnz_per_row,
+                   const IndexType max_nnz_per_row, size_type num_srow_elements,
+                   const IndexType* srow,
                    matrix::view::dense<const MatrixValueType> alpha,
                    matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,
@@ -1601,8 +1599,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
     } else {
         bool use_classical = true;
         if (strategy == matrix::csr::spmv_strategy::load_balance) {
-            use_classical =
-                !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
+            use_classical = !host_kernel::load_balance_spmv(
+                exec, num_srow_elements, srow, a, b, c, alpha, beta);
         } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical =
                 !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1239,7 +1239,7 @@ void merge_path_spmv(
     array<arithmetic_type> val_out(exec, grid_num);
 
     const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a.device_view);
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -1433,11 +1433,10 @@ bool try_general_sparselib_spmv(
         oneapi::mkl::sparse::matrix_handle_t mat_handle;
         oneapi::mkl::sparse::init_matrix_handle(&mat_handle);
         oneapi::mkl::sparse::set_csr_data(
-            *exec->get_queue(), mat_handle,
-            static_cast<IndexType>(a->get_size()[0]),
-            static_cast<IndexType>(a->get_size()[1]),
+            *exec->get_queue(), mat_handle, static_cast<IndexType>(a.size[0]),
+            static_cast<IndexType>(a.size[1]),
 #if INTEL_MKL_VERSION >= 20250300
-            static_cast<std::int64_t>(a->get_num_stored_elements()),
+            static_cast<std::int64_t>(a.num_stored_elements),
 #endif
             oneapi::mkl::index_base::zero, const_cast<IndexType*>(a.row_ptrs),
             const_cast<IndexType*>(a.col_idxs),
@@ -1522,7 +1521,7 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
         // empty output: nothing to do
         return;
     }
-    if (b.size[0] == 0 || a->get_num_stored_elements() == 0) {
+    if (b.size[0] == 0 || a.num_stored_elements == 0) {
         // empty input: zero output
         dense::fill(exec, c, zero<OutputValueType>());
         return;
@@ -1578,7 +1577,7 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
         // empty output: nothing to do
         return;
     }
-    if (b.size[0] == 0 || a->get_num_stored_elements() == 0) {
+    if (b.size[0] == 0 || a.num_stored_elements == 0) {
         // empty input: scale output
         dense::scale(exec, beta, c);
         return;
@@ -1958,7 +1957,7 @@ void spgemm(std::shared_ptr<const DpcppExecutor> exec,
 
     using device_value_type = device_type<ValueType>;
     array<val_heap_element<device_value_type, IndexType>> heap_array(
-        exec, a->get_num_stored_elements());
+        exec, a.num_stored_elements);
 
     auto heap = heap_array.get_data();
     auto col_heap =
@@ -2033,9 +2032,9 @@ void advanced_spgemm(std::shared_ptr<const DpcppExecutor> exec,
     const auto b_row_ptrs = b.row_ptrs;
     const auto b_cols = b.col_idxs;
     const auto b_vals = as_device_type(b.values);
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto d_vals = as_device_type(d->get_const_values());
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto d_cols = d.col_idxs;
+    const auto d_vals = as_device_type(d.values);
     auto c_row_ptrs = c->get_row_ptrs();
     const auto alpha_vals = as_device_type(alpha.values);
     const auto beta_vals = as_device_type(beta.values);
@@ -2045,7 +2044,7 @@ void advanced_spgemm(std::shared_ptr<const DpcppExecutor> exec,
     // first sweep: count nnz for each row
     using device_value_type = device_type<ValueType>;
     array<val_heap_element<device_value_type, IndexType>> heap_array(
-        exec, a->get_num_stored_elements());
+        exec, a.num_stored_elements);
 
     auto heap = heap_array.get_data();
     auto col_heap =

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1255,8 +1255,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -1325,7 +1325,7 @@ template <int subgroup_size, typename MatrixValueType, typename InputValueType,
 void classical_spmv(
     syn::value_list<int, subgroup_size>,
     std::shared_ptr<const DpcppExecutor> exec,
-    matrix::view::csr<const MatrixValueType, const IndexType> a,
+    const matrix::Csr<MatrixValueType, IndexType>* a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1342,7 +1342,7 @@ void classical_spmv(
         exec->get_num_subgroups() * classical_oversubscription;
     const auto nsg_in_group = spmv_block_size / subgroup_size;
     const auto gridx =
-        std::min(ceildiv(a.size[0], spmv_block_size / subgroup_size),
+        std::min(ceildiv(a->get_size()[0], spmv_block_size / subgroup_size),
                  int64(num_subgroup / nsg_in_group));
     const dim3 grid(gridx, b.size[1]);
     const dim3 block(spmv_block_size);
@@ -1355,17 +1355,19 @@ void classical_spmv(
     if (!alpha && !beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subgroup_size>(
-                grid, block, 0, exec->get_queue(), a.size[0],
-                acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
-                acc::as_device_range(b_vals), acc::as_device_range(c_vals));
+                grid, block, 0, exec->get_queue(), a->get_size()[0],
+                acc::as_device_range(a_vals), a->get_const_col_idxs(),
+                a->get_const_row_ptrs(), acc::as_device_range(b_vals),
+                acc::as_device_range(c_vals));
         }
     } else if (alpha && beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subgroup_size>(
-                grid, block, 0, exec->get_queue(), a.size[0],
+                grid, block, 0, exec->get_queue(), a->get_size()[0],
                 as_device_type(alpha->values), acc::as_device_range(a_vals),
-                a.col_idxs, a.row_ptrs, acc::as_device_range(b_vals),
-                as_device_type(beta->values), acc::as_device_range(c_vals));
+                a->get_const_col_idxs(), a->get_const_row_ptrs(),
+                acc::as_device_range(b_vals), as_device_type(beta->values),
+                acc::as_device_range(c_vals));
         }
     } else {
         GKO_KERNEL_NOT_FOUND;
@@ -1406,8 +1408,7 @@ bool load_balance_spmv(
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(
-                    a->get_const_device_view());
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -1440,11 +1441,12 @@ bool load_balance_spmv(
 
 
 template <typename ValueType, typename IndexType>
-bool try_general_sparselib_spmv(
-    std::shared_ptr<const DpcppExecutor> exec, const ValueType host_alpha,
-    matrix::view::csr<const ValueType, const IndexType> a,
-    matrix::view::dense<const ValueType> b, const ValueType host_beta,
-    matrix::view::dense<ValueType> c)
+bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
+                                const ValueType host_alpha,
+                                const matrix::Csr<ValueType, IndexType>* a,
+                                matrix::view::dense<const ValueType> b,
+                                const ValueType host_beta,
+                                matrix::view::dense<ValueType> c)
 {
     constexpr bool try_sparselib =
         !is_complex<ValueType>() &&
@@ -1457,10 +1459,11 @@ bool try_general_sparselib_spmv(
 #if INTEL_MKL_VERSION >= 20240000
             *exec->get_queue(),
 #endif
-            mat_handle, IndexType(a.size[0]), IndexType(a.size[1]),
-            oneapi::mkl::index_base::zero, const_cast<IndexType*>(a.row_ptrs),
-            const_cast<IndexType*>(a.col_idxs),
-            const_cast<ValueType*>(a.values));
+            mat_handle, IndexType(a->get_size()[0]),
+            IndexType(a->get_size()[1]), oneapi::mkl::index_base::zero,
+            const_cast<IndexType*>(a->get_const_row_ptrs()),
+            const_cast<IndexType*>(a->get_const_col_idxs()),
+            const_cast<ValueType*>(a->get_const_values()));
         if (b.size[1] == 1 && b.stride == 1) {
             oneapi::mkl::sparse::gemv(
                 *exec->get_queue(), oneapi::mkl::transpose::nontrans,
@@ -1491,7 +1494,7 @@ template <typename MatrixValueType, typename InputValueType,
               !std::is_same<MatrixValueType, OutputValueType>::value>>
 bool try_sparselib_spmv(
     std::shared_ptr<const DpcppExecutor> exec,
-    matrix::view::csr<const MatrixValueType, const IndexType> a,
+    const matrix::Csr<MatrixValueType, IndexType>* a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1508,7 +1511,7 @@ bool try_sparselib_spmv(
 template <typename ValueType, typename IndexType>
 bool try_sparselib_spmv(
     std::shared_ptr<const DpcppExecutor> exec,
-    matrix::view::csr<const ValueType, const IndexType> a,
+    const matrix::Csr<ValueType, IndexType>* a,
     matrix::view::dense<const ValueType> b, matrix::view::dense<ValueType> c,
     xstd::type_identity_t<std::optional<matrix::view::dense<const ValueType>>>
         alpha = {},
@@ -1564,8 +1567,7 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -1589,8 +1591,7 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
         }
     }
 }
@@ -1637,8 +1638,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical = !host_kernel::try_sparselib_spmv(
-                exec, a->get_const_device_view(), b, c, alpha, beta);
+            use_classical =
+                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -1662,8 +1663,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec,
-                a->get_const_device_view(), b, c, alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
+                alpha, beta);
         }
     }
 }
@@ -2445,19 +2446,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const DpcppExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::dense<const ValueType> beta,
-                    matrix::view::csr<const ValueType, const IndexType> b,
+                    const matrix::Csr<ValueType, IndexType>* b,
                     matrix::view::csr<ValueType, IndexType> c)
 {
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
-    const auto num_rows = a.size[0];
-    const auto a_row_ptrs = a.row_ptrs;
-    const auto a_cols = a.col_idxs;
-    const auto a_vals = as_device_type(a.values);
-    const auto b_row_ptrs = b.row_ptrs;
-    const auto b_cols = b.col_idxs;
-    const auto b_vals = as_device_type(b.values);
+    const auto num_rows = a->get_size()[0];
+    const auto a_row_ptrs = a->get_const_row_ptrs();
+    const auto a_cols = a->get_const_col_idxs();
+    const auto a_vals = as_device_type(a->get_const_values());
+    const auto b_row_ptrs = b->get_const_row_ptrs();
+    const auto b_cols = b->get_const_col_idxs();
+    const auto b_vals = as_device_type(b->get_const_values());
     const auto c_row_ptrs = c.row_ptrs;
     const auto c_vals = as_device_type(c.values);
     const auto alpha_vals = as_device_type(alpha.values);

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1255,8 +1255,8 @@ void merge_path_spmv(
     // TODO: should we store the value in arithmetic_type or output_type?
     array<arithmetic_type> val_out(exec, grid_num);
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
 
     for (IndexType column_id = 0; column_id < b.size[1]; column_id++) {
         const auto column_span =
@@ -1325,7 +1325,7 @@ template <int subgroup_size, typename MatrixValueType, typename InputValueType,
 void classical_spmv(
     syn::value_list<int, subgroup_size>,
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1342,7 +1342,7 @@ void classical_spmv(
         exec->get_num_subgroups() * classical_oversubscription;
     const auto nsg_in_group = spmv_block_size / subgroup_size;
     const auto gridx =
-        std::min(ceildiv(a->get_size()[0], spmv_block_size / subgroup_size),
+        std::min(ceildiv(a.size[0], spmv_block_size / subgroup_size),
                  int64(num_subgroup / nsg_in_group));
     const dim3 grid(gridx, b.size[1]);
     const dim3 block(spmv_block_size);
@@ -1355,19 +1355,17 @@ void classical_spmv(
     if (!alpha && !beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subgroup_size>(
-                grid, block, 0, exec->get_queue(), a->get_size()[0],
-                acc::as_device_range(a_vals), a->get_const_col_idxs(),
-                a->get_const_row_ptrs(), acc::as_device_range(b_vals),
-                acc::as_device_range(c_vals));
+                grid, block, 0, exec->get_queue(), a.size[0],
+                acc::as_device_range(a_vals), a.col_idxs, a.row_ptrs,
+                acc::as_device_range(b_vals), acc::as_device_range(c_vals));
         }
     } else if (alpha && beta) {
         if (grid.x > 0 && grid.y > 0) {
             kernel::abstract_classical_spmv<subgroup_size>(
-                grid, block, 0, exec->get_queue(), a->get_size()[0],
+                grid, block, 0, exec->get_queue(), a.size[0],
                 as_device_type(alpha->values), acc::as_device_range(a_vals),
-                a->get_const_col_idxs(), a->get_const_row_ptrs(),
-                acc::as_device_range(b_vals), as_device_type(beta->values),
-                acc::as_device_range(c_vals));
+                a.col_idxs, a.row_ptrs, acc::as_device_range(b_vals),
+                as_device_type(beta->values), acc::as_device_range(c_vals));
         }
     } else {
         GKO_KERNEL_NOT_FOUND;
@@ -1408,7 +1406,8 @@ bool load_balance_spmv(
             const dim3 csr_block(config::warp_size, warps_in_block, 1);
             const dim3 csr_grid(ceildiv(nwarps, warps_in_block), b.size[1]);
             const auto a_vals =
-                acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+                acc::helper::build_const_rrm_accessor<arithmetic_type>(
+                    a->get_const_device_view());
             const auto b_vals =
                 acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
             auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -1441,12 +1440,11 @@ bool load_balance_spmv(
 
 
 template <typename ValueType, typename IndexType>
-bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
-                                const ValueType host_alpha,
-                                const matrix::Csr<ValueType, IndexType>* a,
-                                matrix::view::dense<const ValueType> b,
-                                const ValueType host_beta,
-                                matrix::view::dense<ValueType> c)
+bool try_general_sparselib_spmv(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType host_alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::dense<const ValueType> b, const ValueType host_beta,
+    matrix::view::dense<ValueType> c)
 {
     constexpr bool try_sparselib =
         !is_complex<ValueType>() &&
@@ -1459,11 +1457,10 @@ bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
 #if INTEL_MKL_VERSION >= 20240000
             *exec->get_queue(),
 #endif
-            mat_handle, IndexType(a->get_size()[0]),
-            IndexType(a->get_size()[1]), oneapi::mkl::index_base::zero,
-            const_cast<IndexType*>(a->get_const_row_ptrs()),
-            const_cast<IndexType*>(a->get_const_col_idxs()),
-            const_cast<ValueType*>(a->get_const_values()));
+            mat_handle, IndexType(a.size[0]), IndexType(a.size[1]),
+            oneapi::mkl::index_base::zero, const_cast<IndexType*>(a.row_ptrs),
+            const_cast<IndexType*>(a.col_idxs),
+            const_cast<ValueType*>(a.values));
         if (b.size[1] == 1 && b.stride == 1) {
             oneapi::mkl::sparse::gemv(
                 *exec->get_queue(), oneapi::mkl::transpose::nontrans,
@@ -1494,7 +1491,7 @@ template <typename MatrixValueType, typename InputValueType,
               !std::is_same<MatrixValueType, OutputValueType>::value>>
 bool try_sparselib_spmv(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<MatrixValueType, IndexType>* a,
+    matrix::view::csr<const MatrixValueType, const IndexType> a,
     matrix::view::dense<const InputValueType> b,
     matrix::view::dense<OutputValueType> c,
     xstd::type_identity_t<
@@ -1511,7 +1508,7 @@ bool try_sparselib_spmv(
 template <typename ValueType, typename IndexType>
 bool try_sparselib_spmv(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* a,
+    matrix::view::csr<const ValueType, const IndexType> a,
     matrix::view::dense<const ValueType> b, matrix::view::dense<ValueType> c,
     xstd::type_identity_t<std::optional<matrix::view::dense<const ValueType>>>
         alpha = {},
@@ -1567,7 +1564,8 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -1591,7 +1589,8 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c);
         }
     }
 }
@@ -1638,8 +1637,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
         } else if (a->get_strategy()->get_name() == "sparselib" ||
                    a->get_strategy()->get_name() == "cusparse") {
-            use_classical =
-                !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
+            use_classical = !host_kernel::try_sparselib_spmv(
+                exec, a->get_const_device_view(), b, c, alpha, beta);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
@@ -1663,8 +1662,8 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
                 [&max_length_per_row](int compiled_info) {
                     return max_length_per_row >= compiled_info;
                 },
-                syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
-                alpha, beta);
+                syn::value_list<int>(), syn::type_list<>(), exec,
+                a->get_const_device_view(), b, c, alpha, beta);
         }
     }
 }
@@ -1735,12 +1734,12 @@ GKO_ENABLE_DEFAULT_HOST(compute_submatrix_idxs_and_vals,
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
-    const auto num_rows = source->get_size()[0];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
+    const auto num_rows = source.size[0];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
     auto grid_dim = ceildiv(row_span.length(), default_block_size);
     auto block_dim = default_block_size;
 
@@ -1756,7 +1755,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
     IndexType* row_nnz) GKO_NOT_IMPLEMENTED;
@@ -1766,27 +1765,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     const auto row_offset = row_span.begin;
     const auto col_offset = col_span.begin;
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
-    const auto row_ptrs = source->get_const_row_ptrs();
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
+    const auto row_ptrs = source.row_ptrs;
 
-    const auto num_nnz = source->get_num_stored_elements();
+    const auto num_nnz = source.num_stored_elements;
     auto grid_dim = ceildiv(num_rows, default_block_size);
     auto block_dim = default_block_size;
     kernel::compute_submatrix_idxs_and_vals(
         grid_dim, block_dim, 0, exec->get_queue(), num_rows, num_cols, num_nnz,
-        row_offset, col_offset, source->get_const_row_ptrs(),
-        source->get_const_col_idxs(),
-        as_device_type(source->get_const_values()),
-        result->get_const_row_ptrs(), result->get_col_idxs(),
-        as_device_type(result->get_values()));
+        row_offset, col_offset, source.row_ptrs, source.col_idxs,
+        as_device_type(source.values), result.row_ptrs, result.col_idxs,
+        as_device_type(result.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -1796,10 +1794,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result) GKO_NOT_IMPLEMENTED;
+    matrix::view::csr<ValueType, IndexType> result) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_COMPUTE_SUB_MATRIX_FROM_INDEX_SET_KERNEL);
@@ -2208,21 +2206,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -2269,28 +2267,29 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_vals = as_device_type(c->get_values());
-    const auto d_vals = as_device_type(d->get_const_values());
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_vals = as_device_type(b.values);
+    const auto c_vals = as_device_type(c.values);
+    const auto d_vals = as_device_type(d.values);
     const auto palpha = as_device_type(alpha.values);
     const auto pbeta = as_device_type(beta.values);
     const auto lookup_storage_offsets =
@@ -2446,21 +2445,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const DpcppExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
-    const auto num_rows = a->get_size()[0];
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto a_vals = as_device_type(a->get_const_values());
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto b_vals = as_device_type(b->get_const_values());
-    const auto c_row_ptrs = c->get_row_ptrs();
-    const auto c_vals = as_device_type(c->get_values());
+    const auto num_rows = a.size[0];
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto a_vals = as_device_type(a.values);
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto b_cols = b.col_idxs;
+    const auto b_vals = as_device_type(b.values);
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto c_vals = as_device_type(c.values);
     const auto alpha_vals = as_device_type(alpha.values);
     const auto beta_vals = as_device_type(beta.values);
     auto queue = exec->get_queue();
@@ -2501,15 +2500,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const DpcppExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
     const auto num_rows = result.size[0];
     const auto num_cols = result.size[1];
     const auto stride = result.stride;
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto vals = as_device_type(source->get_const_values());
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
+    const auto vals = as_device_type(source.values);
 
     auto grid_dim = ceildiv(num_rows, default_block_size);
     kernel::fill_in_dense(grid_dim, default_block_size, 0, exec->get_queue(),
@@ -2522,10 +2521,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
-                      array<ValueType>& values) GKO_NOT_IMPLEMENTED;
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
+    array<ValueType>& values) GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_CSR_CONVERT_TO_FBCSR_KERNEL);
@@ -2533,21 +2533,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <bool conjugate, typename ValueType, typename IndexType>
 void generic_transpose(std::shared_ptr<const DpcppExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* trans)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> trans)
 {
-    const auto num_rows = orig->get_size()[0];
-    const auto num_cols = orig->get_size()[1];
+    const auto num_rows = orig.size[0];
+    const auto num_cols = orig.size[1];
     auto queue = exec->get_queue();
-    const auto row_ptrs = orig->get_const_row_ptrs();
-    const auto cols = orig->get_const_col_idxs();
-    const auto vals = as_device_type(orig->get_const_values());
+    const auto row_ptrs = orig.row_ptrs;
+    const auto cols = orig.col_idxs;
+    const auto vals = as_device_type(orig.values);
 
     array<IndexType> counts{exec, num_cols + 1};
     auto tmp_counts = counts.get_data();
-    auto out_row_ptrs = trans->get_row_ptrs();
-    auto out_cols = trans->get_col_idxs();
-    auto out_vals = as_device_type(trans->get_values());
+    auto out_row_ptrs = trans.row_ptrs;
+    auto out_cols = trans.col_idxs;
+    auto out_vals = as_device_type(trans.values);
     components::fill_array(exec, tmp_counts, num_cols, IndexType{});
 
     queue->submit([&](sycl::handler& cgh) {
@@ -2584,8 +2584,8 @@ void generic_transpose(std::shared_ptr<const DpcppExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const DpcppExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
     generic_transpose<false>(exec, orig, trans);
 }
@@ -2595,8 +2595,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_TRANSPOSE_KERNEL);
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const DpcppExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
     generic_transpose<true>(exec, orig, trans);
 }
@@ -2608,23 +2608,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const DpcppExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_symm_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), permuted->get_row_ptrs(),
-        permuted->get_col_idxs(), as_device_type(permuted->get_values()));
+        perm, orig.row_ptrs, orig.col_idxs, as_device_type(orig.values),
+        permuted.row_ptrs, permuted.col_idxs, as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2632,26 +2630,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const DpcppExecutor> exec,
-                         const IndexType* row_perm, const IndexType* col_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const IndexType* row_perm,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        row_perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, row_perm,
+                               orig.row_ptrs, permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_nonsymm_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        row_perm, col_perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        permuted->get_row_ptrs(), permuted->get_col_idxs(),
-        as_device_type(permuted->get_values()));
+        row_perm, col_perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), permuted.row_ptrs, permuted.col_idxs,
+        as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2661,24 +2658,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const DpcppExecutor> exec,
                  const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                           exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                           row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
-    row_permute_kernel(
-        copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), row_permuted->get_row_ptrs(),
-        row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+    row_permute_kernel(copy_num_blocks, default_block_size, 0,
+                       exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                       orig.col_idxs, as_device_type(orig.values),
+                       row_permuted.row_ptrs, row_permuted.col_idxs,
+                       as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2688,24 +2684,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const DpcppExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
-    inv_row_permute_kernel(
-        copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), row_permuted->get_row_ptrs(),
-        row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+    inv_row_permute_kernel(copy_num_blocks, default_block_size, 0,
+                           exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                           orig.col_idxs, as_device_type(orig.values),
+                           row_permuted.row_ptrs, row_permuted.col_idxs,
+                           as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2713,26 +2708,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_symm_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        as_device_type(scale), perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        permuted->get_row_ptrs(), permuted->get_col_idxs(),
-        as_device_type(permuted->get_values()));
+        as_device_type(scale), perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), permuted.row_ptrs, permuted.col_idxs,
+        as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2740,29 +2734,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        row_perm, orig->get_const_row_ptrs(), permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, permuted->get_row_ptrs(),
-                                       num_rows + 1);
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, row_perm,
+                               orig.row_ptrs, permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, permuted.row_ptrs, num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_nonsymm_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
         as_device_type(row_scale), row_perm, as_device_type(col_scale),
-        col_perm, orig->get_const_row_ptrs(), orig->get_const_col_idxs(),
-        as_device_type(orig->get_const_values()), permuted->get_row_ptrs(),
-        permuted->get_col_idxs(), as_device_type(permuted->get_values()));
+        col_perm, orig.row_ptrs, orig.col_idxs, as_device_type(orig.values),
+        permuted.row_ptrs, permuted.col_idxs, as_device_type(permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2772,24 +2763,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                           exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                           row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     row_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        as_device_type(scale), perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+        as_device_type(scale), perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), row_permuted.row_ptrs,
+        row_permuted.col_idxs, as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2797,26 +2787,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const DpcppExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const DpcppExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto num_rows = orig->get_size()[0];
+    auto num_rows = orig.size[0];
     auto count_num_blocks = ceildiv(num_rows, default_block_size);
-    inv_row_ptr_permute_kernel(
-        count_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        perm, orig->get_const_row_ptrs(), row_permuted->get_row_ptrs());
-    components::prefix_sum_nonnegative(exec, row_permuted->get_row_ptrs(),
+    inv_row_ptr_permute_kernel(count_num_blocks, default_block_size, 0,
+                               exec->get_queue(), num_rows, perm, orig.row_ptrs,
+                               row_permuted.row_ptrs);
+    components::prefix_sum_nonnegative(exec, row_permuted.row_ptrs,
                                        num_rows + 1);
     auto copy_num_blocks =
         ceildiv(num_rows, default_block_size / config::warp_size);
     inv_row_scale_permute_kernel(
         copy_num_blocks, default_block_size, 0, exec->get_queue(), num_rows,
-        as_device_type(scale), perm, orig->get_const_row_ptrs(),
-        orig->get_const_col_idxs(), as_device_type(orig->get_const_values()),
-        row_permuted->get_row_ptrs(), row_permuted->get_col_idxs(),
-        as_device_type(row_permuted->get_values()));
+        as_device_type(scale), perm, orig.row_ptrs, orig.col_idxs,
+        as_device_type(orig.values), row_permuted.row_ptrs,
+        row_permuted.col_idxs, as_device_type(row_permuted.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
@@ -2825,12 +2815,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const DpcppExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    const auto num_rows = to_sort->get_size()[0];
-    const auto row_ptrs = to_sort->get_const_row_ptrs();
-    auto cols = to_sort->get_col_idxs();
-    auto vals = as_device_type(to_sort->get_values());
+    const auto num_rows = to_sort.size[0];
+    const auto row_ptrs = to_sort.row_ptrs;
+    auto cols = to_sort.col_idxs;
+    auto vals = as_device_type(to_sort.values);
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx) {
             const auto row = static_cast<size_type>(idx[0]);
@@ -2884,12 +2874,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const DpcppExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
     array<bool> is_sorted_device_array{exec, {true}};
-    const auto num_rows = to_check->get_size()[0];
-    const auto row_ptrs = to_check->get_const_row_ptrs();
-    const auto cols = to_check->get_const_col_idxs();
+    const auto num_rows = to_check.size[0];
+    const auto row_ptrs = to_check.row_ptrs;
+    const auto cols = to_check.col_idxs;
     auto is_sorted_device = is_sorted_device_array.get_data();
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<1>{num_rows}, [=](sycl::id<1> idx) {
@@ -2915,17 +2906,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const DpcppExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto nnz = orig->get_num_stored_elements();
+    const auto nnz = orig.num_stored_elements;
     const auto diag_size = diag->get_size()[0];
     const auto num_blocks =
         ceildiv(config::warp_size * diag_size, default_block_size);
 
-    const auto orig_values = as_device_type(orig->get_const_values());
-    const auto orig_row_ptrs = orig->get_const_row_ptrs();
-    const auto orig_col_idxs = orig->get_const_col_idxs();
+    const auto orig_values = as_device_type(orig.values);
+    const auto orig_row_ptrs = orig.row_ptrs;
+    const auto orig_col_idxs = orig.col_idxs;
     auto diag_values = as_device_type(diag->get_values());
 
     kernel::extract_diagonal(num_blocks, default_block_size, 0,
@@ -2937,20 +2928,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_EXTRACT_DIAGONAL);
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const DpcppExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const DpcppExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
-    const auto num_diag = static_cast<IndexType>(
-        std::min(mtx->get_size()[0], mtx->get_size()[1]));
+    const auto num_diag =
+        static_cast<IndexType>(std::min(mtx.size[0], mtx.size[1]));
     if (num_diag > 0) {
         const IndexType num_blocks =
             ceildiv(num_diag, default_block_size / config::warp_size);
         array<bool> has_diags(exec, {true});
         kernel::check_diagonal_entries(
             num_blocks, default_block_size, 0, exec->get_queue(), num_diag,
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            has_diags.get_data());
+            mtx.row_ptrs, mtx.col_idxs, has_diags.get_data());
         has_all_diags = get_element(has_diags, 0);
     } else {
         has_all_diags = true;
@@ -2965,19 +2956,19 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const DpcppExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = mtx->get_size()[0];
+    const auto nrows = mtx.size[0];
     if (nrows == 0) {
         return;
     }
     const auto nthreads = nrows * config::warp_size;
     const auto nblocks = ceildiv(nthreads, default_block_size);
-    kernel::add_scaled_identity(
-        nblocks, default_block_size, 0, exec->get_queue(),
-        as_device_type(alpha.values), as_device_type(beta.values),
-        static_cast<IndexType>(nrows), mtx->get_const_row_ptrs(),
-        mtx->get_const_col_idxs(), as_device_type(mtx->get_values()));
+    kernel::add_scaled_identity(nblocks, default_block_size, 0,
+                                exec->get_queue(), as_device_type(alpha.values),
+                                as_device_type(beta.values),
+                                static_cast<IndexType>(nrows), mtx.row_ptrs,
+                                mtx.col_idxs, as_device_type(mtx.values));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -301,16 +301,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
     const auto in_vals = as_device_type(source.values);
     const auto stride = source.stride;
 
-    const auto row_ptrs = result->get_const_row_ptrs();
-    auto cols = result->get_col_idxs();
-    auto vals = as_device_type(result->get_values());
+    const auto row_ptrs = result.row_ptrs;
+    auto cols = result.col_idxs;
+    auto vals = as_device_type(result.values);
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(num_rows, [=](sycl::item<1> item) {

--- a/dpcpp/matrix/dense_kernels.dp.cpp
+++ b/dpcpp/matrix/dense_kernels.dp.cpp
@@ -314,16 +314,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    const auto num_rows = result->get_size()[0];
-    const auto num_cols = result->get_size()[1];
+    const auto num_rows = result.size[0];
+    const auto num_cols = result.size[1];
     const auto in_vals = as_device_type(source.values);
     const auto stride = source.stride;
 
-    const auto row_ptrs = result->get_const_row_ptrs();
-    auto cols = result->get_col_idxs();
-    auto vals = as_device_type(result->get_values());
+    const auto row_ptrs = result.row_ptrs;
+    auto cols = result.col_idxs;
+    auto vals = as_device_type(result.values);
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(num_rows, [=](sycl::item<1> item) {

--- a/dpcpp/matrix/diagonal_kernels.dp.cpp
+++ b/dpcpp/matrix/diagonal_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -68,14 +68,13 @@ GKO_ENABLE_DEFAULT_HOST(apply_to_csr, apply_to_csr);
 template <typename ValueType, typename IndexType>
 void apply_to_csr(std::shared_ptr<const DpcppExecutor> exec,
                   const matrix::Diagonal<ValueType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
-                  matrix::Csr<ValueType, IndexType>* c, bool inverse)
+                  matrix::view::csr<const ValueType, const IndexType> b,
+                  matrix::view::csr<ValueType, IndexType> c, bool inverse)
 {
-    const auto num_rows = b->get_size()[0];
+    const auto num_rows = b.size[0];
     const auto diag_values = as_device_type(a->get_const_values());
-    c->copy_from(b);
-    auto csr_values = as_device_type(c->get_values());
-    const auto csr_row_ptrs = c->get_const_row_ptrs();
+    auto csr_values = as_device_type(c.values);
+    const auto csr_row_ptrs = c.row_ptrs;
 
     const auto grid_dim =
         ceildiv(num_rows * config::warp_size, default_block_size);

--- a/dpcpp/matrix/fbcsr_kernels.dp.cpp
+++ b/dpcpp/matrix/fbcsr_kernels.dp.cpp
@@ -70,7 +70,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(const std::shared_ptr<const DpcppExecutor> exec,
                     const matrix::Fbcsr<ValueType, IndexType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
     GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/preconditioner/batch_jacobi_kernels.dp.cpp
+++ b/dpcpp/preconditioner/batch_jacobi_kernels.dp.cpp
@@ -74,12 +74,12 @@ GKO_INSTANTIATE_FOR_INT32_TYPE(
 template <typename ValueType, typename IndexType>
 void extract_common_blocks_pattern(
     std::shared_ptr<const DefaultExecutor> exec,
-    const gko::matrix::Csr<ValueType, IndexType>* first_sys_csr,
+    matrix::view::csr<const ValueType, const IndexType> first_sys_csr,
     const size_type num_blocks, const IndexType* cumulative_block_storage,
     const IndexType* block_pointers, const IndexType* map_block_row,
     IndexType* blocks_pattern)
 {
-    const auto nrows = first_sys_csr->get_size()[0];
+    const auto nrows = first_sys_csr.size[0];
     constexpr int subgroup_size = config::warp_size;
     auto device = exec->get_queue()->get_device();
     auto group_size =
@@ -88,8 +88,8 @@ void extract_common_blocks_pattern(
     const dim3 block(group_size);
     const dim3 grid(ceildiv(nrows * subgroup_size, group_size));
 
-    const auto row_ptrs = first_sys_csr->get_const_row_ptrs();
-    const auto col_idxs = first_sys_csr->get_const_col_idxs();
+    const auto row_ptrs = first_sys_csr.row_ptrs;
+    const auto col_idxs = first_sys_csr.col_idxs;
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(

--- a/dpcpp/preconditioner/batch_jacobi_kernels.dp.cpp
+++ b/dpcpp/preconditioner/batch_jacobi_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -74,12 +74,12 @@ GKO_INSTANTIATE_FOR_INT32_TYPE(
 template <typename ValueType, typename IndexType>
 void extract_common_blocks_pattern(
     std::shared_ptr<const DefaultExecutor> exec,
-    const gko::matrix::Csr<ValueType, IndexType>* first_sys_csr,
+    matrix::view::csr<const ValueType, const IndexType> first_sys_csr,
     const size_type num_blocks, const IndexType* cumulative_block_storage,
     const IndexType* block_pointers, const IndexType* map_block_row,
     IndexType* blocks_pattern)
 {
-    const auto nrows = first_sys_csr->get_size()[0];
+    const auto nrows = first_sys_csr.size[0];
     constexpr int subgroup_size = config::warp_size;
     auto device = exec->get_queue()->get_device();
     auto group_size =
@@ -88,8 +88,8 @@ void extract_common_blocks_pattern(
     const dim3 block(group_size);
     const dim3 grid(ceildiv(nrows * subgroup_size, group_size));
 
-    const auto row_ptrs = first_sys_csr->get_const_row_ptrs();
-    const auto col_idxs = first_sys_csr->get_const_col_idxs();
+    const auto row_ptrs = first_sys_csr.row_ptrs;
+    const auto col_idxs = first_sys_csr.col_idxs;
 
     exec->get_queue()->submit([&](sycl::handler& cgh) {
         cgh.parallel_for(

--- a/dpcpp/preconditioner/isai_kernels.dp.cpp
+++ b/dpcpp/preconditioner/isai_kernels.dp.cpp
@@ -608,13 +608,13 @@ void copy_excess_solution(dim3 grid, dim3 block,
 
 
 template <typename ValueType, typename IndexType>
-void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                          const matrix::Csr<ValueType, IndexType>* input,
-                          matrix::Csr<ValueType, IndexType>* inverse,
-                          IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs,
-                          bool lower)
+void generate_tri_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> inverse, IndexType* excess_rhs_ptrs,
+    IndexType* excess_nz_ptrs, bool lower)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(num_rows, block / subwarp_size);
@@ -622,21 +622,17 @@ void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
         if (lower) {
             kernel::generate_l_inverse<subwarp_size, subwarps_per_block>(
                 grid, block, 0, exec->get_queue(),
-                static_cast<IndexType>(num_rows), input->get_const_row_ptrs(),
-                input->get_const_col_idxs(),
-                as_device_type(input->get_const_values()),
-                inverse->get_row_ptrs(), inverse->get_col_idxs(),
-                as_device_type(inverse->get_values()), excess_rhs_ptrs,
-                excess_nz_ptrs);
+                static_cast<IndexType>(num_rows), input.row_ptrs,
+                input.col_idxs, as_device_type(input.values), inverse.row_ptrs,
+                inverse.col_idxs, as_device_type(inverse.values),
+                excess_rhs_ptrs, excess_nz_ptrs);
         } else {
             kernel::generate_u_inverse<subwarp_size, subwarps_per_block>(
                 grid, block, 0, exec->get_queue(),
-                static_cast<IndexType>(num_rows), input->get_const_row_ptrs(),
-                input->get_const_col_idxs(),
-                as_device_type(input->get_const_values()),
-                inverse->get_row_ptrs(), inverse->get_col_idxs(),
-                as_device_type(inverse->get_values()), excess_rhs_ptrs,
-                excess_nz_ptrs);
+                static_cast<IndexType>(num_rows), input.row_ptrs,
+                input.col_idxs, as_device_type(input.values), inverse.row_ptrs,
+                inverse.col_idxs, as_device_type(inverse.values),
+                excess_rhs_ptrs, excess_nz_ptrs);
         }
     }
     components::prefix_sum_nonnegative(exec, excess_rhs_ptrs, num_rows + 1);
@@ -648,22 +644,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_general_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                              const matrix::Csr<ValueType, IndexType>* input,
-                              matrix::Csr<ValueType, IndexType>* inverse,
-                              IndexType* excess_rhs_ptrs,
-                              IndexType* excess_nz_ptrs, bool spd)
+void generate_general_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> inverse, IndexType* excess_rhs_ptrs,
+    IndexType* excess_nz_ptrs, bool spd)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(num_rows, block / subwarp_size);
     if (grid > 0) {
         kernel::generate_general_inverse<subwarp_size, subwarps_per_block>(
             grid, block, 0, exec->get_queue(), static_cast<IndexType>(num_rows),
-            input->get_const_row_ptrs(), input->get_const_col_idxs(),
-            as_device_type(input->get_const_values()), inverse->get_row_ptrs(),
-            inverse->get_col_idxs(), as_device_type(inverse->get_values()),
+            input.row_ptrs, input.col_idxs, as_device_type(input.values),
+            inverse.row_ptrs, inverse.col_idxs, as_device_type(inverse.values),
             excess_rhs_ptrs, excess_nz_ptrs, spd);
     }
     components::prefix_sum_nonnegative(exec, excess_rhs_ptrs, num_rows + 1);
@@ -675,28 +670,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_excess_system(std::shared_ptr<const DefaultExecutor> exec,
-                            const matrix::Csr<ValueType, IndexType>* input,
-                            const matrix::Csr<ValueType, IndexType>* inverse,
-                            const IndexType* excess_rhs_ptrs,
-                            const IndexType* excess_nz_ptrs,
-                            matrix::Csr<ValueType, IndexType>* excess_system,
-                            matrix::view::dense<ValueType> excess_rhs,
-                            size_type e_start, size_type e_end)
+void generate_excess_system(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<const ValueType, const IndexType> inverse,
+    const IndexType* excess_rhs_ptrs, const IndexType* excess_nz_ptrs,
+    matrix::view::csr<ValueType, IndexType> excess_system,
+    matrix::view::dense<ValueType> excess_rhs, size_type e_start,
+    size_type e_end)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(e_end - e_start, block / subwarp_size);
     if (grid > 0) {
         kernel::generate_excess_system<subwarp_size>(
             grid, block, 0, exec->get_queue(), static_cast<IndexType>(num_rows),
-            input->get_const_row_ptrs(), input->get_const_col_idxs(),
-            as_device_type(input->get_const_values()),
-            inverse->get_const_row_ptrs(), inverse->get_const_col_idxs(),
-            excess_rhs_ptrs, excess_nz_ptrs, excess_system->get_row_ptrs(),
-            excess_system->get_col_idxs(),
-            as_device_type(excess_system->get_values()),
+            input.row_ptrs, input.col_idxs, as_device_type(input.values),
+            inverse.row_ptrs, inverse.col_idxs, excess_rhs_ptrs, excess_nz_ptrs,
+            excess_system.row_ptrs, excess_system.col_idxs,
+            as_device_type(excess_system.values),
             as_device_type(excess_rhs.values), e_start, e_end);
     }
 }
@@ -729,19 +722,19 @@ void scatter_excess_solution(
     std::shared_ptr<const DefaultExecutor> exec,
     const IndexType* excess_rhs_ptrs,
     matrix::view::dense<const ValueType> excess_solution,
-    matrix::Csr<ValueType, IndexType>* inverse, size_type e_start,
+    matrix::view::csr<ValueType, IndexType> inverse, size_type e_start,
     size_type e_end)
 {
-    const auto num_rows = inverse->get_size()[0];
+    const auto num_rows = inverse.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(e_end - e_start, block / subwarp_size);
     if (grid > 0) {
         kernel::copy_excess_solution<subwarp_size>(
             grid, block, 0, exec->get_queue(), static_cast<IndexType>(num_rows),
-            inverse->get_const_row_ptrs(), excess_rhs_ptrs,
+            inverse.row_ptrs, excess_rhs_ptrs,
             as_device_type(excess_solution.values),
-            as_device_type(inverse->get_values()), e_start, e_end);
+            as_device_type(inverse.values), e_start, e_end);
     }
 }
 

--- a/dpcpp/preconditioner/isai_kernels.dp.cpp
+++ b/dpcpp/preconditioner/isai_kernels.dp.cpp
@@ -617,13 +617,13 @@ void copy_excess_solution(dim3 grid, dim3 block,
 
 
 template <typename ValueType, typename IndexType>
-void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                          const matrix::Csr<ValueType, IndexType>* input,
-                          matrix::Csr<ValueType, IndexType>* inverse,
-                          IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs,
-                          bool lower)
+void generate_tri_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> inverse, IndexType* excess_rhs_ptrs,
+    IndexType* excess_nz_ptrs, bool lower)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(num_rows, block / subwarp_size);
@@ -631,21 +631,17 @@ void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
         if (lower) {
             kernel::generate_l_inverse<subwarp_size, subwarps_per_block>(
                 grid, block, 0, exec->get_queue(),
-                static_cast<IndexType>(num_rows), input->get_const_row_ptrs(),
-                input->get_const_col_idxs(),
-                as_device_type(input->get_const_values()),
-                inverse->get_row_ptrs(), inverse->get_col_idxs(),
-                as_device_type(inverse->get_values()), excess_rhs_ptrs,
-                excess_nz_ptrs);
+                static_cast<IndexType>(num_rows), input.row_ptrs,
+                input.col_idxs, as_device_type(input.values), inverse.row_ptrs,
+                inverse.col_idxs, as_device_type(inverse.values),
+                excess_rhs_ptrs, excess_nz_ptrs);
         } else {
             kernel::generate_u_inverse<subwarp_size, subwarps_per_block>(
                 grid, block, 0, exec->get_queue(),
-                static_cast<IndexType>(num_rows), input->get_const_row_ptrs(),
-                input->get_const_col_idxs(),
-                as_device_type(input->get_const_values()),
-                inverse->get_row_ptrs(), inverse->get_col_idxs(),
-                as_device_type(inverse->get_values()), excess_rhs_ptrs,
-                excess_nz_ptrs);
+                static_cast<IndexType>(num_rows), input.row_ptrs,
+                input.col_idxs, as_device_type(input.values), inverse.row_ptrs,
+                inverse.col_idxs, as_device_type(inverse.values),
+                excess_rhs_ptrs, excess_nz_ptrs);
         }
     }
     components::prefix_sum_nonnegative(exec, excess_rhs_ptrs, num_rows + 1);
@@ -657,22 +653,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_general_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                              const matrix::Csr<ValueType, IndexType>* input,
-                              matrix::Csr<ValueType, IndexType>* inverse,
-                              IndexType* excess_rhs_ptrs,
-                              IndexType* excess_nz_ptrs, bool spd)
+void generate_general_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<ValueType, IndexType> inverse, IndexType* excess_rhs_ptrs,
+    IndexType* excess_nz_ptrs, bool spd)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(num_rows, block / subwarp_size);
     if (grid > 0) {
         kernel::generate_general_inverse<subwarp_size, subwarps_per_block>(
             grid, block, 0, exec->get_queue(), static_cast<IndexType>(num_rows),
-            input->get_const_row_ptrs(), input->get_const_col_idxs(),
-            as_device_type(input->get_const_values()), inverse->get_row_ptrs(),
-            inverse->get_col_idxs(), as_device_type(inverse->get_values()),
+            input.row_ptrs, input.col_idxs, as_device_type(input.values),
+            inverse.row_ptrs, inverse.col_idxs, as_device_type(inverse.values),
             excess_rhs_ptrs, excess_nz_ptrs, spd);
     }
     components::prefix_sum_nonnegative(exec, excess_rhs_ptrs, num_rows + 1);
@@ -684,28 +679,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_excess_system(std::shared_ptr<const DefaultExecutor> exec,
-                            const matrix::Csr<ValueType, IndexType>* input,
-                            const matrix::Csr<ValueType, IndexType>* inverse,
-                            const IndexType* excess_rhs_ptrs,
-                            const IndexType* excess_nz_ptrs,
-                            matrix::Csr<ValueType, IndexType>* excess_system,
-                            matrix::view::dense<ValueType> excess_rhs,
-                            size_type e_start, size_type e_end)
+void generate_excess_system(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<const ValueType, const IndexType> inverse,
+    const IndexType* excess_rhs_ptrs, const IndexType* excess_nz_ptrs,
+    matrix::view::csr<ValueType, IndexType> excess_system,
+    matrix::view::dense<ValueType> excess_rhs, size_type e_start,
+    size_type e_end)
 {
-    const auto num_rows = input->get_size()[0];
+    const auto num_rows = input.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(e_end - e_start, block / subwarp_size);
     if (grid > 0) {
         kernel::generate_excess_system<subwarp_size>(
             grid, block, 0, exec->get_queue(), static_cast<IndexType>(num_rows),
-            input->get_const_row_ptrs(), input->get_const_col_idxs(),
-            as_device_type(input->get_const_values()),
-            inverse->get_const_row_ptrs(), inverse->get_const_col_idxs(),
-            excess_rhs_ptrs, excess_nz_ptrs, excess_system->get_row_ptrs(),
-            excess_system->get_col_idxs(),
-            as_device_type(excess_system->get_values()),
+            input.row_ptrs, input.col_idxs, as_device_type(input.values),
+            inverse.row_ptrs, inverse.col_idxs, excess_rhs_ptrs, excess_nz_ptrs,
+            excess_system.row_ptrs, excess_system.col_idxs,
+            as_device_type(excess_system.values),
             as_device_type(excess_rhs.values), e_start, e_end);
     }
 }
@@ -738,19 +731,19 @@ void scatter_excess_solution(
     std::shared_ptr<const DefaultExecutor> exec,
     const IndexType* excess_rhs_ptrs,
     matrix::view::dense<const ValueType> excess_solution,
-    matrix::Csr<ValueType, IndexType>* inverse, size_type e_start,
+    matrix::view::csr<ValueType, IndexType> inverse, size_type e_start,
     size_type e_end)
 {
-    const auto num_rows = inverse->get_size()[0];
+    const auto num_rows = inverse.size[0];
 
     const auto block = default_block_size;
     const auto grid = ceildiv(e_end - e_start, block / subwarp_size);
     if (grid > 0) {
         kernel::copy_excess_solution<subwarp_size>(
             grid, block, 0, exec->get_queue(), static_cast<IndexType>(num_rows),
-            inverse->get_const_row_ptrs(), excess_rhs_ptrs,
+            inverse.row_ptrs, excess_rhs_ptrs,
             as_device_type(excess_solution.values),
-            as_device_type(inverse->get_values()), e_start, e_end);
+            as_device_type(inverse.values), e_start, e_end);
     }
 }
 

--- a/dpcpp/preconditioner/jacobi_generate_instantiate.inc.dp.cpp
+++ b/dpcpp/preconditioner/jacobi_generate_instantiate.inc.dp.cpp
@@ -342,7 +342,7 @@ template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
 void generate(syn::value_list<int, max_block_size>,
               std::shared_ptr<const DefaultExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* mtx,
+              matrix::view::csr<const ValueType, const IndexType> mtx,
               remove_complex<ValueType> accuracy, ValueType* block_data,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&
                   storage_scheme,
@@ -359,31 +359,29 @@ void generate(syn::value_list<int, max_block_size>,
     if (block_precisions) {
         kernel::adaptive_generate<max_block_size, subwarp_size,
                                   warps_per_block>(
-            grid_size, block_size, 0, exec->get_queue(), mtx->get_size()[0],
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            as_device_type(mtx->get_const_values()), as_device_type(accuracy),
-            as_device_type(block_data), storage_scheme,
-            as_device_type(conditioning), block_precisions, block_ptrs,
-            num_blocks);
+            grid_size, block_size, 0, exec->get_queue(), mtx.size[0],
+            mtx.row_ptrs, mtx.col_idxs, as_device_type(mtx.values),
+            as_device_type(accuracy), as_device_type(block_data),
+            storage_scheme, as_device_type(conditioning), block_precisions,
+            block_ptrs, num_blocks);
     } else {
         kernel::generate<max_block_size, subwarp_size, warps_per_block>(
-            grid_size, block_size, 0, exec->get_queue(), mtx->get_size()[0],
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            as_device_type(mtx->get_const_values()), as_device_type(block_data),
-            storage_scheme, block_ptrs, num_blocks);
+            grid_size, block_size, 0, exec->get_queue(), mtx.size[0],
+            mtx.row_ptrs, mtx.col_idxs, as_device_type(mtx.values),
+            as_device_type(block_data), storage_scheme, block_ptrs, num_blocks);
     }
 }
 
 
-#define DECLARE_JACOBI_GENERATE_INSTANTIATION(ValueType, IndexType)          \
-    void generate<config::min_warps_per_block, GKO_JACOBI_BLOCK_SIZE,        \
-                  ValueType, IndexType>(                                     \
-        syn::value_list<int, GKO_JACOBI_BLOCK_SIZE>,                         \
-        std::shared_ptr<const DefaultExecutor>,                              \
-        const matrix::Csr<ValueType, IndexType>*, remove_complex<ValueType>, \
-        ValueType*,                                                          \
-        const preconditioner::block_interleaved_storage_scheme<IndexType>&,  \
-        remove_complex<ValueType>*, precision_reduction*, const IndexType*,  \
+#define DECLARE_JACOBI_GENERATE_INSTANTIATION(ValueType, IndexType)         \
+    void generate<config::min_warps_per_block, GKO_JACOBI_BLOCK_SIZE,       \
+                  ValueType, IndexType>(                                    \
+        syn::value_list<int, GKO_JACOBI_BLOCK_SIZE>,                        \
+        std::shared_ptr<const DefaultExecutor>,                             \
+        matrix::view::csr<const ValueType, const IndexType>,                \
+        remove_complex<ValueType>, ValueType*,                              \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>&, \
+        remove_complex<ValueType>*, precision_reduction*, const IndexType*, \
         size_type)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/preconditioner/jacobi_generate_instantiate.inc.dp.cpp
+++ b/dpcpp/preconditioner/jacobi_generate_instantiate.inc.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -348,7 +348,7 @@ template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
 void generate(syn::value_list<int, max_block_size>,
               std::shared_ptr<const DefaultExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* mtx,
+              matrix::view::csr<const ValueType, const IndexType> mtx,
               remove_complex<ValueType> accuracy, ValueType* block_data,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&
                   storage_scheme,
@@ -365,31 +365,29 @@ void generate(syn::value_list<int, max_block_size>,
     if (block_precisions) {
         kernel::adaptive_generate<max_block_size, subwarp_size,
                                   warps_per_block>(
-            grid_size, block_size, 0, exec->get_queue(), mtx->get_size()[0],
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            as_device_type(mtx->get_const_values()), as_device_type(accuracy),
-            as_device_type(block_data), storage_scheme,
-            as_device_type(conditioning), block_precisions, block_ptrs,
-            num_blocks);
+            grid_size, block_size, 0, exec->get_queue(), mtx.size[0],
+            mtx.row_ptrs, mtx.col_idxs, as_device_type(mtx.values),
+            as_device_type(accuracy), as_device_type(block_data),
+            storage_scheme, as_device_type(conditioning), block_precisions,
+            block_ptrs, num_blocks);
     } else {
         kernel::generate<max_block_size, subwarp_size, warps_per_block>(
-            grid_size, block_size, 0, exec->get_queue(), mtx->get_size()[0],
-            mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-            as_device_type(mtx->get_const_values()), as_device_type(block_data),
-            storage_scheme, block_ptrs, num_blocks);
+            grid_size, block_size, 0, exec->get_queue(), mtx.size[0],
+            mtx.row_ptrs, mtx.col_idxs, as_device_type(mtx.values),
+            as_device_type(block_data), storage_scheme, block_ptrs, num_blocks);
     }
 }
 
 
-#define DECLARE_JACOBI_GENERATE_INSTANTIATION(ValueType, IndexType)          \
-    void generate<config::min_warps_per_block, GKO_JACOBI_BLOCK_SIZE,        \
-                  ValueType, IndexType>(                                     \
-        syn::value_list<int, GKO_JACOBI_BLOCK_SIZE>,                         \
-        std::shared_ptr<const DefaultExecutor>,                              \
-        const matrix::Csr<ValueType, IndexType>*, remove_complex<ValueType>, \
-        ValueType*,                                                          \
-        const preconditioner::block_interleaved_storage_scheme<IndexType>&,  \
-        remove_complex<ValueType>*, precision_reduction*, const IndexType*,  \
+#define DECLARE_JACOBI_GENERATE_INSTANTIATION(ValueType, IndexType)         \
+    void generate<config::min_warps_per_block, GKO_JACOBI_BLOCK_SIZE,       \
+                  ValueType, IndexType>(                                    \
+        syn::value_list<int, GKO_JACOBI_BLOCK_SIZE>,                        \
+        std::shared_ptr<const DefaultExecutor>,                             \
+        matrix::view::csr<const ValueType, const IndexType>,                \
+        remove_complex<ValueType>, ValueType*,                              \
+        const preconditioner::block_interleaved_storage_scheme<IndexType>&, \
+        remove_complex<ValueType>*, precision_reduction*, const IndexType*, \
         size_type)
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/preconditioner/jacobi_generate_kernel.dp.cpp
+++ b/dpcpp/preconditioner/jacobi_generate_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -26,7 +26,7 @@ template <int warps_per_block, int max_block_size, typename ValueType,
           typename IndexType>
 void generate(syn::value_list<int, max_block_size>,
               std::shared_ptr<const DefaultExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* mtx,
+              matrix::view::csr<const ValueType, const IndexType> mtx,
               remove_complex<ValueType> accuracy, ValueType* block_data,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&
                   storage_scheme,
@@ -39,7 +39,7 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_generate, generate);
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const DpcppExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* system_matrix,
+              matrix::view::csr<const ValueType, const IndexType> system_matrix,
               size_type num_blocks, uint32 max_block_size,
               remove_complex<ValueType> accuracy,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&

--- a/dpcpp/preconditioner/jacobi_kernels.dp.cpp
+++ b/dpcpp/preconditioner/jacobi_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -318,24 +318,23 @@ void adaptive_transpose_jacobi(
 
 
 template <typename ValueType, typename IndexType>
-size_type find_natural_blocks(std::shared_ptr<const DefaultExecutor> exec,
-                              const matrix::Csr<ValueType, IndexType>* mtx,
-                              int32 max_block_size,
-                              IndexType* __restrict__ block_ptrs)
+size_type find_natural_blocks(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    int32 max_block_size, IndexType* __restrict__ block_ptrs)
 {
     array<size_type> nums(exec, 1);
 
-    array<bool> matching_next_row(exec, mtx->get_size()[0] - 1);
+    array<bool> matching_next_row(exec, mtx.size[0] - 1);
 
     const dim3 block_size(config::warp_size, 1, 1);
-    const dim3 grid_size(
-        ceildiv(mtx->get_size()[0] * config::warp_size, block_size.x), 1, 1);
+    const dim3 grid_size(ceildiv(mtx.size[0] * config::warp_size, block_size.x),
+                         1, 1);
     compare_adjacent_rows(grid_size, block_size, 0, exec->get_queue(),
-                          mtx->get_size()[0], max_block_size,
-                          mtx->get_const_row_ptrs(), mtx->get_const_col_idxs(),
-                          matching_next_row.get_data());
+                          mtx.size[0], max_block_size, mtx.row_ptrs,
+                          mtx.col_idxs, matching_next_row.get_data());
     generate_natural_block_pointer(
-        1, 1, 0, exec->get_queue(), mtx->get_size()[0], max_block_size,
+        1, 1, 0, exec->get_queue(), mtx.size[0], max_block_size,
         matching_next_row.get_const_data(), block_ptrs, nums.get_data());
     nums.set_executor(exec->get_master());
     return nums.get_const_data()[0];
@@ -378,10 +377,11 @@ void initialize_precisions(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void find_blocks(std::shared_ptr<const DefaultExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* system_matrix,
-                 uint32 max_block_size, size_type& num_blocks,
-                 array<IndexType>& block_pointers)
+void find_blocks(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    uint32 max_block_size, size_type& num_blocks,
+    array<IndexType>& block_pointers)
 {
     auto num_natural_blocks = find_natural_blocks(
         exec, system_matrix, max_block_size, block_pointers.get_data());

--- a/dpcpp/preconditioner/sor_kernels.dp.cpp
+++ b/dpcpp/preconditioner/sor_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,22 +21,23 @@ constexpr int default_block_size{256};
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const dim3 block_size{default_block_size, 1, 1};
     const dim3 grid_dim{static_cast<uint32>(ceildiv(
                             num_rows, static_cast<size_type>(block_size.x))),
                         1, 1};
 
     auto inv_weight = one(weight) / weight;
-    const auto in_row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto in_col_idxs = system_matrix->get_const_col_idxs();
-    const auto in_values = system_matrix->get_const_values();
-    const auto l_row_ptrs = l_mtx->get_const_row_ptrs();
-    const auto l_col_idxs = l_mtx->get_col_idxs();
-    const auto l_values = l_mtx->get_values();
+    const auto in_row_ptrs = system_matrix.row_ptrs;
+    const auto in_col_idxs = system_matrix.col_idxs;
+    const auto in_values = system_matrix.values;
+    const auto l_row_ptrs = l_mtx.row_ptrs;
+    const auto l_col_idxs = l_mtx.col_idxs;
+    const auto l_values = l_mtx.values;
 
     exec->get_queue()->parallel_for(
         sycl_nd_range(grid_dim, block_size), [=](sycl::nd_item<3> item_ct1) {
@@ -57,11 +58,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l_u(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx,
-    matrix::Csr<ValueType, IndexType>* u_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx,
+    matrix::view::csr<ValueType, IndexType> u_mtx)
 {
-    const size_type num_rows{system_matrix->get_size()[0]};
+    const size_type num_rows{system_matrix.size[0]};
     const dim3 block_size{default_block_size, 1, 1};
     const dim3 grid_dim{static_cast<uint32>(ceildiv(
                             num_rows, static_cast<size_type>(block_size.x))),
@@ -71,15 +73,15 @@ void initialize_weighted_l_u(
     auto inv_two_minus_weight =
         one(weight) / (static_cast<remove_complex<ValueType>>(2.0) - weight);
 
-    const auto in_row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto in_col_idxs = system_matrix->get_const_col_idxs();
-    const auto in_values = system_matrix->get_const_values();
-    const auto l_row_ptrs = l_mtx->get_const_row_ptrs();
-    const auto l_col_idxs = l_mtx->get_col_idxs();
-    const auto l_values = l_mtx->get_values();
-    const auto u_row_ptrs = u_mtx->get_const_row_ptrs();
-    const auto u_col_idxs = u_mtx->get_col_idxs();
-    const auto u_values = u_mtx->get_values();
+    const auto in_row_ptrs = system_matrix.row_ptrs;
+    const auto in_col_idxs = system_matrix.col_idxs;
+    const auto in_values = system_matrix.values;
+    const auto l_row_ptrs = l_mtx.row_ptrs;
+    const auto l_col_idxs = l_mtx.col_idxs;
+    const auto l_values = l_mtx.values;
+    const auto u_row_ptrs = u_mtx.row_ptrs;
+    const auto u_col_idxs = u_mtx.col_idxs;
+    const auto u_values = u_mtx.values;
 
     exec->get_queue()->parallel_for(
         sycl_nd_range(grid_dim, block_size), [=](sycl::nd_item<3> item_ct1) {

--- a/dpcpp/solver/common_trs_kernels.hpp
+++ b/dpcpp/solver/common_trs_kernels.hpp
@@ -39,9 +39,10 @@ struct OneMklSolveStruct : gko::solver::SolveStruct {
     oneapi::mkl::uplo uplo;
     oneapi::mkl::diag diag;
 
-    OneMklSolveStruct(std::shared_ptr<const gko::DpcppExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* matrix,
-                      size_type num_rhs, bool is_upper, bool unit_diag)
+    OneMklSolveStruct(
+        std::shared_ptr<const gko::DpcppExecutor> exec,
+        matrix::view::csr<const ValueType, const IndexType> matrix,
+        size_type num_rhs, bool is_upper, bool unit_diag)
         : exec{exec}, mat_handle{nullptr}, num_rhs{num_rhs}
     {
         if (num_rhs == 0) {
@@ -52,15 +53,15 @@ struct OneMklSolveStruct : gko::solver::SolveStruct {
         oneapi::mkl::sparse::init_matrix_handle(&mat_handle);
         oneapi::mkl::sparse::set_csr_data(
             *exec->get_queue(), mat_handle,
-            static_cast<IndexType>(matrix->get_size()[0]),
-            static_cast<IndexType>(matrix->get_size()[1]),
+            static_cast<IndexType>(matrix.size[0]),
+            static_cast<IndexType>(matrix.size[1]),
 #if INTEL_MKL_VERSION >= 20250300
-            static_cast<std::int64_t>(matrix->get_num_stored_elements()),
+            static_cast<std::int64_t>(matrix.num_stored_elements),
 #endif
             oneapi::mkl::index_base::zero,
-            const_cast<IndexType*>(matrix->get_const_row_ptrs()),
-            const_cast<IndexType*>(matrix->get_const_col_idxs()),
-            const_cast<ValueType*>(matrix->get_const_values()));
+            const_cast<IndexType*>(matrix.row_ptrs),
+            const_cast<IndexType*>(matrix.col_idxs),
+            const_cast<ValueType*>(matrix.values));
 
         oneapi::mkl::sparse::optimize_trsm(
             *exec->get_queue(), oneapi::mkl::layout::row_major, uplo,
@@ -68,8 +69,7 @@ struct OneMklSolveStruct : gko::solver::SolveStruct {
             static_cast<int64>(num_rhs));
     }
 
-    void solve(const matrix::Csr<ValueType, IndexType>* matrix,
-               matrix::view::dense<const ValueType> input,
+    void solve(matrix::view::dense<const ValueType> input,
                matrix::view::dense<ValueType> output) const
     {
         if (input.size[1] != num_rhs) {
@@ -111,12 +111,12 @@ struct OneMklSolveStruct : gko::solver::SolveStruct {
 
 template <typename ValueType, typename IndexType>
 void generate_kernel(std::shared_ptr<const DpcppExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* matrix,
+                     matrix::view::csr<const ValueType, const IndexType> matrix,
                      std::shared_ptr<solver::SolveStruct>& solve_struct,
                      const gko::size_type num_rhs, bool is_upper,
                      bool unit_diag)
 {
-    if (matrix->get_size()[0] == 0) {
+    if (matrix.size[0] == 0) {
         return;
     }
     if constexpr (onemkl::is_supported<ValueType>::value) {
@@ -131,12 +131,12 @@ void generate_kernel(std::shared_ptr<const DpcppExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void solve_kernel(std::shared_ptr<const DpcppExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* matrix,
+                  matrix::view::csr<const ValueType, const IndexType> matrix,
                   const solver::SolveStruct* solve_struct,
                   matrix::view::dense<const ValueType> b,
                   matrix::view::dense<ValueType> x)
 {
-    if (matrix->get_size()[0] == 0 || b.size[1] == 0) {
+    if (matrix.size[0] == 0 || b.size[1] == 0) {
         return;
     }
     using vec = matrix::Dense<ValueType>;
@@ -145,7 +145,7 @@ void solve_kernel(std::shared_ptr<const DpcppExecutor> exec,
         if (auto onemkl_solve_struct =
                 dynamic_cast<const OneMklSolveStruct<ValueType, IndexType>*>(
                     solve_struct)) {
-            onemkl_solve_struct->solve(matrix, b, x);
+            onemkl_solve_struct->solve(b, x);
         } else {
             GKO_NOT_SUPPORTED(solve_struct);
         }

--- a/dpcpp/solver/lower_trs_kernels.dp.cpp
+++ b/dpcpp/solver/lower_trs_kernels.dp.cpp
@@ -38,7 +38,7 @@ void should_perform_transpose(std::shared_ptr<const DpcppExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const DpcppExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -53,7 +53,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const DpcppExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/dpcpp/solver/lower_trs_kernels.dp.cpp
+++ b/dpcpp/solver/lower_trs_kernels.dp.cpp
@@ -38,7 +38,7 @@ void should_perform_transpose(std::shared_ptr<const DpcppExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const DpcppExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs) GKO_NOT_IMPLEMENTED;
@@ -53,7 +53,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const DpcppExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/dpcpp/solver/upper_trs_kernels.dp.cpp
+++ b/dpcpp/solver/upper_trs_kernels.dp.cpp
@@ -38,7 +38,7 @@ void should_perform_transpose(std::shared_ptr<const DpcppExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const DpcppExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -53,7 +53,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const DpcppExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/dpcpp/solver/upper_trs_kernels.dp.cpp
+++ b/dpcpp/solver/upper_trs_kernels.dp.cpp
@@ -38,7 +38,7 @@ void should_perform_transpose(std::shared_ptr<const DpcppExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const DpcppExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs) GKO_NOT_IMPLEMENTED;
@@ -53,7 +53,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const DpcppExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/hip/preconditioner/batch_jacobi_kernels.hip.cpp
+++ b/hip/preconditioner/batch_jacobi_kernels.hip.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -84,20 +84,19 @@ GKO_INSTANTIATE_FOR_INT32_TYPE(
 template <typename ValueType, typename IndexType>
 void extract_common_blocks_pattern(
     std::shared_ptr<const DefaultExecutor> exec,
-    const gko::matrix::Csr<ValueType, IndexType>* first_sys_csr,
+    matrix::view::csr<const ValueType, const IndexType> first_sys_csr,
     const size_type num_blocks, const IndexType* cumulative_block_storage,
     const IndexType* block_pointers, const IndexType* map_block_to_row,
     IndexType* blocks_pattern)
 {
-    const auto nrows = first_sys_csr->get_size()[0];
+    const auto nrows = first_sys_csr.size[0];
     dim3 block(default_block_size);
     dim3 grid(ceildiv(nrows * config::warp_size, default_block_size));
 
     batch_single_kernels::extract_common_block_pattern_kernel<<<
         grid, block, 0, exec->get_stream()>>>(
-        static_cast<int>(nrows), first_sys_csr->get_const_row_ptrs(),
-        first_sys_csr->get_const_col_idxs(), num_blocks,
-        cumulative_block_storage, block_pointers, map_block_to_row,
+        static_cast<int>(nrows), first_sys_csr.row_ptrs, first_sys_csr.col_idxs,
+        num_blocks, cumulative_block_storage, block_pointers, map_block_to_row,
         blocks_pattern);
 }
 

--- a/hip/solver/common_trs_kernels.hip.hpp
+++ b/hip/solver/common_trs_kernels.hip.hpp
@@ -96,12 +96,12 @@ void should_perform_transpose_kernel(std::shared_ptr<const HipExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate_kernel(std::shared_ptr<const HipExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* matrix,
+                     matrix::view::csr<const ValueType, const IndexType> matrix,
                      std::shared_ptr<solver::SolveStruct>& solve_struct,
                      const gko::size_type num_rhs, bool is_upper,
                      bool unit_diag)
 {
-    if (matrix->get_size()[0] == 0) {
+    if (matrix.size[0] == 0) {
         return;
     }
     if (sparselib::is_supported<ValueType, IndexType>::value) {
@@ -116,10 +116,9 @@ void generate_kernel(std::shared_ptr<const HipExecutor> exec,
                 sparselib::pointer_mode_guard pm_guard(handle);
                 int factor_work_size{};
                 sparselib::csrsv2_buffer_size(
-                    handle, SPARSELIB_OPERATION_NON_TRANSPOSE,
-                    matrix->get_size()[0], matrix->get_num_stored_elements(),
-                    hip_solve_struct->factor_descr, matrix->get_const_values(),
-                    matrix->get_const_row_ptrs(), matrix->get_const_col_idxs(),
+                    handle, SPARSELIB_OPERATION_NON_TRANSPOSE, matrix.size[0],
+                    matrix.num_stored_elements, hip_solve_struct->factor_descr,
+                    matrix.values, matrix.row_ptrs, matrix.col_idxs,
                     hip_solve_struct->solve_info, &factor_work_size);
 
                 // allocate workspace
@@ -132,10 +131,9 @@ void generate_kernel(std::shared_ptr<const HipExecutor> exec,
                 }
 
                 sparselib::csrsv2_analysis(
-                    handle, SPARSELIB_OPERATION_NON_TRANSPOSE,
-                    matrix->get_size()[0], matrix->get_num_stored_elements(),
-                    hip_solve_struct->factor_descr, matrix->get_const_values(),
-                    matrix->get_const_row_ptrs(), matrix->get_const_col_idxs(),
+                    handle, SPARSELIB_OPERATION_NON_TRANSPOSE, matrix.size[0],
+                    matrix.num_stored_elements, hip_solve_struct->factor_descr,
+                    matrix.values, matrix.row_ptrs, matrix.col_idxs,
                     hip_solve_struct->solve_info, hip_solve_struct->policy,
                     hip_solve_struct->factor_work_vec);
             }
@@ -150,14 +148,14 @@ void generate_kernel(std::shared_ptr<const HipExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void solve_kernel(std::shared_ptr<const HipExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* matrix,
+                  matrix::view::csr<const ValueType, const IndexType> matrix,
                   const solver::SolveStruct* solve_struct,
                   matrix::view::dense<ValueType> trans_b,
                   matrix::view::dense<ValueType> trans_x,
                   matrix::view::dense<const ValueType> b,
                   matrix::view::dense<ValueType> x)
 {
-    if (matrix->get_size()[0] == 0 || b.size[1] == 0) {
+    if (matrix.size[0] == 0 || b.size[1] == 0) {
         return;
     }
 
@@ -172,12 +170,9 @@ void solve_kernel(std::shared_ptr<const HipExecutor> exec,
                 if (b.stride == 1) {
                     sparselib::csrsv2_solve(
                         handle, SPARSELIB_OPERATION_NON_TRANSPOSE,
-                        matrix->get_size()[0],
-                        matrix->get_num_stored_elements(), &one,
-                        hip_solve_struct->factor_descr,
-                        matrix->get_const_values(),
-                        matrix->get_const_row_ptrs(),
-                        matrix->get_const_col_idxs(),
+                        matrix.size[0], matrix.num_stored_elements, &one,
+                        hip_solve_struct->factor_descr, matrix.values,
+                        matrix.row_ptrs, matrix.col_idxs,
                         hip_solve_struct->solve_info, b.values, x.values,
                         hip_solve_struct->policy,
                         hip_solve_struct->factor_work_vec);
@@ -187,12 +182,9 @@ void solve_kernel(std::shared_ptr<const HipExecutor> exec,
                     for (IndexType i = 0; i < trans_b.size[0]; i++) {
                         sparselib::csrsv2_solve(
                             handle, SPARSELIB_OPERATION_NON_TRANSPOSE,
-                            matrix->get_size()[0],
-                            matrix->get_num_stored_elements(), &one,
-                            hip_solve_struct->factor_descr,
-                            matrix->get_const_values(),
-                            matrix->get_const_row_ptrs(),
-                            matrix->get_const_col_idxs(),
+                            matrix.size[0], matrix.num_stored_elements, &one,
+                            hip_solve_struct->factor_descr, matrix.values,
+                            matrix.row_ptrs, matrix.col_idxs,
                             hip_solve_struct->solve_info,
                             trans_b.values + i * trans_b.stride,
                             trans_x.values + i * trans_x.stride,

--- a/hip/solver/lower_trs_kernels.hip.cpp
+++ b/hip/solver/lower_trs_kernels.hip.cpp
@@ -40,7 +40,7 @@ void should_perform_transpose(std::shared_ptr<const HipExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const HipExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -55,7 +55,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const HipExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/hip/solver/upper_trs_kernels.hip.cpp
+++ b/hip/solver/upper_trs_kernels.hip.cpp
@@ -40,7 +40,7 @@ void should_perform_transpose(std::shared_ptr<const HipExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const HipExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -55,7 +55,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const HipExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -10,6 +10,7 @@
 #include <ginkgo/core/base/index_set.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 #include <ginkgo/core/matrix/permutation.hpp>
 #include <ginkgo/core/matrix/scaled_permutation.hpp>
 
@@ -203,6 +204,8 @@ public:
     using mat_data = matrix_data<ValueType, IndexType>;
     using device_mat_data = device_matrix_data<ValueType, IndexType>;
     using absolute_type = remove_complex<Csr>;
+    using device_view = view::csr<value_type, index_type>;
+    using const_device_view = view::csr<const value_type, const index_type>;
 
     class GKO_DEPRECATED(
         "please use enum gko::matrix::csr::spmv_strategy::<strategy>")
@@ -349,6 +352,20 @@ public:
     std::unique_ptr<LinOp> transpose() const override;
 
     std::unique_ptr<LinOp> conj_transpose() const override;
+
+    /**
+     * Returns a non-owning device view of this matrix.
+     *
+     * @return a device view of this matrix.
+     */
+    device_view get_device_view();
+
+    /**
+     * Returns a non-owning const device view of this matrix.
+     *
+     * @return a const device view of this matrix.
+     */
+    const_device_view get_const_device_view() const;
 
     /**
      * Class describing the internal lookup structures created by

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,7 @@
 #include <ginkgo/core/base/index_set.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/matrix/device_views.hpp>
 #include <ginkgo/core/matrix/permutation.hpp>
 #include <ginkgo/core/matrix/scaled_permutation.hpp>
 
@@ -164,6 +165,9 @@ public:
     using mat_data = matrix_data<ValueType, IndexType>;
     using device_mat_data = device_matrix_data<ValueType, IndexType>;
     using absolute_type = remove_complex<Csr>;
+    using device_view = matrix::view::csr<value_type, index_type>;
+    using const_device_view =
+        matrix::view::csr<const value_type, const index_type>;
 
     class automatical;
 
@@ -768,6 +772,20 @@ public:
     std::unique_ptr<LinOp> transpose() const override;
 
     std::unique_ptr<LinOp> conj_transpose() const override;
+
+    /**
+     * Returns a non-owning device view of this matrix.
+     *
+     * @return a device view of this matrix.
+     */
+    device_view get_device_view();
+
+    /**
+     * Returns a non-owning const device view of this matrix.
+     *
+     * @return a const device view of this matrix.
+     */
+    const_device_view get_const_device_view() const;
 
     /**
      * Class describing the internal lookup structures created by

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -87,6 +87,42 @@ struct coo {
 
 
 /**
+ * Non-owning view of a matrix::Csr to be used inside device kernels.
+ * This type is used to provide a simple and stable ABI for passing data between
+ * libraries.
+ *
+ * @tparam ValueType  the value type used to store matrix entries.
+ * @tparam IndexType  the index type used to store row and column indices.
+ */
+template <typename ValueType, typename IndexType>
+struct csr {
+    dim<2> size;
+    size_type num_stored_elements;
+    ValueType* values;
+    IndexType* row_ptrs;
+    IndexType* col_idxs;
+
+    /** Constructs a coo view from size, nnz, values, row pointers, and column
+     * indices. */
+    constexpr csr(dim<2> size, size_type num_stored_elements, ValueType* values,
+                  IndexType* row_ptrs, IndexType* col_idxs)
+        : size{size},
+          num_stored_elements{num_stored_elements},
+          values{values},
+          row_ptrs{row_ptrs},
+          col_idxs{col_idxs}
+    {}
+
+    /** Returns a const view of the same data */
+    constexpr csr<const ValueType, const IndexType> as_const() const
+    {
+        return csr<const ValueType, const IndexType>{
+            size, num_stored_elements, values, row_ptrs, col_idxs};
+    }
+};
+
+
+/**
  * Non-owning view of a matrix::Ell to be used inside device kernels.
  * This type is used to provide a simple and stable ABI for passing data between
  * libraries.

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -101,23 +101,29 @@ struct csr {
     ValueType* values;
     IndexType* row_ptrs;
     IndexType* col_idxs;
+    size_type num_srow_elements;
+    IndexType* srow;  // TODO: should we handle it additionally?
 
     /** Constructs a coo view from size, nnz, values, row pointers, and column
      * indices. */
     constexpr csr(dim<2> size, size_type num_stored_elements, ValueType* values,
-                  IndexType* row_ptrs, IndexType* col_idxs)
+                  IndexType* row_ptrs, IndexType* col_idxs,
+                  size_type num_srow_elements, IndexType* srow)
         : size{size},
           num_stored_elements{num_stored_elements},
           values{values},
           row_ptrs{row_ptrs},
-          col_idxs{col_idxs}
+          col_idxs{col_idxs},
+          num_srow_elements{num_srow_elements},
+          srow{srow}
     {}
 
     /** Returns a const view of the same data */
     constexpr csr<const ValueType, const IndexType> as_const() const
     {
         return csr<const ValueType, const IndexType>{
-            size, num_stored_elements, values, row_ptrs, col_idxs};
+            size,     num_stored_elements, values, row_ptrs,
+            col_idxs, num_srow_elements,   srow};
     }
 };
 

--- a/include/ginkgo/core/matrix/device_views.hpp
+++ b/include/ginkgo/core/matrix/device_views.hpp
@@ -101,29 +101,23 @@ struct csr {
     ValueType* values;
     IndexType* row_ptrs;
     IndexType* col_idxs;
-    size_type num_srow_elements;
-    IndexType* srow;  // TODO: should we handle it additionally?
 
     /** Constructs a coo view from size, nnz, values, row pointers, and column
      * indices. */
     constexpr csr(dim<2> size, size_type num_stored_elements, ValueType* values,
-                  IndexType* row_ptrs, IndexType* col_idxs,
-                  size_type num_srow_elements, IndexType* srow)
+                  IndexType* row_ptrs, IndexType* col_idxs)
         : size{size},
           num_stored_elements{num_stored_elements},
           values{values},
           row_ptrs{row_ptrs},
-          col_idxs{col_idxs},
-          num_srow_elements{num_srow_elements},
-          srow{srow}
+          col_idxs{col_idxs}
     {}
 
     /** Returns a const view of the same data */
     constexpr csr<const ValueType, const IndexType> as_const() const
     {
         return csr<const ValueType, const IndexType>{
-            size,     num_stored_elements, values, row_ptrs,
-            col_idxs, num_srow_elements,   srow};
+            size, num_stored_elements, values, row_ptrs, col_idxs};
     }
 };
 

--- a/omp/components/csr_spgeam.hpp
+++ b/omp/components/csr_spgeam.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -29,18 +29,18 @@ namespace omp {
  */
 template <typename ValueType, typename IndexType, typename BeginCallback,
           typename EntryCallback, typename EndCallback>
-void abstract_spgeam(const matrix::Csr<ValueType, IndexType>* a,
-                     const matrix::Csr<ValueType, IndexType>* b,
+void abstract_spgeam(matrix::view::csr<const ValueType, const IndexType> a,
+                     matrix::view::csr<const ValueType, const IndexType> b,
                      BeginCallback begin_cb, EntryCallback entry_cb,
                      EndCallback end_cb)
 {
-    auto num_rows = a->get_size()[0];
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
-    auto b_vals = b->get_const_values();
+    auto num_rows = a.size[0];
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
+    auto b_vals = b.values;
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {

--- a/omp/components/csr_spgeam.hpp
+++ b/omp/components/csr_spgeam.hpp
@@ -29,18 +29,18 @@ namespace omp {
  */
 template <typename ValueType, typename IndexType, typename BeginCallback,
           typename EntryCallback, typename EndCallback>
-void abstract_spgeam(matrix::view::csr<const ValueType, const IndexType> a,
-                     matrix::view::csr<const ValueType, const IndexType> b,
+void abstract_spgeam(const matrix::Csr<ValueType, IndexType>* a,
+                     const matrix::Csr<ValueType, IndexType>* b,
                      BeginCallback begin_cb, EntryCallback entry_cb,
                      EndCallback end_cb)
 {
-    auto num_rows = a.size[0];
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto a_vals = a.values;
-    auto b_row_ptrs = b.row_ptrs;
-    auto b_col_idxs = b.col_idxs;
-    auto b_vals = b.values;
+    auto num_rows = a->get_size()[0];
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto a_vals = a->get_const_values();
+    auto b_row_ptrs = b->get_const_row_ptrs();
+    auto b_col_idxs = b->get_const_col_idxs();
+    auto b_vals = b->get_const_values();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {

--- a/omp/factorization/cholesky_kernels.cpp
+++ b/omp/factorization/cholesky_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -32,19 +32,19 @@ namespace cholesky {
 
 template <typename ValueType, typename IndexType>
 void symbolic_count(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* mtx,
+                    matrix::view::csr<const ValueType, const IndexType> mtx,
                     const factorization::elimination_forest<IndexType>& forest,
                     IndexType* row_nnz, array<IndexType>& tmp_storage)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto cols = mtx->get_const_col_idxs();
+    const auto num_rows = mtx.size[0];
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto cols = mtx.col_idxs;
     const auto inv_postorder = forest.inv_postorder.get_const_data();
     const auto postorder = forest.postorder.get_const_data();
     const auto postorder_parent = forest.postorder_parents.get_const_data();
-    tmp_storage.resize_and_reset(mtx->get_num_stored_elements() + num_rows);
+    tmp_storage.resize_and_reset(mtx.num_stored_elements + num_rows);
     const auto postorder_cols = tmp_storage.get_data();
-    const auto lower_ends = postorder_cols + mtx->get_num_stored_elements();
+    const auto lower_ends = postorder_cols + mtx.num_stored_elements;
 #pragma omp parallel for
     for (IndexType row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
@@ -87,19 +87,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void symbolic_factorize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
     const factorization::elimination_forest<IndexType>& forest,
-    matrix::Csr<ValueType, IndexType>* l_factor,
+    matrix::view::csr<ValueType, IndexType> l_factor,
     const array<IndexType>& tmp_storage)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto cols = mtx->get_const_col_idxs();
+    const auto num_rows = mtx.size[0];
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto cols = mtx.col_idxs;
     const auto postorder_parent = forest.postorder_parents.get_const_data();
-    const auto out_row_ptrs = l_factor->get_const_row_ptrs();
-    const auto out_cols = l_factor->get_col_idxs();
+    const auto out_row_ptrs = l_factor.row_ptrs;
+    const auto out_cols = l_factor.col_idxs;
     const auto postorder_cols = tmp_storage.get_const_data();
-    const auto lower_ends = postorder_cols + mtx->get_num_stored_elements();
+    const auto lower_ends = postorder_cols + mtx.num_stored_elements;
     const auto inv_postorder = forest.inv_postorder.get_const_data();
     const auto postorder = forest.postorder.get_const_data();
 #pragma omp parallel for
@@ -134,23 +134,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
+                matrix::view::csr<const ValueType, const IndexType> mtx,
                 const IndexType* factor_lookup_offsets,
                 const int64* factor_lookup_descs,
                 const int32* factor_lookup_storage, IndexType* diag_idxs,
                 IndexType* transpose_idxs,
-                matrix::Csr<ValueType, IndexType>* factors)
+                matrix::view::csr<ValueType, IndexType> factors)
 {
     lu_factorization::initialize(exec, mtx, factor_lookup_offsets,
                                  factor_lookup_descs, factor_lookup_storage,
                                  diag_idxs, factors);
     // convert to COO
-    const auto nnz = factors->get_num_stored_elements();
+    const auto nnz = factors.num_stored_elements;
     array<IndexType> row_idx_array{exec, nnz};
     const auto row_idxs = row_idx_array.get_data();
-    const auto col_idxs = factors->get_const_col_idxs();
-    components::convert_ptrs_to_idxs(exec, factors->get_const_row_ptrs(),
-                                     factors->get_size()[0], row_idxs);
+    const auto col_idxs = factors.col_idxs;
+    components::convert_ptrs_to_idxs(exec, factors.row_ptrs, factors.size[0],
+                                     row_idxs);
     components::fill_seq_array(exec, transpose_idxs, nnz);
     // compute nonzero permutation for sparse transpose
     std::sort(transpose_idxs, transpose_idxs + nnz,
@@ -172,13 +172,13 @@ void factorize_impl(std::shared_ptr<const DefaultExecutor> exec,
                     const int32* lookup_storage, const IndexType* diag_idxs,
                     const IndexType* transpose_idxs,
                     const factorization::elimination_forest<IndexType>& forest,
-                    matrix::Csr<ValueType, IndexType>* factors,
+                    matrix::view::csr<ValueType, IndexType> factors,
                     array<int>& tmp_storage)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto row_ptrs = factors->get_const_row_ptrs();
-    const auto cols = factors->get_const_col_idxs();
-    const auto vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto row_ptrs = factors.row_ptrs;
+    const auto cols = factors.col_idxs;
+    const auto vals = factors.values;
     for (size_type row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_diag = diag_idxs[row];
@@ -227,8 +227,8 @@ void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const int32* lookup_storage, const IndexType* diag_idxs,
                const IndexType* transpose_idxs,
                const factorization::elimination_forest<IndexType>& forest,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage)
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage)
 {
     if (full_fillin) {
         factorize_impl<true>(exec, lookup_offsets, lookup_descs, lookup_storage,

--- a/omp/factorization/elimination_forest_kernels.cpp
+++ b/omp/factorization/elimination_forest_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -77,15 +77,15 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void from_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* factors,
+                 matrix::view::csr<const ValueType, const IndexType> factors,
                  gko::factorization::elimination_forest<IndexType>& forest)
 {
-    const auto row_ptrs = factors->get_const_row_ptrs();
-    const auto col_idxs = factors->get_const_col_idxs();
+    const auto row_ptrs = factors.row_ptrs;
+    const auto col_idxs = factors.col_idxs;
     const auto parents = forest.parents.get_data();
     const auto children = forest.children.get_data();
     const auto child_ptrs = forest.child_ptrs.get_data();
-    const auto num_rows = static_cast<IndexType>(factors->get_size()[0]);
+    const auto num_rows = static_cast<IndexType>(factors.size[0]);
     components::fill_array(exec, parents, num_rows, num_rows);
 #pragma omp parallel for
     for (IndexType l_col = 0; l_col < num_rows; l_col++) {

--- a/omp/factorization/factorization_helpers.hpp
+++ b/omp/factorization/factorization_helpers.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -19,25 +19,26 @@ using namespace ::gko::factorization;
 
 template <typename ValueType, typename IndexType, typename LClosure,
           typename UClosure>
-void initialize_l_u(const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u,
-                    LClosure&& l_closure, UClosure&& u_closure)
+void initialize_l_u(
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u, LClosure&& l_closure,
+    UClosure&& u_closure)
 {
-    const auto row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto vals = system_matrix->get_const_values();
+    const auto row_ptrs = system_matrix.row_ptrs;
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto vals = system_matrix.values;
 
-    const auto row_ptrs_l = csr_l->get_const_row_ptrs();
-    auto col_idxs_l = csr_l->get_col_idxs();
-    auto vals_l = csr_l->get_values();
+    const auto row_ptrs_l = csr_l.row_ptrs;
+    auto col_idxs_l = csr_l.col_idxs;
+    auto vals_l = csr_l.values;
 
-    const auto row_ptrs_u = csr_u->get_const_row_ptrs();
-    auto col_idxs_u = csr_u->get_col_idxs();
-    auto vals_u = csr_u->get_values();
+    const auto row_ptrs_u = csr_u.row_ptrs;
+    auto col_idxs_u = csr_u.col_idxs;
+    auto vals_u = csr_u.values;
 
 #pragma omp parallel for
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         size_type current_index_l = row_ptrs_l[row];
         size_type current_index_u =
             row_ptrs_u[row] + 1;  // we treat the diagonal separately
@@ -71,19 +72,20 @@ void initialize_l_u(const matrix::Csr<ValueType, IndexType>* system_matrix,
 
 
 template <typename ValueType, typename IndexType, typename Closure>
-void initialize_l(const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, Closure&& closure)
+void initialize_l(
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, Closure&& closure)
 {
-    const auto row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto vals = system_matrix->get_const_values();
+    const auto row_ptrs = system_matrix.row_ptrs;
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto vals = system_matrix.values;
 
-    const auto row_ptrs_l = csr_l->get_const_row_ptrs();
-    auto col_idxs_l = csr_l->get_col_idxs();
-    auto vals_l = csr_l->get_values();
+    const auto row_ptrs_l = csr_l.row_ptrs;
+    auto col_idxs_l = csr_l.col_idxs;
+    auto vals_l = csr_l.values;
 
 #pragma omp parallel for
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         size_type current_index_l = row_ptrs_l[row];
         // if there is no diagonal value, set it to 1 by default
         auto diag_val = one<ValueType>();

--- a/omp/factorization/factorization_kernels.cpp
+++ b/omp/factorization/factorization_kernels.cpp
@@ -54,15 +54,14 @@ struct find_helper<true> {
 }  // namespace detail
 
 
-template <bool IsSorted, typename ValueType, typename IndexType>
-void find_missing_diagonal_elements(
-    matrix::view::csr<const ValueType, const IndexType> mtx,
-    IndexType* elements_to_add_per_row, bool* changes_required)
+template <bool IsSorted, typename IndexType>
+void find_missing_diagonal_elements(dim<2> size, const IndexType* row_ptrs,
+                                    const IndexType* col_idxs,
+                                    IndexType* elements_to_add_per_row,
+                                    bool* changes_required)
 {
-    auto num_rows = static_cast<IndexType>(mtx.size[0]);
-    auto num_cols = static_cast<IndexType>(mtx.size[1]);
-    auto col_idxs = mtx.col_idxs;
-    auto row_ptrs = mtx.row_ptrs;
+    auto num_rows = static_cast<IndexType>(size[0]);
+    auto num_cols = static_cast<IndexType>(size[1]);
     bool local_change{false};
 #pragma omp parallel for reduction(|| : local_change)
     for (IndexType row = 0; row < num_rows; ++row) {
@@ -84,15 +83,14 @@ void find_missing_diagonal_elements(
 
 
 template <typename ValueType, typename IndexType>
-void add_missing_diagonal_elements(
-    matrix::view::csr<const ValueType, const IndexType> mtx,
-    ValueType* new_values, IndexType* new_col_idxs,
-    const IndexType* row_ptrs_addition)
+void add_missing_diagonal_elements(IndexType num_rows,
+                                   const IndexType* row_ptrs,
+                                   const IndexType* old_col_idxs,
+                                   const ValueType* old_values,
+                                   ValueType* new_values,
+                                   IndexType* new_col_idxs,
+                                   const IndexType* row_ptrs_addition)
 {
-    const auto num_rows = static_cast<IndexType>(mtx.size[0]);
-    const auto old_values = mtx.values;
-    const auto old_col_idxs = mtx.col_idxs;
-    const auto row_ptrs = mtx.row_ptrs;
 #pragma omp parallel for
     for (IndexType row = 0; row < num_rows; ++row) {
         const IndexType old_row_start{row_ptrs[row]};
@@ -149,11 +147,13 @@ void add_diagonal_elements(
     bool needs_change{};
     if (is_sorted) {
         kernel::find_missing_diagonal_elements<true>(
-            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
+            mtx->get_size(), mtx->get_const_row_ptrs(),
+            mtx->get_const_col_idxs(), row_ptrs_addition.get_data(),
             &needs_change);
     } else {
         kernel::find_missing_diagonal_elements<false>(
-            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
+            mtx->get_size(), mtx->get_const_row_ptrs(),
+            mtx->get_const_col_idxs(), row_ptrs_addition.get_data(),
             &needs_change);
     }
     if (!needs_change) {
@@ -169,8 +169,10 @@ void add_diagonal_elements(
     array<ValueType> new_values{exec, new_num_elems};
     array<IndexType> new_col_idxs{exec, new_num_elems};
     kernel::add_missing_diagonal_elements(
-        mtx->get_const_device_view(), new_values.get_data(),
-        new_col_idxs.get_data(), row_ptrs_addition.get_const_data());
+        static_cast<IndexType>(mtx->get_size()[0]), mtx->get_const_row_ptrs(),
+        mtx->get_const_col_idxs(), mtx->get_const_values(),
+        new_values.get_data(), new_col_idxs.get_data(),
+        row_ptrs_addition.get_const_data());
 
     auto old_row_ptrs_ptr = mtx->get_row_ptrs();
     auto row_ptrs_addition_ptr = row_ptrs_addition.get_const_data();

--- a/omp/factorization/factorization_kernels.cpp
+++ b/omp/factorization/factorization_kernels.cpp
@@ -56,13 +56,13 @@ struct find_helper<true> {
 
 template <bool IsSorted, typename ValueType, typename IndexType>
 void find_missing_diagonal_elements(
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
     IndexType* elements_to_add_per_row, bool* changes_required)
 {
-    auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
-    auto num_cols = static_cast<IndexType>(mtx->get_size()[1]);
-    auto col_idxs = mtx->get_const_col_idxs();
-    auto row_ptrs = mtx->get_const_row_ptrs();
+    auto num_rows = static_cast<IndexType>(mtx.size[0]);
+    auto num_cols = static_cast<IndexType>(mtx.size[1]);
+    auto col_idxs = mtx.col_idxs;
+    auto row_ptrs = mtx.row_ptrs;
     bool local_change{false};
 #pragma omp parallel for reduction(|| : local_change)
     for (IndexType row = 0; row < num_rows; ++row) {
@@ -84,15 +84,15 @@ void find_missing_diagonal_elements(
 
 
 template <typename ValueType, typename IndexType>
-void add_missing_diagonal_elements(const matrix::Csr<ValueType, IndexType>* mtx,
-                                   ValueType* new_values,
-                                   IndexType* new_col_idxs,
-                                   const IndexType* row_ptrs_addition)
+void add_missing_diagonal_elements(
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    ValueType* new_values, IndexType* new_col_idxs,
+    const IndexType* row_ptrs_addition)
 {
-    const auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
-    const auto old_values = mtx->get_const_values();
-    const auto old_col_idxs = mtx->get_const_col_idxs();
-    const auto row_ptrs = mtx->get_const_row_ptrs();
+    const auto num_rows = static_cast<IndexType>(mtx.size[0]);
+    const auto old_values = mtx.values;
+    const auto old_col_idxs = mtx.col_idxs;
+    const auto row_ptrs = mtx.row_ptrs;
 #pragma omp parallel for
     for (IndexType row = 0; row < num_rows; ++row) {
         const IndexType old_row_start{row_ptrs[row]};
@@ -149,10 +149,12 @@ void add_diagonal_elements(
     bool needs_change{};
     if (is_sorted) {
         kernel::find_missing_diagonal_elements<true>(
-            mtx, row_ptrs_addition.get_data(), &needs_change);
+            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
+            &needs_change);
     } else {
         kernel::find_missing_diagonal_elements<false>(
-            mtx, row_ptrs_addition.get_data(), &needs_change);
+            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
+            &needs_change);
     }
     if (!needs_change) {
         return;
@@ -166,9 +168,9 @@ void add_diagonal_elements(
                               row_ptrs_addition.get_data()[row_ptrs_size - 1];
     array<ValueType> new_values{exec, new_num_elems};
     array<IndexType> new_col_idxs{exec, new_num_elems};
-    kernel::add_missing_diagonal_elements(mtx, new_values.get_data(),
-                                          new_col_idxs.get_data(),
-                                          row_ptrs_addition.get_const_data());
+    kernel::add_missing_diagonal_elements(
+        mtx->get_const_device_view(), new_values.get_data(),
+        new_col_idxs.get_data(), row_ptrs_addition.get_const_data());
 
     auto old_row_ptrs_ptr = mtx->get_row_ptrs();
     auto row_ptrs_addition_ptr = row_ptrs_addition.get_const_data();
@@ -188,12 +190,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    auto num_rows = system_matrix->get_size()[0];
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto num_rows = system_matrix.size[0];
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
 
 // Calculate the NNZ per row first
 #pragma omp parallel for
@@ -221,10 +223,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const OmpExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
     helpers::initialize_l_u(
         system_matrix, csr_l, csr_u,
@@ -241,12 +244,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    auto num_rows = system_matrix->get_size()[0];
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto num_rows = system_matrix.size[0];
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
 
 // Calculate the NNZ per row first
 #pragma omp parallel for
@@ -270,9 +273,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const OmpExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
     helpers::initialize_l(system_matrix, csr_l,
                           helpers::triangular_mtx_closure(
@@ -341,15 +345,13 @@ bool symbolic_validate_impl(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup, bool& valid)
 {
     valid = symbolic_validate_impl(
-        exec, system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(), factors->get_const_row_ptrs(),
-        factors->get_const_col_idxs(),
-        static_cast<IndexType>(system_matrix->get_size()[0]));
+        exec, system_matrix.row_ptrs, system_matrix.col_idxs, factors.row_ptrs,
+        factors.col_idxs, static_cast<IndexType>(system_matrix.size[0]));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/factorization/factorization_kernels.cpp
+++ b/omp/factorization/factorization_kernels.cpp
@@ -56,13 +56,13 @@ struct find_helper<true> {
 
 template <bool IsSorted, typename ValueType, typename IndexType>
 void find_missing_diagonal_elements(
-    matrix::view::csr<const ValueType, const IndexType> mtx,
+    const matrix::Csr<ValueType, IndexType>* mtx,
     IndexType* elements_to_add_per_row, bool* changes_required)
 {
-    auto num_rows = static_cast<IndexType>(mtx.size[0]);
-    auto num_cols = static_cast<IndexType>(mtx.size[1]);
-    auto col_idxs = mtx.col_idxs;
-    auto row_ptrs = mtx.row_ptrs;
+    auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
+    auto num_cols = static_cast<IndexType>(mtx->get_size()[1]);
+    auto col_idxs = mtx->get_const_col_idxs();
+    auto row_ptrs = mtx->get_const_row_ptrs();
     bool local_change{false};
 #pragma omp parallel for reduction(|| : local_change)
     for (IndexType row = 0; row < num_rows; ++row) {
@@ -84,15 +84,15 @@ void find_missing_diagonal_elements(
 
 
 template <typename ValueType, typename IndexType>
-void add_missing_diagonal_elements(
-    matrix::view::csr<const ValueType, const IndexType> mtx,
-    ValueType* new_values, IndexType* new_col_idxs,
-    const IndexType* row_ptrs_addition)
+void add_missing_diagonal_elements(const matrix::Csr<ValueType, IndexType>* mtx,
+                                   ValueType* new_values,
+                                   IndexType* new_col_idxs,
+                                   const IndexType* row_ptrs_addition)
 {
-    const auto num_rows = static_cast<IndexType>(mtx.size[0]);
-    const auto old_values = mtx.values;
-    const auto old_col_idxs = mtx.col_idxs;
-    const auto row_ptrs = mtx.row_ptrs;
+    const auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
+    const auto old_values = mtx->get_const_values();
+    const auto old_col_idxs = mtx->get_const_col_idxs();
+    const auto row_ptrs = mtx->get_const_row_ptrs();
 #pragma omp parallel for
     for (IndexType row = 0; row < num_rows; ++row) {
         const IndexType old_row_start{row_ptrs[row]};
@@ -148,12 +148,10 @@ void add_diagonal_elements(std::shared_ptr<const OmpExecutor> exec,
     bool needs_change{};
     if (is_sorted) {
         kernel::find_missing_diagonal_elements<true>(
-            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
-            &needs_change);
+            mtx, row_ptrs_addition.get_data(), &needs_change);
     } else {
         kernel::find_missing_diagonal_elements<false>(
-            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
-            &needs_change);
+            mtx, row_ptrs_addition.get_data(), &needs_change);
     }
     if (!needs_change) {
         return;
@@ -167,9 +165,9 @@ void add_diagonal_elements(std::shared_ptr<const OmpExecutor> exec,
                               row_ptrs_addition.get_data()[row_ptrs_size - 1];
     array<ValueType> new_values{exec, new_num_elems};
     array<IndexType> new_col_idxs{exec, new_num_elems};
-    kernel::add_missing_diagonal_elements(
-        mtx->get_const_device_view(), new_values.get_data(),
-        new_col_idxs.get_data(), row_ptrs_addition.get_const_data());
+    kernel::add_missing_diagonal_elements(mtx, new_values.get_data(),
+                                          new_col_idxs.get_data(),
+                                          row_ptrs_addition.get_const_data());
 
     auto old_row_ptrs_ptr = mtx->get_row_ptrs();
     auto row_ptrs_addition_ptr = row_ptrs_addition.get_const_data();

--- a/omp/factorization/factorization_kernels.cpp
+++ b/omp/factorization/factorization_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -56,13 +56,13 @@ struct find_helper<true> {
 
 template <bool IsSorted, typename ValueType, typename IndexType>
 void find_missing_diagonal_elements(
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
     IndexType* elements_to_add_per_row, bool* changes_required)
 {
-    auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
-    auto num_cols = static_cast<IndexType>(mtx->get_size()[1]);
-    auto col_idxs = mtx->get_const_col_idxs();
-    auto row_ptrs = mtx->get_const_row_ptrs();
+    auto num_rows = static_cast<IndexType>(mtx.size[0]);
+    auto num_cols = static_cast<IndexType>(mtx.size[1]);
+    auto col_idxs = mtx.col_idxs;
+    auto row_ptrs = mtx.row_ptrs;
     bool local_change{false};
 #pragma omp parallel for reduction(|| : local_change)
     for (IndexType row = 0; row < num_rows; ++row) {
@@ -84,15 +84,15 @@ void find_missing_diagonal_elements(
 
 
 template <typename ValueType, typename IndexType>
-void add_missing_diagonal_elements(const matrix::Csr<ValueType, IndexType>* mtx,
-                                   ValueType* new_values,
-                                   IndexType* new_col_idxs,
-                                   const IndexType* row_ptrs_addition)
+void add_missing_diagonal_elements(
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    ValueType* new_values, IndexType* new_col_idxs,
+    const IndexType* row_ptrs_addition)
 {
-    const auto num_rows = static_cast<IndexType>(mtx->get_size()[0]);
-    const auto old_values = mtx->get_const_values();
-    const auto old_col_idxs = mtx->get_const_col_idxs();
-    const auto row_ptrs = mtx->get_const_row_ptrs();
+    const auto num_rows = static_cast<IndexType>(mtx.size[0]);
+    const auto old_values = mtx.values;
+    const auto old_col_idxs = mtx.col_idxs;
+    const auto row_ptrs = mtx.row_ptrs;
 #pragma omp parallel for
     for (IndexType row = 0; row < num_rows; ++row) {
         const IndexType old_row_start{row_ptrs[row]};
@@ -148,10 +148,12 @@ void add_diagonal_elements(std::shared_ptr<const OmpExecutor> exec,
     bool needs_change{};
     if (is_sorted) {
         kernel::find_missing_diagonal_elements<true>(
-            mtx, row_ptrs_addition.get_data(), &needs_change);
+            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
+            &needs_change);
     } else {
         kernel::find_missing_diagonal_elements<false>(
-            mtx, row_ptrs_addition.get_data(), &needs_change);
+            mtx->get_const_device_view(), row_ptrs_addition.get_data(),
+            &needs_change);
     }
     if (!needs_change) {
         return;
@@ -165,9 +167,9 @@ void add_diagonal_elements(std::shared_ptr<const OmpExecutor> exec,
                               row_ptrs_addition.get_data()[row_ptrs_size - 1];
     array<ValueType> new_values{exec, new_num_elems};
     array<IndexType> new_col_idxs{exec, new_num_elems};
-    kernel::add_missing_diagonal_elements(mtx, new_values.get_data(),
-                                          new_col_idxs.get_data(),
-                                          row_ptrs_addition.get_const_data());
+    kernel::add_missing_diagonal_elements(
+        mtx->get_const_device_view(), new_values.get_data(),
+        new_col_idxs.get_data(), row_ptrs_addition.get_const_data());
 
     auto old_row_ptrs_ptr = mtx->get_row_ptrs();
     auto row_ptrs_addition_ptr = row_ptrs_addition.get_const_data();
@@ -188,12 +190,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    auto num_rows = system_matrix->get_size()[0];
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto num_rows = system_matrix.size[0];
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
 
 // Calculate the NNZ per row first
 #pragma omp parallel for
@@ -221,10 +223,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const OmpExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
     helpers::initialize_l_u(
         system_matrix, csr_l, csr_u,
@@ -241,12 +244,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    auto num_rows = system_matrix->get_size()[0];
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto num_rows = system_matrix.size[0];
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
 
 // Calculate the NNZ per row first
 #pragma omp parallel for
@@ -270,9 +273,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const OmpExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
     helpers::initialize_l(system_matrix, csr_l,
                           helpers::triangular_mtx_closure(
@@ -341,15 +345,13 @@ bool symbolic_validate_impl(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup, bool& valid)
 {
     valid = symbolic_validate_impl(
-        exec, system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(), factors->get_const_row_ptrs(),
-        factors->get_const_col_idxs(),
-        static_cast<IndexType>(system_matrix->get_size()[0]));
+        exec, system_matrix.row_ptrs, system_matrix.col_idxs, factors.row_ptrs,
+        factors.col_idxs, static_cast<IndexType>(system_matrix.size[0]));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/factorization/ic_kernels.cpp
+++ b/omp/factorization/ic_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,7 +18,8 @@ namespace ic_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ic(std::shared_ptr<const DefaultExecutor> exec,
-                  matrix::Csr<ValueType, IndexType>* m) GKO_NOT_IMPLEMENTED;
+                  matrix::view::csr<ValueType, IndexType> m)
+    GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_IC_SPARSELIB_IC_KERNEL);

--- a/omp/factorization/ilu_kernels.cpp
+++ b/omp/factorization/ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,7 +18,8 @@ namespace ilu_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ilu(std::shared_ptr<const DefaultExecutor> exec,
-                   matrix::Csr<ValueType, IndexType>* m) GKO_NOT_IMPLEMENTED;
+                   matrix::view::csr<ValueType, IndexType> m)
+    GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_ILU_SPARSELIB_ILU_KERNEL);

--- a/omp/factorization/lu_kernels.cpp
+++ b/omp/factorization/lu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -26,19 +26,19 @@ namespace lu_factorization {
 
 template <typename ValueType, typename IndexType>
 void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
+                matrix::view::csr<const ValueType, const IndexType> mtx,
                 const IndexType* factor_lookup_offsets,
                 const int64* factor_lookup_descs,
                 const int32* factor_lookup_storage, IndexType* diag_idxs,
-                matrix::Csr<ValueType, IndexType>* factors)
+                matrix::view::csr<ValueType, IndexType> factors)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto mtx_row_ptrs = mtx->get_const_row_ptrs();
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto mtx_cols = mtx->get_const_col_idxs();
-    const auto factor_cols = factors->get_const_col_idxs();
-    const auto mtx_vals = mtx->get_const_values();
-    const auto factor_vals = factors->get_values();
+    const auto num_rows = mtx.size[0];
+    const auto mtx_row_ptrs = mtx.row_ptrs;
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto mtx_cols = mtx.col_idxs;
+    const auto factor_cols = factors.col_idxs;
+    const auto mtx_vals = mtx.values;
+    const auto factor_vals = factors.values;
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; row++) {
         const auto factor_begin = factor_row_ptrs[row];
@@ -69,13 +69,13 @@ template <bool full_fillin, typename ValueType, typename IndexType>
 void factorize_impl(std::shared_ptr<const DefaultExecutor> exec,
                     const IndexType* lookup_offsets, const int64* lookup_descs,
                     const int32* lookup_storage, const IndexType* diag_idxs,
-                    matrix::Csr<ValueType, IndexType>* factors,
+                    matrix::view::csr<ValueType, IndexType> factors,
                     array<int>& tmp_storage)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto row_ptrs = factors->get_const_row_ptrs();
-    const auto cols = factors->get_const_col_idxs();
-    const auto vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto row_ptrs = factors.row_ptrs;
+    const auto cols = factors.col_idxs;
+    const auto vals = factors.values;
     // TODO parallelize
     for (size_type row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
@@ -114,8 +114,8 @@ template <typename ValueType, typename IndexType>
 void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const IndexType* lookup_offsets, const int64* lookup_descs,
                const int32* lookup_storage, const IndexType* diag_idxs,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage)
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage)
 {
     if (full_fillin) {
         factorize_impl<true>(exec, lookup_offsets, lookup_descs, lookup_storage,
@@ -134,12 +134,12 @@ void symbolic_factorize_simple(
     std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_ptrs,
     const IndexType* col_idxs, const IndexType* lookup_offsets,
     const int64* lookup_descs, const int32* lookup_storage,
-    matrix::Csr<float, IndexType>* factors, IndexType* out_row_nnz)
+    matrix::view::csr<float, IndexType> factors, IndexType* out_row_nnz)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto factor_cols = factors->get_const_col_idxs();
-    const auto factor_vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto factor_cols = factors.col_idxs;
+    const auto factor_vals = factors.values;
     array<IndexType> diag_idx_array{exec, num_rows};
     const auto diag_idxs = diag_idx_array.get_data();
     for (size_type row = 0; row < num_rows; row++) {
@@ -193,14 +193,15 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_LU_SYMMETRIC_FACTORIZE_SIMPLE);
 template <typename IndexType>
 void symbolic_factorize_simple_finalize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<float, IndexType>* factors, IndexType* out_col_idxs)
+    matrix::view::csr<const float, const IndexType> factors,
+    IndexType* out_col_idxs)
 {
-    const auto col_idxs = factors->get_const_col_idxs();
-    const auto vals = factors->get_const_values();
+    const auto col_idxs = factors.col_idxs;
+    const auto vals = factors.values;
     size_type output_idx{};
     // copy all nonzero entries from the symmetric factor to the unsymmetric
     // factor
-    for (size_type i = 0; i < factors->get_num_stored_elements(); i++) {
+    for (size_type i = 0; i < factors.num_stored_elements; i++) {
         if (vals[i] == one<float>()) {
             out_col_idxs[output_idx] = col_idxs[i];
             ++output_idx;

--- a/omp/factorization/par_ic_kernels.cpp
+++ b/omp/factorization/par_ic_kernels.cpp
@@ -24,11 +24,11 @@ namespace par_ic_factorization {
 
 template <typename ValueType, typename IndexType>
 void init_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 matrix::Csr<ValueType, IndexType>* l)
+                 matrix::view::csr<ValueType, IndexType> l)
 {
-    auto num_rows = l->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_vals = l->get_values();
+    auto num_rows = l.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_vals = l.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -50,12 +50,12 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type iterations,
                     matrix::view::coo<const ValueType, const IndexType> a_lower,
-                    matrix::Csr<ValueType, IndexType>* l)
+                    matrix::view::csr<ValueType, IndexType> l)
 {
     auto num_rows = a_lower.size[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto a_vals = a_lower.values;
 
     for (size_type i = 0; i < iterations; ++i) {

--- a/omp/factorization/par_ict_kernels.cpp
+++ b/omp/factorization/par_ict_kernels.cpp
@@ -34,17 +34,17 @@ namespace par_ict_factorization {
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType>)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -99,15 +99,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto l_new = l_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();

--- a/omp/factorization/par_ict_kernels.cpp
+++ b/omp/factorization/par_ict_kernels.cpp
@@ -99,12 +99,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> llh,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* llh,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a.size[0];
+    auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = l.values;

--- a/omp/factorization/par_ict_kernels.cpp
+++ b/omp/factorization/par_ict_kernels.cpp
@@ -34,17 +34,17 @@ namespace par_ict_factorization {
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType>)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -99,15 +99,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
     // count nnz

--- a/omp/factorization/par_ilu_kernels.cpp
+++ b/omp/factorization/par_ilu_kernels.cpp
@@ -27,8 +27,8 @@ template <typename ValueType, typename IndexType>
 void compute_l_u_factors(
     std::shared_ptr<const OmpExecutor> exec, size_type iterations,
     matrix::view::coo<const ValueType, const IndexType> system_matrix,
-    matrix::Csr<ValueType, IndexType>* l_factor,
-    matrix::Csr<ValueType, IndexType>* u_factor)
+    matrix::view::csr<ValueType, IndexType> l_factor,
+    matrix::view::csr<ValueType, IndexType> u_factor)
 {
     // If `iterations` is set to `Auto`, we do 3 fix-point sweeps as
     // experiments indicate this works well for many problems.
@@ -36,12 +36,12 @@ void compute_l_u_factors(
     const auto col_idxs = system_matrix.col_idxs;
     const auto row_idxs = system_matrix.row_idxs;
     const auto vals = system_matrix.values;
-    const auto row_ptrs_l = l_factor->get_const_row_ptrs();
-    const auto row_ptrs_u = u_factor->get_const_row_ptrs();
-    const auto col_idxs_l = l_factor->get_const_col_idxs();
-    const auto col_idxs_u = u_factor->get_const_col_idxs();
-    auto vals_l = l_factor->get_values();
-    auto vals_u = u_factor->get_values();
+    const auto row_ptrs_l = l_factor.row_ptrs;
+    const auto row_ptrs_u = u_factor.row_ptrs;
+    const auto col_idxs_l = l_factor.col_idxs;
+    const auto col_idxs_u = u_factor.col_idxs;
+    auto vals_l = l_factor.values;
+    auto vals_u = u_factor.values;
     for (size_type iter = 0; iter < iterations; ++iter) {
         // all elements in the incomplete factors are updated in parallel
 #pragma omp parallel for

--- a/omp/factorization/par_ilut_kernels.cpp
+++ b/omp/factorization/par_ilut_kernels.cpp
@@ -37,13 +37,13 @@ namespace par_ilut_factorization {
 
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp,
                       array<remove_complex<ValueType>>&,
                       remove_complex<ValueType>& threshold)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     tmp.resize_and_reset(size);
     std::copy_n(values, size, tmp.get_data());
 
@@ -67,15 +67,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* m,
+                     matrix::view::csr<const ValueType, const IndexType> m,
                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
-    auto num_rows = m->get_size()[0];
-    auto row_ptrs = m->get_const_row_ptrs();
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto num_rows = m.size[0];
+    auto row_ptrs = m.row_ptrs;
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
 
     auto m_out = m_out_builder->get_matrix();
     // first sweep: count nnz for each row
@@ -132,13 +132,13 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       remove_complex<ValueType> threshold,
                       matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
     abstract_filter(
         exec, m, m_out_builder, m_out_coo, [&](IndexType row, IndexType nz) {
             return abs(vals[nz]) >= threshold || col_idxs[nz] == row;
@@ -156,14 +156,14 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 template <typename ValueType, typename IndexType>
 void threshold_filter_approx(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
     matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto vals = m->get_const_values();
-    auto col_idxs = m->get_const_col_idxs();
-    auto size = static_cast<IndexType>(m->get_num_stored_elements());
+    auto vals = m.values;
+    auto col_idxs = m.col_idxs;
+    auto size = static_cast<IndexType>(m.num_stored_elements);
     using AbsType = remove_complex<ValueType>;
     auto num_threads = omp_get_max_threads();
     auto storage_size =
@@ -240,26 +240,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
+                         matrix::view::csr<const ValueType, const IndexType> a,
+                         matrix::view::csr<ValueType, IndexType> l,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u,
+                         matrix::view::csr<ValueType, IndexType> u,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+                         matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_values();
-    auto ut_col_ptrs = u_csc->get_const_row_ptrs();
-    auto ut_row_idxs = u_csc->get_const_col_idxs();
-    auto ut_vals = u_csc->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
+    auto ut_col_ptrs = u_csc.row_ptrs;
+    auto ut_row_idxs = u_csc.col_idxs;
+    auto ut_vals = u_csc.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
     auto compute_sum = [&](IndexType row, IndexType col) {
         // find value from A
@@ -324,20 +324,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
                     matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
     auto l_new = l_new_builder->get_matrix();
     auto u_new = u_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();

--- a/omp/factorization/par_ilut_kernels.cpp
+++ b/omp/factorization/par_ilut_kernels.cpp
@@ -324,14 +324,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> lu,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* lu,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a.size[0];
+    auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = l.values;

--- a/omp/factorization/par_ilut_kernels.cpp
+++ b/omp/factorization/par_ilut_kernels.cpp
@@ -37,13 +37,13 @@ namespace par_ilut_factorization {
 
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp,
                       array<remove_complex<ValueType>>&,
                       remove_complex<ValueType>& threshold)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     tmp.resize_and_reset(size);
     std::copy_n(values, size, tmp.get_data());
 
@@ -67,15 +67,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* m,
+                     matrix::view::csr<const ValueType, const IndexType> m,
                      matrix::Csr<ValueType, IndexType>* m_out,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
-    auto num_rows = m->get_size()[0];
-    auto row_ptrs = m->get_const_row_ptrs();
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto num_rows = m.size[0];
+    auto row_ptrs = m.row_ptrs;
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
 
     // first sweep: count nnz for each row
     auto new_row_ptrs = m_out->get_row_ptrs();
@@ -132,13 +132,13 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
     abstract_filter(
         exec, m, m_out, m_out_coo, [&](IndexType row, IndexType nz) {
             return abs(vals[nz]) >= threshold || col_idxs[nz] == row;
@@ -154,16 +154,16 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 
 
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto vals = m->get_const_values();
-    auto col_idxs = m->get_const_col_idxs();
-    auto size = static_cast<IndexType>(m->get_num_stored_elements());
+    auto vals = m.values;
+    auto col_idxs = m.col_idxs;
+    auto size = static_cast<IndexType>(m.num_stored_elements);
     using AbsType = remove_complex<ValueType>;
     auto num_threads = omp_get_max_threads();
     auto storage_size =
@@ -240,26 +240,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
+                         matrix::view::csr<const ValueType, const IndexType> a,
+                         matrix::view::csr<ValueType, IndexType> l,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u,
+                         matrix::view::csr<ValueType, IndexType> u,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+                         matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_values();
-    auto ut_col_ptrs = u_csc->get_const_row_ptrs();
-    auto ut_row_idxs = u_csc->get_const_col_idxs();
-    auto ut_vals = u_csc->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
+    auto ut_col_ptrs = u_csc.row_ptrs;
+    auto ut_row_idxs = u_csc.col_idxs;
+    auto ut_vals = u_csc.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
     auto compute_sum = [&](IndexType row, IndexType col) {
         // find value from A
@@ -324,20 +324,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -205,7 +205,7 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const OmpExecutor> exec,
           const matrix::csr::spmv_strategy strategy, const IndexType,
-          const matrix::Csr<MatrixValueType, IndexType>* a,
+          matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
 {
@@ -215,12 +215,10 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (strategy == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
-            exec, a->get_const_device_view(), b, c,
-            [](auto val) { return val; },
+            exec, a, b, c, [](auto val) { return val; },
             [](auto) { return zero<arithmetic_type>(); });
     } else {
-        classical_spmv(exec, a->get_const_device_view(), b, c,
-                       [](auto sum, auto) { return sum; });
+        classical_spmv(exec, a, b, c, [](auto sum, auto) { return sum; });
     }
 }
 
@@ -233,7 +231,7 @@ template <typename MatrixValueType, typename InputValueType,
 void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
                    const matrix::csr::spmv_strategy strategy, const IndexType,
                    matrix::view::dense<const MatrixValueType> alpha,
-                   const matrix::Csr<MatrixValueType, IndexType>* a,
+                   matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,
                    matrix::view::dense<const OutputValueType> beta,
                    matrix::view::dense<OutputValueType> c)
@@ -246,18 +244,16 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (strategy == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
-            exec, a->get_const_device_view(), b, c,
-            [valpha](auto val) { return valpha * val; },
+            exec, a, b, c, [valpha](auto val) { return valpha * val; },
             [vbeta](auto val) {
                 return is_zero(vbeta) ? zero(vbeta) : val * vbeta;
             });
     } else {
-        classical_spmv(exec, a->get_const_device_view(), b, c,
-                       [valpha, vbeta](auto sum, auto orig_val) {
-                           auto scaled_orig_val =
-                               is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
-                           return valpha * sum + scaled_orig_val;
-                       });
+        classical_spmv(exec, a, b, c, [valpha, vbeta](auto sum, auto orig_val) {
+            auto scaled_orig_val =
+                is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
+            return valpha * sum + scaled_orig_val;
+        });
     }
 }
 
@@ -281,7 +277,7 @@ template <typename ValueType, typename IndexType>
 struct col_heap_element {
     using value_type = ValueType;
     using index_type = IndexType;
-    using matrix_type = matrix::Csr<ValueType, IndexType>;
+    using matrix_type = matrix::view::csr<const ValueType, const IndexType>;
 
     IndexType idx;
     IndexType end;
@@ -308,7 +304,7 @@ template <typename ValueType, typename IndexType>
 struct val_heap_element {
     using value_type = ValueType;
     using index_type = IndexType;
-    using matrix_type = matrix::Csr<ValueType, IndexType>;
+    using matrix_type = matrix::view::csr<const ValueType, const IndexType>;
 
     IndexType idx;
     IndexType end;
@@ -393,18 +389,18 @@ void sift_down(HeapElement* heap, typename HeapElement::index_type idx,
 template <typename HeapElement, typename InitCallback, typename StepCallback,
           typename ColCallback>
 auto spgemm_multiway_merge(size_type row,
-                           const typename HeapElement::matrix_type* a,
-                           const typename HeapElement::matrix_type* b,
+                           const typename HeapElement::matrix_type a,
+                           const typename HeapElement::matrix_type b,
                            HeapElement* heap, InitCallback init_cb,
                            StepCallback step_cb, ColCallback col_cb)
     -> decltype(init_cb(0))
 {
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_cols = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_cols = b->get_const_col_idxs();
-    auto b_vals = b->get_const_values();
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_cols = a.col_idxs;
+    auto a_vals = a.values;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_cols = b.col_idxs;
+    auto b_vals = b.values;
     auto a_begin = a_row_ptrs[row];
     auto a_end = a_row_ptrs[row + 1];
 
@@ -458,16 +454,16 @@ auto spgemm_multiway_merge(size_type row,
 
 template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const OmpExecutor> exec,
-            const matrix::Csr<ValueType, IndexType>* a,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> a,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto num_rows = a->get_size()[0];
+    auto num_rows = a.size[0];
     auto c = c_builder->get_matrix();
     auto c_row_ptrs = c->get_row_ptrs();
 
     array<col_heap_element<ValueType, IndexType>> col_heap_array(
-        exec, a->get_num_stored_elements());
+        exec, a.num_stored_elements);
 
     auto col_heap = col_heap_array.get_data();
 
@@ -483,7 +479,7 @@ void spgemm(std::shared_ptr<const OmpExecutor> exec,
     col_heap_array.clear();
 
     array<val_heap_element<ValueType, IndexType>> heap_array(
-        exec, a->get_num_stored_elements());
+        exec, a.num_stored_elements);
 
     auto heap = heap_array.get_data();
 
@@ -523,13 +519,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEMM_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
                      matrix::view::dense<const ValueType> alpha,
-                     const matrix::Csr<ValueType, IndexType>* a,
-                     const matrix::Csr<ValueType, IndexType>* b,
+                     matrix::view::csr<const ValueType, const IndexType> a,
+                     matrix::view::csr<const ValueType, const IndexType> b,
                      matrix::view::dense<const ValueType> beta,
-                     const matrix::Csr<ValueType, IndexType>* d,
+                     matrix::view::csr<const ValueType, const IndexType> d,
                      matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto num_rows = a->get_size()[0];
+    auto num_rows = a.size[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
@@ -537,12 +533,12 @@ void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
     auto c = c_builder->get_matrix();
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
-    auto d_row_ptrs = d->get_const_row_ptrs();
-    auto d_cols = d->get_const_col_idxs();
-    auto d_vals = d->get_const_values();
+    auto d_row_ptrs = d.row_ptrs;
+    auto d_cols = d.col_idxs;
+    auto d_vals = d.values;
 
     array<val_heap_element<ValueType, IndexType>> heap_array(
-        exec, a->get_num_stored_elements());
+        exec, a.num_stored_elements);
 
     auto heap = heap_array.get_data();
     auto col_heap =
@@ -767,12 +763,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void spgeam(std::shared_ptr<const OmpExecutor> exec,
             matrix::view::dense<const ValueType> alpha,
-            const matrix::Csr<ValueType, IndexType>* a,
+            matrix::view::csr<const ValueType, const IndexType> a,
             matrix::view::dense<const ValueType> beta,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto num_rows = a->get_size()[0];
+    auto num_rows = a.size[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
 
@@ -781,8 +777,7 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [](IndexType) { return IndexType{}; },
+        a, b, [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -801,8 +796,7 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [&](IndexType row) { return c_row_ptrs[row]; },
+        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -81,7 +81,7 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType, typename AlphaOp,
           typename BetaOp>
 void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
-                const matrix::Csr<MatrixValueType, IndexType>* a,
+                matrix::view::csr<const MatrixValueType, const IndexType> a,
                 matrix::view::dense<const InputValueType> b,
                 matrix::view::dense<OutputValueType> c, AlphaOp alpha_op,
                 BetaOp beta_op)
@@ -89,8 +89,8 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a->get_const_row_ptrs();
-    auto col_idxs = a->get_const_col_idxs();
+    auto row_ptrs = a.row_ptrs;
+    auto col_idxs = a.col_idxs;
 
     const auto a_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
@@ -99,8 +99,8 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
 
     // Merge-SpMV variables
-    const auto num_rows = static_cast<IndexType>(a->get_size()[0]);
-    const auto nnz = static_cast<IndexType>(a->get_num_stored_elements());
+    const auto num_rows = static_cast<IndexType>(a.size[0]);
+    const auto nnz = static_cast<IndexType>(a.num_stored_elements);
     const auto num_threads = static_cast<IndexType>(omp_get_max_threads());
     // Merge list A: row end ptr
     const IndexType* row_end_ptrs = row_ptrs + 1;
@@ -169,15 +169,15 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType, typename Function>
 void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
-                    const matrix::Csr<MatrixValueType, IndexType>* a,
+                    matrix::view::csr<const MatrixValueType, const IndexType> a,
                     matrix::view::dense<const InputValueType> b,
                     matrix::view::dense<OutputValueType> c, Function lambda)
 {
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a->get_const_row_ptrs();
-    auto col_idxs = a->get_const_col_idxs();
+    auto row_ptrs = a.row_ptrs;
+    auto col_idxs = a.col_idxs;
 
     const auto a_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
@@ -186,7 +186,7 @@ void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
 
 #pragma omp parallel for
-    for (size_type row = 0; row < a->get_size()[0]; ++row) {
+    for (size_type row = 0; row < a.size[0]; ++row) {
         for (size_type j = 0; j < c.size[1]; ++j) {
             auto sum = zero<arithmetic_type>();
             for (size_type k = row_ptrs[row];
@@ -215,10 +215,12 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (strategy == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
-            exec, a, b, c, [](auto val) { return val; },
+            exec, a->get_const_device_view(), b, c,
+            [](auto val) { return val; },
             [](auto) { return zero<arithmetic_type>(); });
     } else {
-        classical_spmv(exec, a, b, c, [](auto sum, auto) { return sum; });
+        classical_spmv(exec, a->get_const_device_view(), b, c,
+                       [](auto sum, auto) { return sum; });
     }
 }
 
@@ -244,16 +246,18 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (strategy == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
-            exec, a, b, c, [valpha](auto val) { return valpha * val; },
+            exec, a->get_const_device_view(), b, c,
+            [valpha](auto val) { return valpha * val; },
             [vbeta](auto val) {
                 return is_zero(vbeta) ? zero(vbeta) : val * vbeta;
             });
     } else {
-        classical_spmv(exec, a, b, c, [valpha, vbeta](auto sum, auto orig_val) {
-            auto scaled_orig_val =
-                is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
-            return valpha * sum + scaled_orig_val;
-        });
+        classical_spmv(exec, a->get_const_device_view(), b, c,
+                       [valpha, vbeta](auto sum, auto orig_val) {
+                           auto scaled_orig_val =
+                               is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
+                           return valpha * sum + scaled_orig_val;
+                       });
     }
 }
 
@@ -635,21 +639,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -686,28 +690,29 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
-    const auto d_vals = d->get_const_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
+    const auto d_vals = d.values;
     const auto valpha = alpha(0, 0);
     const auto vbeta = beta(0, 0);
     const auto lookup_storage_offsets =
@@ -776,7 +781,8 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a, b, [](IndexType) { return IndexType{}; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -795,7 +801,8 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;
@@ -811,16 +818,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const OmpExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
-    auto c_row_ptrs = c->get_const_row_ptrs();
-    auto c_col_idxs = c->get_const_col_idxs();
-    auto c_vals = c->get_values();
+    auto c_row_ptrs = c.row_ptrs;
+    auto c_col_idxs = c.col_idxs;
+    auto c_vals = c.values;
 
     abstract_spgeam(
         a, b, [&](IndexType row) { return c_row_ptrs[row]; },
@@ -838,14 +845,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const OmpExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
-    auto num_rows = source->get_size()[0];
-    auto num_cols = source->get_size()[1];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
-    auto vals = source->get_const_values();
+    auto num_rows = source.size[0];
+    auto num_cols = source.size[1];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
+    auto vals = source.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -861,20 +868,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
-                      array<ValueType>& values)
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
+    array<ValueType>& values)
 {
     using entry = matrix_data_entry<ValueType, IndexType>;
-    const auto num_rows = source->get_size()[0];
-    const auto num_cols = source->get_size()[1];
+    const auto num_rows = source.size[0];
+    const auto num_cols = source.size[1];
     const auto num_block_rows = num_rows / bs;
     const auto num_block_cols = num_cols / bs;
-    const auto in_row_ptrs = source->get_const_row_ptrs();
-    const auto in_cols = source->get_const_col_idxs();
-    const auto in_vals = source->get_const_values();
-    const auto nnz = source->get_num_stored_elements();
+    const auto in_row_ptrs = source.row_ptrs;
+    const auto in_cols = source.col_idxs;
+    const auto in_vals = source.values;
+    const auto nnz = source.num_stored_elements;
     auto out_row_ptrs = row_ptrs.get_data();
     array<entry> entry_array{exec, nnz};
     auto entries = entry_array.get_data();
@@ -948,20 +956,20 @@ inline void convert_csr_to_csc(size_type num_rows, const IndexType* row_ptrs,
 
 
 template <typename ValueType, typename IndexType, typename UnaryOperator>
-void transpose_and_transform(std::shared_ptr<const OmpExecutor> exec,
-                             matrix::Csr<ValueType, IndexType>* trans,
-                             const matrix::Csr<ValueType, IndexType>* orig,
-                             UnaryOperator op)
+void transpose_and_transform(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<ValueType, IndexType> trans,
+    matrix::view::csr<const ValueType, const IndexType> orig, UnaryOperator op)
 {
-    auto trans_row_ptrs = trans->get_row_ptrs();
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto trans_col_idxs = trans->get_col_idxs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto trans_vals = trans->get_values();
-    auto orig_vals = orig->get_const_values();
+    auto trans_row_ptrs = trans.row_ptrs;
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto trans_col_idxs = trans.col_idxs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto trans_vals = trans.values;
+    auto orig_vals = orig.values;
 
-    auto orig_num_cols = orig->get_size()[1];
-    auto orig_num_rows = orig->get_size()[0];
+    auto orig_num_cols = orig.size[1];
+    auto orig_num_rows = orig.size[0];
     auto orig_nnz = orig_row_ptrs[orig_num_rows];
 
     components::fill_array(exec, trans_row_ptrs, orig_num_cols + 1,
@@ -978,8 +986,8 @@ void transpose_and_transform(std::shared_ptr<const OmpExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const OmpExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return x; });
@@ -990,8 +998,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_TRANSPOSE_KERNEL);
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const OmpExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return conj(x); });
@@ -1004,11 +1012,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
 #pragma omp parallel for
     for (size_type row = row_span.begin; row < row_span.end; ++row) {
         row_nnz.get_data()[row - row_span.begin] = zero<IndexType>();
@@ -1028,7 +1036,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set, IndexType* row_nnz)
 {
@@ -1039,7 +1047,7 @@ void calculate_nonzeros_per_row_in_index_set(
     auto row_subset_end = row_index_set.get_subsets_end();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
-    auto src_ptrs = source->get_const_row_ptrs();
+    auto src_ptrs = source.row_ptrs;
 
 #pragma omp parallel for
     for (size_type set = 0; set < num_row_subsets; ++set) {
@@ -1048,7 +1056,7 @@ void calculate_nonzeros_per_row_in_index_set(
              ++row) {
             row_nnz[res_row] = zero<IndexType>();
             for (size_type i = src_ptrs[row]; i < src_ptrs[row + 1]; ++i) {
-                auto index = source->get_const_col_idxs()[i];
+                auto index = source.col_idxs[i];
                 if (index >= col_index_set.get_size()) {
                     continue;
                 }
@@ -1073,19 +1081,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     auto row_offset = row_span.begin;
     auto col_offset = col_span.begin;
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto values = source->get_const_values();
-    auto res_row_ptrs = result->get_row_ptrs();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
+    const auto values = source.values;
+    auto res_row_ptrs = result.row_ptrs;
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
         size_type res_nnz = res_row_ptrs[row];
@@ -1093,8 +1102,8 @@ void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
              nnz < row_ptrs[row_offset + row + 1]; ++nnz) {
             const auto local_col = col_idxs[nnz] - col_offset;
             if (local_col >= 0 && local_col < num_cols) {
-                result->get_col_idxs()[res_nnz] = local_col;
-                result->get_values()[res_nnz] = values[nnz];
+                result.col_idxs[res_nnz] = local_col;
+                result.values[res_nnz] = values[nnz];
                 res_nnz++;
             }
         }
@@ -1108,27 +1117,27 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
     auto num_row_subsets = row_index_set.get_num_subsets();
     auto row_subset_begin = row_index_set.get_subsets_begin();
     auto row_subset_end = row_index_set.get_subsets_end();
     auto row_superset_indices = row_index_set.get_superset_indices();
-    auto res_row_ptrs = result->get_row_ptrs();
-    auto res_col_idxs = result->get_col_idxs();
-    auto res_values = result->get_values();
+    auto res_row_ptrs = result.row_ptrs;
+    auto res_col_idxs = result.col_idxs;
+    auto res_values = result.values;
     auto num_col_subsets = col_index_set.get_num_subsets();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
     auto col_superset_indices = col_index_set.get_superset_indices();
-    const auto src_ptrs = source->get_const_row_ptrs();
-    const auto src_col_idxs = source->get_const_col_idxs();
-    const auto src_values = source->get_const_values();
+    const auto src_ptrs = source.row_ptrs;
+    const auto src_col_idxs = source.col_idxs;
+    const auto src_values = source.values;
 
 #pragma unroll
     for (size_type set = 0; set < num_row_subsets; ++set) {
@@ -1168,8 +1177,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const DefaultExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_permute(exec, perm, perm, orig, permuted);
 }
@@ -1179,19 +1188,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,
-                         const IndexType* row_perm,
-                         const IndexType* column_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_perm,
+    const IndexType* column_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1220,16 +1229,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const OmpExecutor> exec, const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1259,16 +1268,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const OmpExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1296,10 +1305,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_scale_permute(exec, scale, perm, scale, perm, orig, permuted);
 }
@@ -1309,21 +1319,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1355,16 +1364,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const OmpExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1394,18 +1403,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const OmpExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const OmpExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1436,12 +1446,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const OmpExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    auto values = to_sort->get_values();
-    auto row_ptrs = to_sort->get_row_ptrs();
-    auto col_idxs = to_sort->get_col_idxs();
-    const auto number_rows = to_sort->get_size()[0];
+    auto values = to_sort.values;
+    auto row_ptrs = to_sort.row_ptrs;
+    auto col_idxs = to_sort.col_idxs;
+    const auto number_rows = to_sort.size[0];
 #pragma omp parallel for
     for (size_type i = 0; i < number_rows; ++i) {
         auto start_row_idx = row_ptrs[i];
@@ -1460,11 +1470,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
-    const auto row_ptrs = to_check->get_const_row_ptrs();
-    const auto col_idxs = to_check->get_const_col_idxs();
-    const auto size = to_check->get_size();
+    const auto row_ptrs = to_check.row_ptrs;
+    const auto col_idxs = to_check.col_idxs;
+    const auto size = to_check.size;
     bool local_is_sorted = true;
 #pragma omp parallel for reduction(&& : local_is_sorted)
     for (size_type i = 0; i < size[0]; ++i) {
@@ -1487,12 +1498,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const OmpExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto row_ptrs = orig->get_const_row_ptrs();
-    const auto col_idxs = orig->get_const_col_idxs();
-    const auto values = orig->get_const_values();
+    const auto row_ptrs = orig.row_ptrs;
+    const auto col_idxs = orig.col_idxs;
+    const auto values = orig.values;
     const auto diag_size = diag->get_size()[0];
     auto diag_values = diag->get_values();
 
@@ -1511,14 +1522,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_EXTRACT_DIAGONAL);
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const OmpExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
     bool l_has_all_diags = true;
-    const size_type minsize = std::min(mtx->get_size()[0], mtx->get_size()[1]);
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idxs = mtx->get_const_col_idxs();
+    const size_type minsize = std::min(mtx.size[0], mtx.size[1]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idxs = mtx.col_idxs;
 #pragma omp parallel for reduction(&& : l_has_all_diags)
     for (size_type row = 0; row < minsize; row++) {
         bool row_diag = false;
@@ -1542,11 +1554,11 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const OmpExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = static_cast<IndexType>(mtx->get_size()[0]);
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto vals = mtx->get_values();
+    const auto nrows = static_cast<IndexType>(mtx.size[0]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto vals = mtx.values;
     const auto beta_val = beta.values[0];
     const auto alpha_val = alpha.values[0];
 #pragma omp parallel for
@@ -1555,8 +1567,7 @@ void add_scaled_identity(std::shared_ptr<const OmpExecutor> exec,
             if (beta_val != one<ValueType>()) {
                 vals[iz] *= beta_val;
             }
-            if (row == mtx->get_const_col_idxs()[iz] &&
-                alpha_val != zero<ValueType>()) {
+            if (row == mtx.col_idxs[iz] && alpha_val != zero<ValueType>()) {
                 vals[iz] += alpha_val;
             }
         }

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -204,7 +204,9 @@ void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const OmpExecutor> exec,
-          const matrix::csr::spmv_strategy strategy, const IndexType,
+          const matrix::csr::spmv_strategy strategy,
+          const IndexType /* max_nnz_per_row */,
+          size_type /* num_srow_elements */, const IndexType* /*srow*/,
           matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
@@ -229,7 +231,9 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
-                   const matrix::csr::spmv_strategy strategy, const IndexType,
+                   const matrix::csr::spmv_strategy strategy,
+                   const IndexType /* max_nnz_per_row */,
+                   size_type /* num_srow_elements */, const IndexType* /*srow*/,
                    matrix::view::dense<const MatrixValueType> alpha,
                    matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -84,7 +84,7 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType, typename AlphaOp,
           typename BetaOp>
 void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
-                const matrix::Csr<MatrixValueType, IndexType>* a,
+                matrix::view::csr<const MatrixValueType, const IndexType> a,
                 matrix::view::dense<const InputValueType> b,
                 matrix::view::dense<OutputValueType> c, AlphaOp alpha_op,
                 BetaOp beta_op)
@@ -92,8 +92,8 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a->get_const_row_ptrs();
-    auto col_idxs = a->get_const_col_idxs();
+    auto row_ptrs = a.row_ptrs;
+    auto col_idxs = a.col_idxs;
 
     const auto a_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
@@ -102,8 +102,8 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
 
     // Merge-SpMV variables
-    const auto num_rows = static_cast<IndexType>(a->get_size()[0]);
-    const auto nnz = static_cast<IndexType>(a->get_num_stored_elements());
+    const auto num_rows = static_cast<IndexType>(a.size[0]);
+    const auto nnz = static_cast<IndexType>(a.num_stored_elements);
     const auto num_threads = static_cast<IndexType>(omp_get_max_threads());
     // Merge list A: row end ptr
     const IndexType* row_end_ptrs = row_ptrs + 1;
@@ -172,15 +172,15 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType, typename Function>
 void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
-                    const matrix::Csr<MatrixValueType, IndexType>* a,
+                    matrix::view::csr<const MatrixValueType, const IndexType> a,
                     matrix::view::dense<const InputValueType> b,
                     matrix::view::dense<OutputValueType> c, Function lambda)
 {
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a->get_const_row_ptrs();
-    auto col_idxs = a->get_const_col_idxs();
+    auto row_ptrs = a.row_ptrs;
+    auto col_idxs = a.col_idxs;
 
     const auto a_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
@@ -189,7 +189,7 @@ void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
 
 #pragma omp parallel for
-    for (size_type row = 0; row < a->get_size()[0]; ++row) {
+    for (size_type row = 0; row < a.size[0]; ++row) {
         for (size_type j = 0; j < c.size[1]; ++j) {
             auto sum = zero<arithmetic_type>();
             for (size_type k = row_ptrs[row];
@@ -217,10 +217,12 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (a->get_strategy()->get_name() == "merge_path") {
         merge_spmv(
-            exec, a, b, c, [](auto val) { return val; },
+            exec, a->get_const_device_view(), b, c,
+            [](auto val) { return val; },
             [](auto) { return zero<arithmetic_type>(); });
     } else {
-        classical_spmv(exec, a, b, c, [](auto sum, auto) { return sum; });
+        classical_spmv(exec, a->get_const_device_view(), b, c,
+                       [](auto sum, auto) { return sum; });
     }
 }
 
@@ -245,16 +247,18 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (a->get_strategy()->get_name() == "merge_path") {
         merge_spmv(
-            exec, a, b, c, [valpha](auto val) { return valpha * val; },
+            exec, a->get_const_device_view(), b, c,
+            [valpha](auto val) { return valpha * val; },
             [vbeta](auto val) {
                 return is_zero(vbeta) ? zero(vbeta) : val * vbeta;
             });
     } else {
-        classical_spmv(exec, a, b, c, [valpha, vbeta](auto sum, auto orig_val) {
-            auto scaled_orig_val =
-                is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
-            return valpha * sum + scaled_orig_val;
-        });
+        classical_spmv(exec, a->get_const_device_view(), b, c,
+                       [valpha, vbeta](auto sum, auto orig_val) {
+                           auto scaled_orig_val =
+                               is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
+                           return valpha * sum + scaled_orig_val;
+                       });
     }
 }
 
@@ -636,21 +640,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -687,28 +691,29 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
-    const auto d_vals = d->get_const_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
+    const auto d_vals = d.values;
     const auto valpha = alpha(0, 0);
     const auto vbeta = beta(0, 0);
     const auto lookup_storage_offsets =
@@ -776,7 +781,8 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a, b, [](IndexType) { return IndexType{}; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -796,7 +802,8 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;
@@ -812,16 +819,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const OmpExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
-    auto c_row_ptrs = c->get_const_row_ptrs();
-    auto c_col_idxs = c->get_const_col_idxs();
-    auto c_vals = c->get_values();
+    auto c_row_ptrs = c.row_ptrs;
+    auto c_col_idxs = c.col_idxs;
+    auto c_vals = c.values;
 
     abstract_spgeam(
         a, b, [&](IndexType row) { return c_row_ptrs[row]; },
@@ -839,14 +846,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const OmpExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
-    auto num_rows = source->get_size()[0];
-    auto num_cols = source->get_size()[1];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
-    auto vals = source->get_const_values();
+    auto num_rows = source.size[0];
+    auto num_cols = source.size[1];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
+    auto vals = source.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -862,20 +869,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
-                      array<ValueType>& values)
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
+    array<ValueType>& values)
 {
     using entry = matrix_data_entry<ValueType, IndexType>;
-    const auto num_rows = source->get_size()[0];
-    const auto num_cols = source->get_size()[1];
+    const auto num_rows = source.size[0];
+    const auto num_cols = source.size[1];
     const auto num_block_rows = num_rows / bs;
     const auto num_block_cols = num_cols / bs;
-    const auto in_row_ptrs = source->get_const_row_ptrs();
-    const auto in_cols = source->get_const_col_idxs();
-    const auto in_vals = source->get_const_values();
-    const auto nnz = source->get_num_stored_elements();
+    const auto in_row_ptrs = source.row_ptrs;
+    const auto in_cols = source.col_idxs;
+    const auto in_vals = source.values;
+    const auto nnz = source.num_stored_elements;
     auto out_row_ptrs = row_ptrs.get_data();
     array<entry> entry_array{exec, nnz};
     auto entries = entry_array.get_data();
@@ -949,20 +957,20 @@ inline void convert_csr_to_csc(size_type num_rows, const IndexType* row_ptrs,
 
 
 template <typename ValueType, typename IndexType, typename UnaryOperator>
-void transpose_and_transform(std::shared_ptr<const OmpExecutor> exec,
-                             matrix::Csr<ValueType, IndexType>* trans,
-                             const matrix::Csr<ValueType, IndexType>* orig,
-                             UnaryOperator op)
+void transpose_and_transform(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<ValueType, IndexType> trans,
+    matrix::view::csr<const ValueType, const IndexType> orig, UnaryOperator op)
 {
-    auto trans_row_ptrs = trans->get_row_ptrs();
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto trans_col_idxs = trans->get_col_idxs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto trans_vals = trans->get_values();
-    auto orig_vals = orig->get_const_values();
+    auto trans_row_ptrs = trans.row_ptrs;
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto trans_col_idxs = trans.col_idxs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto trans_vals = trans.values;
+    auto orig_vals = orig.values;
 
-    auto orig_num_cols = orig->get_size()[1];
-    auto orig_num_rows = orig->get_size()[0];
+    auto orig_num_cols = orig.size[1];
+    auto orig_num_rows = orig.size[0];
     auto orig_nnz = orig_row_ptrs[orig_num_rows];
 
     components::fill_array(exec, trans_row_ptrs, orig_num_cols + 1,
@@ -979,8 +987,8 @@ void transpose_and_transform(std::shared_ptr<const OmpExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const OmpExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return x; });
@@ -991,8 +999,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_TRANSPOSE_KERNEL);
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const OmpExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return conj(x); });
@@ -1005,11 +1013,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
 #pragma omp parallel for
     for (size_type row = row_span.begin; row < row_span.end; ++row) {
         row_nnz.get_data()[row - row_span.begin] = zero<IndexType>();
@@ -1029,7 +1037,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set, IndexType* row_nnz)
 {
@@ -1040,7 +1048,7 @@ void calculate_nonzeros_per_row_in_index_set(
     auto row_subset_end = row_index_set.get_subsets_end();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
-    auto src_ptrs = source->get_const_row_ptrs();
+    auto src_ptrs = source.row_ptrs;
 
 #pragma omp parallel for
     for (size_type set = 0; set < num_row_subsets; ++set) {
@@ -1049,7 +1057,7 @@ void calculate_nonzeros_per_row_in_index_set(
              ++row) {
             row_nnz[res_row] = zero<IndexType>();
             for (size_type i = src_ptrs[row]; i < src_ptrs[row + 1]; ++i) {
-                auto index = source->get_const_col_idxs()[i];
+                auto index = source.col_idxs[i];
                 if (index >= col_index_set.get_size()) {
                     continue;
                 }
@@ -1074,19 +1082,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     auto row_offset = row_span.begin;
     auto col_offset = col_span.begin;
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    const auto row_ptrs = source->get_const_row_ptrs();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto values = source->get_const_values();
-    auto res_row_ptrs = result->get_row_ptrs();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    const auto row_ptrs = source.row_ptrs;
+    const auto col_idxs = source.col_idxs;
+    const auto values = source.values;
+    auto res_row_ptrs = result.row_ptrs;
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
         size_type res_nnz = res_row_ptrs[row];
@@ -1094,8 +1103,8 @@ void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
              nnz < row_ptrs[row_offset + row + 1]; ++nnz) {
             const auto local_col = col_idxs[nnz] - col_offset;
             if (local_col >= 0 && local_col < num_cols) {
-                result->get_col_idxs()[res_nnz] = local_col;
-                result->get_values()[res_nnz] = values[nnz];
+                result.col_idxs[res_nnz] = local_col;
+                result.values[res_nnz] = values[nnz];
                 res_nnz++;
             }
         }
@@ -1109,27 +1118,27 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
     auto num_row_subsets = row_index_set.get_num_subsets();
     auto row_subset_begin = row_index_set.get_subsets_begin();
     auto row_subset_end = row_index_set.get_subsets_end();
     auto row_superset_indices = row_index_set.get_superset_indices();
-    auto res_row_ptrs = result->get_row_ptrs();
-    auto res_col_idxs = result->get_col_idxs();
-    auto res_values = result->get_values();
+    auto res_row_ptrs = result.row_ptrs;
+    auto res_col_idxs = result.col_idxs;
+    auto res_values = result.values;
     auto num_col_subsets = col_index_set.get_num_subsets();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
     auto col_superset_indices = col_index_set.get_superset_indices();
-    const auto src_ptrs = source->get_const_row_ptrs();
-    const auto src_col_idxs = source->get_const_col_idxs();
-    const auto src_values = source->get_const_values();
+    const auto src_ptrs = source.row_ptrs;
+    const auto src_col_idxs = source.col_idxs;
+    const auto src_values = source.values;
 
 #pragma unroll
     for (size_type set = 0; set < num_row_subsets; ++set) {
@@ -1169,8 +1178,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const DefaultExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_permute(exec, perm, perm, orig, permuted);
 }
@@ -1180,19 +1189,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const DefaultExecutor> exec,
-                         const IndexType* row_perm,
-                         const IndexType* column_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_perm,
+    const IndexType* column_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1221,16 +1230,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const OmpExecutor> exec, const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1260,16 +1269,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const OmpExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1297,10 +1306,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_scale_permute(exec, scale, perm, scale, perm, orig, permuted);
 }
@@ -1310,21 +1320,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const DefaultExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const DefaultExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1356,16 +1365,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const OmpExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1395,18 +1404,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const OmpExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const OmpExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto orig_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto orig_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {
@@ -1437,12 +1447,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const OmpExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    auto values = to_sort->get_values();
-    auto row_ptrs = to_sort->get_row_ptrs();
-    auto col_idxs = to_sort->get_col_idxs();
-    const auto number_rows = to_sort->get_size()[0];
+    auto values = to_sort.values;
+    auto row_ptrs = to_sort.row_ptrs;
+    auto col_idxs = to_sort.col_idxs;
+    const auto number_rows = to_sort.size[0];
 #pragma omp parallel for
     for (size_type i = 0; i < number_rows; ++i) {
         auto start_row_idx = row_ptrs[i];
@@ -1461,11 +1471,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const OmpExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
-    const auto row_ptrs = to_check->get_const_row_ptrs();
-    const auto col_idxs = to_check->get_const_col_idxs();
-    const auto size = to_check->get_size();
+    const auto row_ptrs = to_check.row_ptrs;
+    const auto col_idxs = to_check.col_idxs;
+    const auto size = to_check.size;
     bool local_is_sorted = true;
 #pragma omp parallel for reduction(&& : local_is_sorted)
     for (size_type i = 0; i < size[0]; ++i) {
@@ -1488,12 +1499,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const OmpExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto row_ptrs = orig->get_const_row_ptrs();
-    const auto col_idxs = orig->get_const_col_idxs();
-    const auto values = orig->get_const_values();
+    const auto row_ptrs = orig.row_ptrs;
+    const auto col_idxs = orig.col_idxs;
+    const auto values = orig.values;
     const auto diag_size = diag->get_size()[0];
     auto diag_values = diag->get_values();
 
@@ -1512,14 +1523,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_EXTRACT_DIAGONAL);
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const OmpExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
     bool l_has_all_diags = true;
-    const size_type minsize = std::min(mtx->get_size()[0], mtx->get_size()[1]);
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idxs = mtx->get_const_col_idxs();
+    const size_type minsize = std::min(mtx.size[0], mtx.size[1]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idxs = mtx.col_idxs;
 #pragma omp parallel for reduction(&& : l_has_all_diags)
     for (size_type row = 0; row < minsize; row++) {
         bool row_diag = false;
@@ -1543,11 +1555,11 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const OmpExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = static_cast<IndexType>(mtx->get_size()[0]);
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto vals = mtx->get_values();
+    const auto nrows = static_cast<IndexType>(mtx.size[0]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto vals = mtx.values;
     const auto beta_val = beta.values[0];
     const auto alpha_val = alpha.values[0];
 #pragma omp parallel for
@@ -1556,8 +1568,7 @@ void add_scaled_identity(std::shared_ptr<const OmpExecutor> exec,
             if (beta_val != one<ValueType>()) {
                 vals[iz] *= beta_val;
             }
-            if (row == mtx->get_const_col_idxs()[iz] &&
-                alpha_val != zero<ValueType>()) {
+            if (row == mtx.col_idxs[iz] && alpha_val != zero<ValueType>()) {
                 vals[iz] += alpha_val;
             }
         }

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -84,7 +84,7 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType, typename AlphaOp,
           typename BetaOp>
 void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
-                matrix::view::csr<const MatrixValueType, const IndexType> a,
+                const matrix::Csr<MatrixValueType, IndexType>* a,
                 matrix::view::dense<const InputValueType> b,
                 matrix::view::dense<OutputValueType> c, AlphaOp alpha_op,
                 BetaOp beta_op)
@@ -92,8 +92,8 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a.row_ptrs;
-    auto col_idxs = a.col_idxs;
+    auto row_ptrs = a->get_const_row_ptrs();
+    auto col_idxs = a->get_const_col_idxs();
 
     const auto a_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
@@ -102,8 +102,8 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
 
     // Merge-SpMV variables
-    const auto num_rows = static_cast<IndexType>(a.size[0]);
-    const auto nnz = static_cast<IndexType>(a.num_stored_elements);
+    const auto num_rows = static_cast<IndexType>(a->get_size()[0]);
+    const auto nnz = static_cast<IndexType>(a->get_num_stored_elements());
     const auto num_threads = static_cast<IndexType>(omp_get_max_threads());
     // Merge list A: row end ptr
     const IndexType* row_end_ptrs = row_ptrs + 1;
@@ -172,15 +172,15 @@ void merge_spmv(std::shared_ptr<const OmpExecutor> exec,
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType, typename Function>
 void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
-                    matrix::view::csr<const MatrixValueType, const IndexType> a,
+                    const matrix::Csr<MatrixValueType, IndexType>* a,
                     matrix::view::dense<const InputValueType> b,
                     matrix::view::dense<OutputValueType> c, Function lambda)
 {
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a.row_ptrs;
-    auto col_idxs = a.col_idxs;
+    auto row_ptrs = a->get_const_row_ptrs();
+    auto col_idxs = a->get_const_col_idxs();
 
     const auto a_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
@@ -189,7 +189,7 @@ void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
 
 #pragma omp parallel for
-    for (size_type row = 0; row < a.size[0]; ++row) {
+    for (size_type row = 0; row < a->get_size()[0]; ++row) {
         for (size_type j = 0; j < c.size[1]; ++j) {
             auto sum = zero<arithmetic_type>();
             for (size_type k = row_ptrs[row];
@@ -217,12 +217,10 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (a->get_strategy()->get_name() == "merge_path") {
         merge_spmv(
-            exec, a->get_const_device_view(), b, c,
-            [](auto val) { return val; },
+            exec, a, b, c, [](auto val) { return val; },
             [](auto) { return zero<arithmetic_type>(); });
     } else {
-        classical_spmv(exec, a->get_const_device_view(), b, c,
-                       [](auto sum, auto) { return sum; });
+        classical_spmv(exec, a, b, c, [](auto sum, auto) { return sum; });
     }
 }
 
@@ -247,18 +245,16 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
         // empty output: nothing to do
     } else if (a->get_strategy()->get_name() == "merge_path") {
         merge_spmv(
-            exec, a->get_const_device_view(), b, c,
-            [valpha](auto val) { return valpha * val; },
+            exec, a, b, c, [valpha](auto val) { return valpha * val; },
             [vbeta](auto val) {
                 return is_zero(vbeta) ? zero(vbeta) : val * vbeta;
             });
     } else {
-        classical_spmv(exec, a->get_const_device_view(), b, c,
-                       [valpha, vbeta](auto sum, auto orig_val) {
-                           auto scaled_orig_val =
-                               is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
-                           return valpha * sum + scaled_orig_val;
-                       });
+        classical_spmv(exec, a, b, c, [valpha, vbeta](auto sum, auto orig_val) {
+            auto scaled_orig_val =
+                is_zero(vbeta) ? zero(vbeta) : orig_val * vbeta;
+            return valpha * sum + scaled_orig_val;
+        });
     }
 }
 
@@ -781,8 +777,7 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [](IndexType) { return IndexType{}; },
+        a, b, [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -802,8 +797,7 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [&](IndexType row) { return c_row_ptrs[row]; },
+        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;
@@ -819,9 +813,9 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const OmpExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::dense<const ValueType> beta,
-                    matrix::view::csr<const ValueType, const IndexType> b,
+                    const matrix::Csr<ValueType, IndexType>* b,
                     matrix::view::csr<ValueType, IndexType> c)
 {
     auto valpha = alpha(0, 0);

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -174,15 +174,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto num_nonzeros = result->get_num_stored_elements();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto num_nonzeros = result.num_stored_elements;
 
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -177,15 +177,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const DefaultExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto num_nonzeros = result->get_num_stored_elements();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto num_nonzeros = result.num_stored_elements;
 
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
 #pragma omp parallel for
     for (size_type row = 0; row < num_rows; ++row) {

--- a/omp/matrix/diagonal_kernels.cpp
+++ b/omp/matrix/diagonal_kernels.cpp
@@ -24,16 +24,15 @@ namespace diagonal {
 template <typename ValueType, typename IndexType>
 void apply_to_csr(std::shared_ptr<const OmpExecutor> exec,
                   const matrix::Diagonal<ValueType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
-                  matrix::Csr<ValueType, IndexType>* c, bool inverse)
+                  matrix::view::csr<const ValueType, const IndexType> b,
+                  matrix::view::csr<ValueType, IndexType> c, bool inverse)
 {
     const auto diag_values = a->get_const_values();
-    c->copy_from(b);
-    auto csr_values = c->get_values();
-    const auto csr_row_ptrs = c->get_const_row_ptrs();
+    auto csr_values = c.values;
+    const auto csr_row_ptrs = c.row_ptrs;
 
 #pragma omp parallel for
-    for (size_type row = 0; row < c->get_size()[0]; row++) {
+    for (size_type row = 0; row < c.size[0]; row++) {
         const auto scal =
             inverse ? one<ValueType>() / diag_values[row] : diag_values[row];
         for (size_type idx = csr_row_ptrs[row]; idx < csr_row_ptrs[row + 1];

--- a/omp/matrix/diagonal_kernels.cpp
+++ b/omp/matrix/diagonal_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/omp/matrix/fbcsr_kernels.cpp
+++ b/omp/matrix/fbcsr_kernels.cpp
@@ -221,15 +221,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(const std::shared_ptr<const OmpExecutor> exec,
                     const matrix::Fbcsr<ValueType, IndexType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     const auto nbrows = source->get_num_block_rows();
     const auto bs = source->get_block_size();
     const auto block_row_ptrs = source->get_const_row_ptrs();
     const auto block_col_idxs = source->get_const_col_idxs();
-    const auto row_ptrs = result->get_row_ptrs();
-    const auto col_idxs = result->get_col_idxs();
-    const auto vals = result->get_values();
+    const auto row_ptrs = result.row_ptrs;
+    const auto col_idxs = result.col_idxs;
+    const auto vals = result.values;
     auto sizes =
         gko::to_std_array<acc::size_type>(block_row_ptrs[nbrows], bs, bs);
     const auto block_vals =
@@ -257,7 +257,7 @@ void convert_to_csr(const std::shared_ptr<const OmpExecutor> exec,
             }
         }
     }
-    row_ptrs[result->get_size()[0]] = source->get_num_stored_elements();
+    row_ptrs[result.size[0]] = source->get_num_stored_elements();
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/preconditioner/batch_jacobi_kernels.cpp
+++ b/omp/preconditioner/batch_jacobi_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -61,7 +61,7 @@ GKO_INSTANTIATE_FOR_INT32_TYPE(
 template <typename ValueType, typename IndexType>
 void extract_common_blocks_pattern(
     std::shared_ptr<const DefaultExecutor> exec,
-    const gko::matrix::Csr<ValueType, IndexType>* first_sys_csr,
+    matrix::view::csr<const ValueType, const IndexType> first_sys_csr,
     const size_type num_blocks, const IndexType* cumulative_block_storage,
     const IndexType* block_pointers, const IndexType*,
     IndexType* blocks_pattern)

--- a/omp/preconditioner/isai_kernels.cpp
+++ b/omp/preconditioner/isai_kernels.cpp
@@ -50,8 +50,8 @@ void forall_matching(const IndexType* fst, IndexType fst_size,
 
 template <typename ValueType, typename IndexType, typename Callable>
 void generic_generate(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* mtx,
-                      matrix::Csr<ValueType, IndexType>* inverse_mtx,
+                      matrix::view::csr<const ValueType, const IndexType> mtx,
+                      matrix::view::csr<ValueType, IndexType> inverse_mtx,
                       IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs,
                       Callable direct_solve, bool tri)
 {
@@ -69,13 +69,13 @@ void generic_generate(std::shared_ptr<const DefaultExecutor> exec,
     <=> D(i)^T * aiM[i, :]^T = e(i)   =^ Triangular system (Trs)
     Solve Trs, fill in aiM row by row (coalesced access)
     */
-    const auto num_rows = mtx->get_size()[0];
-    const auto m_row_ptrs = mtx->get_const_row_ptrs();
-    const auto m_cols = mtx->get_const_col_idxs();
-    const auto m_vals = mtx->get_const_values();
-    const auto i_row_ptrs = inverse_mtx->get_const_row_ptrs();
-    const auto i_cols = inverse_mtx->get_const_col_idxs();
-    auto i_vals = inverse_mtx->get_values();
+    const auto num_rows = mtx.size[0];
+    const auto m_row_ptrs = mtx.row_ptrs;
+    const auto m_cols = mtx.col_idxs;
+    const auto m_vals = mtx.values;
+    const auto i_row_ptrs = inverse_mtx.row_ptrs;
+    const auto i_cols = inverse_mtx.col_idxs;
+    auto i_vals = inverse_mtx.values;
 
     auto num_threads = static_cast<size_type>(omp_get_max_threads());
     // RHS for local dense system
@@ -184,11 +184,11 @@ void generic_generate(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                          const matrix::Csr<ValueType, IndexType>* mtx,
-                          matrix::Csr<ValueType, IndexType>* inverse_mtx,
-                          IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs,
-                          bool lower)
+void generate_tri_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    matrix::view::csr<ValueType, IndexType> inverse_mtx,
+    IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs, bool lower)
 {
     auto trs_solve =
         [lower](const range<accessor::row_major<ValueType, 2>> trisystem,
@@ -260,11 +260,11 @@ inline void swap_rows(IndexType row1, IndexType row2, IndexType block_size,
 
 
 template <typename ValueType, typename IndexType>
-void generate_general_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                              const matrix::Csr<ValueType, IndexType>* mtx,
-                              matrix::Csr<ValueType, IndexType>* inverse_mtx,
-                              IndexType* excess_rhs_ptrs,
-                              IndexType* excess_nz_ptrs, bool spd)
+void generate_general_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    matrix::view::csr<ValueType, IndexType> inverse_mtx,
+    IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs, bool spd)
 {
     using std::swap;
     auto general_solve = [spd](const range<accessor::row_major<ValueType, 2>>
@@ -329,25 +329,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_excess_system(std::shared_ptr<const DefaultExecutor>,
-                            const matrix::Csr<ValueType, IndexType>* input,
-                            const matrix::Csr<ValueType, IndexType>* inverse,
-                            const IndexType* excess_rhs_ptrs,
-                            const IndexType* excess_nz_ptrs,
-                            matrix::Csr<ValueType, IndexType>* excess_system,
-                            matrix::view::dense<ValueType> excess_rhs,
-                            size_type e_start, size_type e_end)
+void generate_excess_system(
+    std::shared_ptr<const DefaultExecutor>,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<const ValueType, const IndexType> inverse,
+    const IndexType* excess_rhs_ptrs, const IndexType* excess_nz_ptrs,
+    matrix::view::csr<ValueType, IndexType> excess_system,
+    matrix::view::dense<ValueType> excess_rhs, size_type e_start,
+    size_type e_end)
 {
-    const auto num_rows = input->get_size()[0];
-    const auto m_row_ptrs = input->get_const_row_ptrs();
-    const auto m_cols = input->get_const_col_idxs();
-    const auto m_vals = input->get_const_values();
-    const auto i_row_ptrs = inverse->get_const_row_ptrs();
-    const auto i_cols = inverse->get_const_col_idxs();
+    const auto num_rows = input.size[0];
+    const auto m_row_ptrs = input.row_ptrs;
+    const auto m_cols = input.col_idxs;
+    const auto m_vals = input.values;
+    const auto i_row_ptrs = inverse.row_ptrs;
+    const auto i_cols = inverse.col_idxs;
     const auto e_dim = excess_rhs.size[0];
-    auto e_row_ptrs = excess_system->get_row_ptrs();
-    auto e_cols = excess_system->get_col_idxs();
-    auto e_vals = excess_system->get_values();
+    auto e_row_ptrs = excess_system.row_ptrs;
+    auto e_cols = excess_system.col_idxs;
+    auto e_vals = excess_system.values;
     auto e_rhs = excess_rhs.values;
 
 #pragma omp parallel for
@@ -423,12 +423,12 @@ template <typename ValueType, typename IndexType>
 void scatter_excess_solution(
     std::shared_ptr<const DefaultExecutor>, const IndexType* excess_block_ptrs,
     matrix::view::dense<const ValueType> excess_solution,
-    matrix::Csr<ValueType, IndexType>* inverse, size_type e_start,
+    matrix::view::csr<ValueType, IndexType> inverse, size_type e_start,
     size_type e_end)
 {
     auto excess_values = excess_solution.values;
-    auto values = inverse->get_values();
-    auto row_ptrs = inverse->get_const_row_ptrs();
+    auto values = inverse.values;
+    auto row_ptrs = inverse.row_ptrs;
     auto offset = excess_block_ptrs[e_start];
 #pragma omp parallel for
     for (size_type row = e_start; row < e_end; ++row) {

--- a/omp/preconditioner/jacobi_kernels.cpp
+++ b/omp/preconditioner/jacobi_kernels.cpp
@@ -60,12 +60,13 @@ inline bool has_same_nonzero_pattern(const IndexType* prev_row_ptr,
 
 
 template <typename ValueType, typename IndexType>
-size_type find_natural_blocks(const matrix::Csr<ValueType, IndexType>* mtx,
-                              uint32 max_block_size, IndexType* block_ptrs)
+size_type find_natural_blocks(
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    uint32 max_block_size, IndexType* block_ptrs)
 {
-    const auto rows = mtx->get_size()[0];
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idx = mtx->get_const_col_idxs();
+    const auto rows = mtx.size[0];
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idx = mtx.col_idxs;
     block_ptrs[0] = 0;
     if (rows == 0) {
         return 0;
@@ -121,10 +122,11 @@ inline size_type agglomerate_supervariables(uint32 max_block_size,
 
 
 template <typename ValueType, typename IndexType>
-void find_blocks(std::shared_ptr<const OmpExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* system_matrix,
-                 uint32 max_block_size, size_type& num_blocks,
-                 array<IndexType>& block_pointers)
+void find_blocks(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    uint32 max_block_size, size_type& num_blocks,
+    array<IndexType>& block_pointers)
 {
     num_blocks = find_natural_blocks(system_matrix, max_block_size,
                                      block_pointers.get_data());
@@ -140,18 +142,19 @@ namespace {
 
 
 template <typename ValueType, typename IndexType>
-inline void extract_block(const matrix::Csr<ValueType, IndexType>* mtx,
-                          IndexType block_size, IndexType block_start,
-                          ValueType* block, size_type stride)
+inline void extract_block(
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    IndexType block_size, IndexType block_start, ValueType* block,
+    size_type stride)
 {
     for (int i = 0; i < block_size; ++i) {
         for (int j = 0; j < block_size; ++j) {
             block[i * stride + j] = zero<ValueType>();
         }
     }
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idxs = mtx->get_const_col_idxs();
-    const auto vals = mtx->get_const_values();
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idxs = mtx.col_idxs;
+    const auto vals = mtx.values;
     for (int row = 0; row < block_size; ++row) {
         const auto start = row_ptrs[block_start + row];
         const auto end = row_ptrs[block_start + row + 1];
@@ -327,7 +330,7 @@ inline bool validate_precision_reduction_feasibility(IndexType block_size,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const OmpExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* system_matrix,
+              matrix::view::csr<const ValueType, const IndexType> system_matrix,
               size_type num_blocks, uint32 max_block_size,
               remove_complex<ValueType> accuracy,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&

--- a/omp/preconditioner/sor_kernels.cpp
+++ b/omp/preconditioner/sor_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -18,8 +18,9 @@ namespace sor {
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx)
 {
     auto inv_weight = one(weight) / weight;
     factorization::helpers::initialize_l(
@@ -36,9 +37,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l_u(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx,
-    matrix::Csr<ValueType, IndexType>* u_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx,
+    matrix::view::csr<ValueType, IndexType> u_mtx)
 {
     auto inv_weight = one(weight) / weight;
     auto inv_two_minus_weight =

--- a/omp/solver/lower_trs_kernels.cpp
+++ b/omp/solver/lower_trs_kernels.cpp
@@ -38,7 +38,7 @@ void should_perform_transpose(std::shared_ptr<const OmpExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const OmpExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -58,7 +58,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const OmpExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,
@@ -66,13 +66,13 @@ void solve(std::shared_ptr<const OmpExecutor> exec,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> x)
 {
-    auto row_ptrs = matrix->get_const_row_ptrs();
-    auto col_idxs = matrix->get_const_col_idxs();
-    auto vals = matrix->get_const_values();
+    auto row_ptrs = matrix.row_ptrs;
+    auto col_idxs = matrix.col_idxs;
+    auto vals = matrix.values;
 
 #pragma omp parallel for
     for (size_type j = 0; j < b.size[1]; ++j) {
-        for (size_type row = 0; row < matrix->get_size()[0]; ++row) {
+        for (size_type row = 0; row < matrix.size[0]; ++row) {
             auto diag = one<ValueType>();
             x(row, j) = b(row, j);
             for (auto k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {

--- a/omp/solver/upper_trs_kernels.cpp
+++ b/omp/solver/upper_trs_kernels.cpp
@@ -38,7 +38,7 @@ void should_perform_transpose(std::shared_ptr<const OmpExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const OmpExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -58,7 +58,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const OmpExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,
@@ -66,15 +66,14 @@ void solve(std::shared_ptr<const OmpExecutor> exec,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> x)
 {
-    auto row_ptrs = matrix->get_const_row_ptrs();
-    auto col_idxs = matrix->get_const_col_idxs();
-    auto vals = matrix->get_const_values();
+    auto row_ptrs = matrix.row_ptrs;
+    auto col_idxs = matrix.col_idxs;
+    auto vals = matrix.values;
 
 #pragma omp parallel for
     for (size_type j = 0; j < b.size[1]; ++j) {
-        for (size_type inv_row = 0; inv_row < matrix->get_size()[0];
-             ++inv_row) {
-            auto row = matrix->get_size()[0] - 1 - inv_row;
+        for (size_type inv_row = 0; inv_row < matrix.size[0]; ++inv_row) {
+            auto row = matrix.size[0] - 1 - inv_row;
             auto diag = one<ValueType>();
             x(row, j) = b(row, j);
             for (auto k = row_ptrs[row]; k < row_ptrs[row + 1]; ++k) {

--- a/reference/components/csr_spgeam.hpp
+++ b/reference/components/csr_spgeam.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -27,18 +27,18 @@ namespace reference {
  */
 template <typename ValueType, typename IndexType, typename BeginCallback,
           typename EntryCallback, typename EndCallback>
-void abstract_spgeam(const matrix::Csr<ValueType, IndexType>* a,
-                     const matrix::Csr<ValueType, IndexType>* b,
+void abstract_spgeam(matrix::view::csr<const ValueType, const IndexType> a,
+                     matrix::view::csr<const ValueType, const IndexType> b,
                      BeginCallback begin_cb, EntryCallback entry_cb,
                      EndCallback end_cb)
 {
-    auto num_rows = a->get_size()[0];
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
-    auto b_vals = b->get_const_values();
+    auto num_rows = a.size[0];
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
+    auto b_vals = b.values;
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
     for (size_type row = 0; row < num_rows; ++row) {
         auto a_begin = a_row_ptrs[row];

--- a/reference/components/csr_spgeam.hpp
+++ b/reference/components/csr_spgeam.hpp
@@ -27,18 +27,18 @@ namespace reference {
  */
 template <typename ValueType, typename IndexType, typename BeginCallback,
           typename EntryCallback, typename EndCallback>
-void abstract_spgeam(matrix::view::csr<const ValueType, const IndexType> a,
-                     matrix::view::csr<const ValueType, const IndexType> b,
+void abstract_spgeam(const matrix::Csr<ValueType, IndexType>* a,
+                     const matrix::Csr<ValueType, IndexType>* b,
                      BeginCallback begin_cb, EntryCallback entry_cb,
                      EndCallback end_cb)
 {
-    auto num_rows = a.size[0];
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto a_vals = a.values;
-    auto b_row_ptrs = b.row_ptrs;
-    auto b_col_idxs = b.col_idxs;
-    auto b_vals = b.values;
+    auto num_rows = a->get_size()[0];
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto a_vals = a->get_const_values();
+    auto b_row_ptrs = b->get_const_row_ptrs();
+    auto b_col_idxs = b->get_const_col_idxs();
+    auto b_vals = b->get_const_values();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
     for (size_type row = 0; row < num_rows; ++row) {
         auto a_begin = a_row_ptrs[row];

--- a/reference/factorization/cholesky_kernels.cpp
+++ b/reference/factorization/cholesky_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -31,13 +31,13 @@ namespace cholesky {
 
 template <typename ValueType, typename IndexType>
 void symbolic_count(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* mtx,
+                    matrix::view::csr<const ValueType, const IndexType> mtx,
                     const factorization::elimination_forest<IndexType>& forest,
                     IndexType* row_nnz, array<IndexType>&)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto cols = mtx->get_const_col_idxs();
+    const auto num_rows = mtx.size[0];
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto cols = mtx.col_idxs;
     const auto parent = forest.parents.get_const_data();
     vector<bool> visited(num_rows, {exec});
     for (IndexType row = 0; row < num_rows; row++) {
@@ -68,15 +68,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void symbolic_factorize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* mtx,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
     const factorization::elimination_forest<IndexType>& forest,
-    matrix::Csr<ValueType, IndexType>* l_factor, const array<IndexType>&)
+    matrix::view::csr<ValueType, IndexType> l_factor, const array<IndexType>&)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto cols = mtx->get_const_col_idxs();
-    const auto out_row_ptrs = l_factor->get_const_row_ptrs();
-    const auto out_cols = l_factor->get_col_idxs();
+    const auto num_rows = mtx.size[0];
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto cols = mtx.col_idxs;
+    const auto out_row_ptrs = l_factor.row_ptrs;
+    const auto out_cols = l_factor.col_idxs;
     const auto parent = forest.parents.get_const_data();
     vector<bool> visited(num_rows, {exec});
     for (IndexType row = 0; row < num_rows; row++) {
@@ -106,23 +106,23 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
+                matrix::view::csr<const ValueType, const IndexType> mtx,
                 const IndexType* factor_lookup_offsets,
                 const int64* factor_lookup_descs,
                 const int32* factor_lookup_storage, IndexType* diag_idxs,
                 IndexType* transpose_idxs,
-                matrix::Csr<ValueType, IndexType>* factors)
+                matrix::view::csr<ValueType, IndexType> factors)
 {
     lu_factorization::initialize(exec, mtx, factor_lookup_offsets,
                                  factor_lookup_descs, factor_lookup_storage,
                                  diag_idxs, factors);
     // convert to COO
-    const auto nnz = factors->get_num_stored_elements();
+    const auto nnz = factors.num_stored_elements;
     array<IndexType> row_idx_array{exec, nnz};
     const auto row_idxs = row_idx_array.get_data();
-    const auto col_idxs = factors->get_const_col_idxs();
-    components::convert_ptrs_to_idxs(exec, factors->get_const_row_ptrs(),
-                                     factors->get_size()[0], row_idxs);
+    const auto col_idxs = factors.col_idxs;
+    components::convert_ptrs_to_idxs(exec, factors.row_ptrs, factors.size[0],
+                                     row_idxs);
     components::fill_seq_array(exec, transpose_idxs, nnz);
     // compute nonzero permutation for sparse transpose
     std::sort(transpose_idxs, transpose_idxs + nnz,
@@ -144,13 +144,13 @@ void factorize_impl(std::shared_ptr<const DefaultExecutor> exec,
                     const int32* lookup_storage, const IndexType* diag_idxs,
                     const IndexType* transpose_idxs,
                     const factorization::elimination_forest<IndexType>& forest,
-                    matrix::Csr<ValueType, IndexType>* factors,
+                    matrix::view::csr<ValueType, IndexType> factors,
                     array<int>& tmp_storage)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto row_ptrs = factors->get_const_row_ptrs();
-    const auto cols = factors->get_const_col_idxs();
-    const auto vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto row_ptrs = factors.row_ptrs;
+    const auto cols = factors.col_idxs;
+    const auto vals = factors.values;
     for (size_type row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_diag = diag_idxs[row];
@@ -200,8 +200,8 @@ void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const int32* lookup_storage, const IndexType* diag_idxs,
                const IndexType* transpose_idxs,
                const factorization::elimination_forest<IndexType>& forest,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage)
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage)
 {
     if (full_fillin) {
         factorize_impl<true>(exec, lookup_offsets, lookup_descs, lookup_storage,

--- a/reference/factorization/elimination_forest_kernels.cpp
+++ b/reference/factorization/elimination_forest_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -77,12 +77,12 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void from_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* factors,
+                 matrix::view::csr<const ValueType, const IndexType> factors,
                  gko::factorization::elimination_forest<IndexType>& forest)
 {
-    const auto row_ptrs = factors->get_const_row_ptrs();
-    const auto col_idxs = factors->get_const_col_idxs();
-    const auto num_rows = static_cast<IndexType>(factors->get_size()[0]);
+    const auto row_ptrs = factors.row_ptrs;
+    const auto col_idxs = factors.col_idxs;
+    const auto num_rows = static_cast<IndexType>(factors.size[0]);
     const auto parents = forest.parents.get_data();
     const auto children = forest.children.get_data();
     const auto child_ptrs = forest.child_ptrs.get_data();

--- a/reference/factorization/factorization_helpers.hpp
+++ b/reference/factorization/factorization_helpers.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -19,24 +19,25 @@ using namespace ::gko::factorization;
 
 template <typename ValueType, typename IndexType, typename LClosure,
           typename UClosure>
-void initialize_l_u(const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u,
-                    LClosure&& l_closure, UClosure&& u_closure)
+void initialize_l_u(
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u, LClosure&& l_closure,
+    UClosure&& u_closure)
 {
-    const auto row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto vals = system_matrix->get_const_values();
+    const auto row_ptrs = system_matrix.row_ptrs;
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto vals = system_matrix.values;
 
-    const auto row_ptrs_l = csr_l->get_const_row_ptrs();
-    auto col_idxs_l = csr_l->get_col_idxs();
-    auto vals_l = csr_l->get_values();
+    const auto row_ptrs_l = csr_l.row_ptrs;
+    auto col_idxs_l = csr_l.col_idxs;
+    auto vals_l = csr_l.values;
 
-    const auto row_ptrs_u = csr_u->get_const_row_ptrs();
-    auto col_idxs_u = csr_u->get_col_idxs();
-    auto vals_u = csr_u->get_values();
+    const auto row_ptrs_u = csr_u.row_ptrs;
+    auto col_idxs_u = csr_u.col_idxs;
+    auto vals_u = csr_u.values;
 
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         size_type current_index_l = row_ptrs_l[row];
         size_type current_index_u =
             row_ptrs_u[row] + 1;  // we treat the diagonal separately
@@ -70,18 +71,19 @@ void initialize_l_u(const matrix::Csr<ValueType, IndexType>* system_matrix,
 
 
 template <typename ValueType, typename IndexType, typename Closure>
-void initialize_l(const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, Closure&& closure)
+void initialize_l(
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, Closure&& closure)
 {
-    const auto row_ptrs = system_matrix->get_const_row_ptrs();
-    const auto col_idxs = system_matrix->get_const_col_idxs();
-    const auto vals = system_matrix->get_const_values();
+    const auto row_ptrs = system_matrix.row_ptrs;
+    const auto col_idxs = system_matrix.col_idxs;
+    const auto vals = system_matrix.values;
 
-    const auto row_ptrs_l = csr_l->get_const_row_ptrs();
-    auto col_idxs_l = csr_l->get_col_idxs();
-    auto vals_l = csr_l->get_values();
+    const auto row_ptrs_l = csr_l.row_ptrs;
+    auto col_idxs_l = csr_l.col_idxs;
+    auto vals_l = csr_l.values;
 
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         size_type current_index_l = row_ptrs_l[row];
         // if there is no diagonal value, set it to 1 by default
         auto diag_val = one<ValueType>();

--- a/reference/factorization/factorization_kernels.cpp
+++ b/reference/factorization/factorization_kernels.cpp
@@ -135,17 +135,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
     IndexType l_nnz{};
     IndexType u_nnz{};
 
     l_row_ptrs[0] = 0;
     u_row_ptrs[0] = 0;
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         for (auto el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
             auto col = col_idxs[el];
             // don't count diagonal
@@ -165,10 +165,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
     helpers::initialize_l_u(
         system_matrix, csr_l, csr_u,
@@ -185,15 +186,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
     size_type l_nnz{};
 
     l_row_ptrs[0] = 0;
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         for (size_type el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
             size_type col = col_idxs[el];
             // skip diagonal
@@ -210,9 +211,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const ReferenceExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
     helpers::initialize_l(system_matrix, csr_l,
                           helpers::triangular_mtx_closure(
@@ -276,15 +278,13 @@ bool symbolic_validate_impl(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup, bool& valid)
 {
     valid = symbolic_validate_impl(
-        exec, system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(), factors->get_const_row_ptrs(),
-        factors->get_const_col_idxs(),
-        static_cast<IndexType>(system_matrix->get_size()[0]));
+        exec, system_matrix.row_ptrs, system_matrix.col_idxs, factors.row_ptrs,
+        factors.col_idxs, static_cast<IndexType>(system_matrix.size[0]));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/reference/factorization/factorization_kernels.cpp
+++ b/reference/factorization/factorization_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -135,17 +135,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l_u(
     std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs, IndexType* u_row_ptrs)
 {
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
     IndexType l_nnz{};
     IndexType u_nnz{};
 
     l_row_ptrs[0] = 0;
     u_row_ptrs[0] = 0;
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         for (auto el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
             auto col = col_idxs[el];
             // don't count diagonal
@@ -165,10 +165,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l_u(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* system_matrix,
-                    matrix::Csr<ValueType, IndexType>* csr_l,
-                    matrix::Csr<ValueType, IndexType>* csr_u)
+void initialize_l_u(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l,
+    matrix::view::csr<ValueType, IndexType> csr_u)
 {
     helpers::initialize_l_u(
         system_matrix, csr_l, csr_u,
@@ -185,15 +186,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_row_ptrs_l(
     std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
     IndexType* l_row_ptrs)
 {
-    auto row_ptrs = system_matrix->get_const_row_ptrs();
-    auto col_idxs = system_matrix->get_const_col_idxs();
+    auto row_ptrs = system_matrix.row_ptrs;
+    auto col_idxs = system_matrix.col_idxs;
     size_type l_nnz{};
 
     l_row_ptrs[0] = 0;
-    for (size_type row = 0; row < system_matrix->get_size()[0]; ++row) {
+    for (size_type row = 0; row < system_matrix.size[0]; ++row) {
         for (size_type el = row_ptrs[row]; el < row_ptrs[row + 1]; ++el) {
             size_type col = col_idxs[el];
             // skip diagonal
@@ -210,9 +211,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void initialize_l(std::shared_ptr<const ReferenceExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* system_matrix,
-                  matrix::Csr<ValueType, IndexType>* csr_l, bool diag_sqrt)
+void initialize_l(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<ValueType, IndexType> csr_l, bool diag_sqrt)
 {
     helpers::initialize_l(system_matrix, csr_l,
                           helpers::triangular_mtx_closure(
@@ -276,15 +278,13 @@ bool symbolic_validate_impl(std::shared_ptr<const DefaultExecutor> exec,
 template <typename ValueType, typename IndexType>
 void symbolic_validate(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    const matrix::Csr<ValueType, IndexType>* factors,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    matrix::view::csr<const ValueType, const IndexType> factors,
     const matrix::csr::lookup_data<IndexType>& factors_lookup, bool& valid)
 {
     valid = symbolic_validate_impl(
-        exec, system_matrix->get_const_row_ptrs(),
-        system_matrix->get_const_col_idxs(), factors->get_const_row_ptrs(),
-        factors->get_const_col_idxs(),
-        static_cast<IndexType>(system_matrix->get_size()[0]));
+        exec, system_matrix.row_ptrs, system_matrix.col_idxs, factors.row_ptrs,
+        factors.col_idxs, static_cast<IndexType>(system_matrix.size[0]));
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/reference/factorization/ic_kernels.cpp
+++ b/reference/factorization/ic_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -22,13 +22,13 @@ namespace ic_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ic(std::shared_ptr<const DefaultExecutor> exec,
-                  matrix::Csr<ValueType, IndexType>* m)
+                  matrix::view::csr<ValueType, IndexType> m)
 {
-    vector<IndexType> diagonals{m->get_size()[0], -1, exec};
-    const auto row_ptrs = m->get_const_row_ptrs();
-    const auto col_idxs = m->get_const_col_idxs();
-    const auto values = m->get_values();
-    for (size_type row = 0; row < m->get_size()[0]; row++) {
+    vector<IndexType> diagonals{m.size[0], -1, exec};
+    const auto row_ptrs = m.row_ptrs;
+    const auto col_idxs = m.col_idxs;
+    const auto values = m.values;
+    for (size_type row = 0; row < m.size[0]; row++) {
         const auto begin = row_ptrs[row];
         const auto end = row_ptrs[row + 1];
         for (auto nz = begin; nz < end; nz++) {

--- a/reference/factorization/ilu_kernels.cpp
+++ b/reference/factorization/ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -24,14 +24,13 @@ namespace ilu_factorization {
 
 template <typename ValueType, typename IndexType>
 void sparselib_ilu(std::shared_ptr<const DefaultExecutor> exec,
-                   matrix::Csr<ValueType, IndexType>* m)
+                   matrix::view::csr<ValueType, IndexType> m)
 {
-    vector<IndexType> diagonals{m->get_size()[0], -1, exec};
-    const auto row_ptrs = m->get_const_row_ptrs();
-    const auto col_idxs = m->get_const_col_idxs();
-    const auto values = m->get_values();
-    for (IndexType row = 0; row < static_cast<IndexType>(m->get_size()[0]);
-         row++) {
+    vector<IndexType> diagonals{m.size[0], -1, exec};
+    const auto row_ptrs = m.row_ptrs;
+    const auto col_idxs = m.col_idxs;
+    const auto values = m.values;
+    for (IndexType row = 0; row < static_cast<IndexType>(m.size[0]); row++) {
         const auto begin = row_ptrs[row];
         const auto end = row_ptrs[row + 1];
         for (auto nz = begin; nz < end; nz++) {

--- a/reference/factorization/lu_kernels.cpp
+++ b/reference/factorization/lu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -26,19 +26,19 @@ namespace lu_factorization {
 
 template <typename ValueType, typename IndexType>
 void initialize(std::shared_ptr<const DefaultExecutor> exec,
-                const matrix::Csr<ValueType, IndexType>* mtx,
+                matrix::view::csr<const ValueType, const IndexType> mtx,
                 const IndexType* factor_lookup_offsets,
                 const int64* factor_lookup_descs,
                 const int32* factor_lookup_storage, IndexType* diag_idxs,
-                matrix::Csr<ValueType, IndexType>* factors)
+                matrix::view::csr<ValueType, IndexType> factors)
 {
-    const auto num_rows = mtx->get_size()[0];
-    const auto mtx_row_ptrs = mtx->get_const_row_ptrs();
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto mtx_cols = mtx->get_const_col_idxs();
-    const auto factor_cols = factors->get_const_col_idxs();
-    const auto mtx_vals = mtx->get_const_values();
-    const auto factor_vals = factors->get_values();
+    const auto num_rows = mtx.size[0];
+    const auto mtx_row_ptrs = mtx.row_ptrs;
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto mtx_cols = mtx.col_idxs;
+    const auto factor_cols = factors.col_idxs;
+    const auto mtx_vals = mtx.values;
+    const auto factor_vals = factors.values;
     for (size_type row = 0; row < num_rows; row++) {
         const auto factor_begin = factor_row_ptrs[row];
         const auto factor_end = factor_row_ptrs[row + 1];
@@ -68,13 +68,13 @@ template <bool full_fillin, typename ValueType, typename IndexType>
 void factorize_impl(std::shared_ptr<const DefaultExecutor> exec,
                     const IndexType* lookup_offsets, const int64* lookup_descs,
                     const int32* lookup_storage, const IndexType* diag_idxs,
-                    matrix::Csr<ValueType, IndexType>* factors,
+                    matrix::view::csr<ValueType, IndexType> factors,
                     array<int>& tmp_storage)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto row_ptrs = factors->get_const_row_ptrs();
-    const auto cols = factors->get_const_col_idxs();
-    const auto vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto row_ptrs = factors.row_ptrs;
+    const auto cols = factors.col_idxs;
+    const auto vals = factors.values;
     for (size_type row = 0; row < num_rows; row++) {
         const auto row_begin = row_ptrs[row];
         const auto row_diag = diag_idxs[row];
@@ -112,8 +112,8 @@ template <typename ValueType, typename IndexType>
 void factorize(std::shared_ptr<const DefaultExecutor> exec,
                const IndexType* lookup_offsets, const int64* lookup_descs,
                const int32* lookup_storage, const IndexType* diag_idxs,
-               matrix::Csr<ValueType, IndexType>* factors, bool full_fillin,
-               array<int>& tmp_storage)
+               matrix::view::csr<ValueType, IndexType> factors,
+               bool full_fillin, array<int>& tmp_storage)
 {
     if (full_fillin) {
         factorize_impl<true>(exec, lookup_offsets, lookup_descs, lookup_storage,
@@ -132,12 +132,12 @@ void symbolic_factorize_simple(
     std::shared_ptr<const DefaultExecutor> exec, const IndexType* row_ptrs,
     const IndexType* col_idxs, const IndexType* lookup_offsets,
     const int64* lookup_descs, const int32* lookup_storage,
-    matrix::Csr<float, IndexType>* factors, IndexType* out_row_nnz)
+    matrix::view::csr<float, IndexType> factors, IndexType* out_row_nnz)
 {
-    const auto num_rows = factors->get_size()[0];
-    const auto factor_row_ptrs = factors->get_const_row_ptrs();
-    const auto factor_cols = factors->get_const_col_idxs();
-    const auto factor_vals = factors->get_values();
+    const auto num_rows = factors.size[0];
+    const auto factor_row_ptrs = factors.row_ptrs;
+    const auto factor_cols = factors.col_idxs;
+    const auto factor_vals = factors.values;
     array<IndexType> diag_idx_array{exec, num_rows};
     const auto diag_idxs = diag_idx_array.get_data();
     for (size_type row = 0; row < num_rows; row++) {
@@ -190,14 +190,15 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_LU_SYMMETRIC_FACTORIZE_SIMPLE);
 template <typename IndexType>
 void symbolic_factorize_simple_finalize(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<float, IndexType>* factors, IndexType* out_col_idxs)
+    matrix::view::csr<const float, const IndexType> factors,
+    IndexType* out_col_idxs)
 {
-    const auto col_idxs = factors->get_const_col_idxs();
-    const auto vals = factors->get_const_values();
+    const auto col_idxs = factors.col_idxs;
+    const auto vals = factors.values;
     size_type output_idx{};
     // copy all nonzero entries from the symmetric factor to the unsymmetric
     // factor
-    for (size_type i = 0; i < factors->get_num_stored_elements(); i++) {
+    for (size_type i = 0; i < factors.num_stored_elements; i++) {
         if (vals[i] == one<float>()) {
             out_col_idxs[output_idx] = col_idxs[i];
             ++output_idx;

--- a/reference/factorization/par_ic_kernels.cpp
+++ b/reference/factorization/par_ic_kernels.cpp
@@ -23,12 +23,12 @@ namespace par_ic_factorization {
 
 template <typename ValueType, typename IndexType>
 void init_factor(std::shared_ptr<const DefaultExecutor> exec,
-                 matrix::Csr<ValueType, IndexType>* l)
+                 matrix::view::csr<ValueType, IndexType> l)
 {
-    auto num_rows = l->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
+    auto num_rows = l.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
 
     for (size_type row = 0; row < num_rows; ++row) {
         for (size_type l_nz = l_row_ptrs[row]; l_nz < l_row_ptrs[row + 1];
@@ -53,12 +53,12 @@ template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
                     size_type /* num_iterations */,
                     matrix::view::coo<const ValueType, const IndexType> a_lower,
-                    matrix::Csr<ValueType, IndexType>* l)
+                    matrix::view::csr<ValueType, IndexType> l)
 {
     auto num_rows = a_lower.size[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto a_vals = a_lower.values;
 
     for (size_type row = 0; row < num_rows; ++row) {

--- a/reference/factorization/par_ict_kernels.cpp
+++ b/reference/factorization/par_ict_kernels.cpp
@@ -33,17 +33,17 @@ namespace par_ict_factorization {
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType>)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
     for (size_type row = 0; row < num_rows; ++row) {
         for (auto l_nz = l_row_ptrs[row]; l_nz < l_row_ptrs[row + 1]; ++l_nz) {
@@ -95,15 +95,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto l_new = l_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();

--- a/reference/factorization/par_ict_kernels.cpp
+++ b/reference/factorization/par_ict_kernels.cpp
@@ -33,17 +33,17 @@ namespace par_ict_factorization {
 
 template <typename ValueType, typename IndexType>
 void compute_factor(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<ValueType, IndexType> l,
                     matrix::view::coo<const ValueType, const IndexType>)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
     for (size_type row = 0; row < num_rows; ++row) {
         for (auto l_nz = l_row_ptrs[row]; l_nz < l_row_ptrs[row + 1]; ++l_nz) {
@@ -95,15 +95,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* llh,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
+                    matrix::view::csr<const ValueType, const IndexType> llh,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
     // count nnz

--- a/reference/factorization/par_ict_kernels.cpp
+++ b/reference/factorization/par_ict_kernels.cpp
@@ -95,12 +95,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> llh,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* llh,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::Csr<ValueType, IndexType>* l_new)
 {
-    auto num_rows = a.size[0];
+    auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = l.values;

--- a/reference/factorization/par_ilu_kernels.cpp
+++ b/reference/factorization/par_ilu_kernels.cpp
@@ -25,8 +25,8 @@ template <typename ValueType, typename IndexType>
 void compute_l_u_factors(
     std::shared_ptr<const ReferenceExecutor> exec, size_type iterations,
     matrix::view::coo<const ValueType, const IndexType> system_matrix,
-    matrix::Csr<ValueType, IndexType>* l_factor,
-    matrix::Csr<ValueType, IndexType>* u_factor)
+    matrix::view::csr<ValueType, IndexType> l_factor,
+    matrix::view::csr<ValueType, IndexType> u_factor)
 {
     // If `iterations` is set to `Auto`, a single iteration is sufficient since
     // it is computed sequentially
@@ -34,12 +34,12 @@ void compute_l_u_factors(
     const auto col_idxs = system_matrix.col_idxs;
     const auto row_idxs = system_matrix.row_idxs;
     const auto vals = system_matrix.values;
-    const auto row_ptrs_l = l_factor->get_const_row_ptrs();
-    const auto row_ptrs_u = u_factor->get_const_row_ptrs();
-    const auto col_idxs_l = l_factor->get_const_col_idxs();
-    const auto col_idxs_u = u_factor->get_const_col_idxs();
-    auto vals_l = l_factor->get_values();
-    auto vals_u = u_factor->get_values();
+    const auto row_ptrs_l = l_factor.row_ptrs;
+    const auto row_ptrs_u = u_factor.row_ptrs;
+    const auto col_idxs_l = l_factor.col_idxs;
+    const auto col_idxs_u = u_factor.col_idxs;
+    auto vals_l = l_factor.values;
+    auto vals_u = u_factor.values;
     for (size_type iter = 0; iter < iterations; ++iter) {
         for (size_type el = 0; el < system_matrix.num_stored_elements; ++el) {
             const auto row = row_idxs[el];

--- a/reference/factorization/par_ilut_kernels.cpp
+++ b/reference/factorization/par_ilut_kernels.cpp
@@ -40,13 +40,13 @@ namespace par_ilut_factorization {
  */
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp,
                       array<remove_complex<ValueType>>&,
                       remove_complex<ValueType>& threshold)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     tmp.resize_and_reset(size);
     std::copy_n(values, size, tmp.get_data());
 
@@ -70,15 +70,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* m,
+                     matrix::view::csr<const ValueType, const IndexType> m,
                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
-    auto num_rows = m->get_size()[0];
-    auto row_ptrs = m->get_const_row_ptrs();
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto num_rows = m.size[0];
+    auto row_ptrs = m.row_ptrs;
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
 
     auto m_out = m_out_builder->get_matrix();
     // first sweep: count nnz for each row
@@ -137,13 +137,13 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
  */
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       remove_complex<ValueType> threshold,
                       matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
     abstract_filter(
         exec, m, m_out_builder, m_out_coo, [&](IndexType row, IndexType nz) {
             return abs(vals[nz]) >= threshold || col_idxs[nz] == row;
@@ -167,14 +167,14 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 template <typename ValueType, typename IndexType>
 void threshold_filter_approx(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
     array<ValueType>& tmp, remove_complex<ValueType>& threshold,
     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
     matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto vals = m->get_const_values();
-    auto col_idxs = m->get_const_col_idxs();
-    auto size = static_cast<IndexType>(m->get_num_stored_elements());
+    auto vals = m.values;
+    auto col_idxs = m.col_idxs;
+    auto size = static_cast<IndexType>(m.num_stored_elements);
     using AbsType = remove_complex<ValueType>;
     constexpr auto storage_size = ceildiv(
         sample_size * sizeof(AbsType) + bucket_count * sizeof(IndexType),
@@ -237,26 +237,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
+                         matrix::view::csr<const ValueType, const IndexType> a,
+                         matrix::view::csr<ValueType, IndexType> l,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u,
+                         matrix::view::csr<ValueType, IndexType> u,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+                         matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_values();
-    auto ut_col_ptrs = u_csc->get_const_row_ptrs();
-    auto ut_row_idxs = u_csc->get_const_col_idxs();
-    auto ut_vals = u_csc->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
+    auto ut_col_ptrs = u_csc.row_ptrs;
+    auto ut_row_idxs = u_csc.col_idxs;
+    auto ut_vals = u_csc.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
     auto compute_sum = [&](IndexType row, IndexType col) {
         // find value from A
@@ -327,20 +327,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
                     matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
     auto l_new = l_new_builder->get_matrix();
     auto u_new = u_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();

--- a/reference/factorization/par_ilut_kernels.cpp
+++ b/reference/factorization/par_ilut_kernels.cpp
@@ -40,13 +40,13 @@ namespace par_ilut_factorization {
  */
 template <typename ValueType, typename IndexType>
 void threshold_select(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       IndexType rank, array<ValueType>& tmp,
                       array<remove_complex<ValueType>>&,
                       remove_complex<ValueType>& threshold)
 {
-    auto values = m->get_const_values();
-    IndexType size = m->get_num_stored_elements();
+    auto values = m.values;
+    IndexType size = m.num_stored_elements;
     tmp.resize_and_reset(size);
     std::copy_n(values, size, tmp.get_data());
 
@@ -70,15 +70,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
-                     const matrix::Csr<ValueType, IndexType>* m,
+                     matrix::view::csr<const ValueType, const IndexType> m,
                      matrix::Csr<ValueType, IndexType>* m_out,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
-    auto num_rows = m->get_size()[0];
-    auto row_ptrs = m->get_const_row_ptrs();
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto num_rows = m.size[0];
+    auto row_ptrs = m.row_ptrs;
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
 
     // first sweep: count nnz for each row
     auto new_row_ptrs = m_out->get_row_ptrs();
@@ -137,13 +137,13 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
  */
 template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* m,
+                      matrix::view::csr<const ValueType, const IndexType> m,
                       remove_complex<ValueType> threshold,
                       matrix::Csr<ValueType, IndexType>* m_out,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
-    auto col_idxs = m->get_const_col_idxs();
-    auto vals = m->get_const_values();
+    auto col_idxs = m.col_idxs;
+    auto vals = m.values;
     abstract_filter(
         exec, m, m_out, m_out_coo, [&](IndexType row, IndexType nz) {
             return abs(vals[nz]) >= threshold || col_idxs[nz] == row;
@@ -165,16 +165,16 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
  * and removes all elements below this threshold from the input matrix.
  */
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::Csr<ValueType, IndexType>* m_out,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
-    auto vals = m->get_const_values();
-    auto col_idxs = m->get_const_col_idxs();
-    auto size = static_cast<IndexType>(m->get_num_stored_elements());
+    auto vals = m.values;
+    auto col_idxs = m.col_idxs;
+    auto size = static_cast<IndexType>(m.num_stored_elements);
     using AbsType = remove_complex<ValueType>;
     constexpr auto storage_size = ceildiv(
         sample_size * sizeof(AbsType) + bucket_count * sizeof(IndexType),
@@ -237,26 +237,26 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void compute_l_u_factors(std::shared_ptr<const DefaultExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* a,
-                         matrix::Csr<ValueType, IndexType>* l,
+                         matrix::view::csr<const ValueType, const IndexType> a,
+                         matrix::view::csr<ValueType, IndexType> l,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u,
+                         matrix::view::csr<ValueType, IndexType> u,
                          matrix::view::coo<const ValueType, const IndexType>,
-                         matrix::Csr<ValueType, IndexType>* u_csc)
+                         matrix::view::csr<ValueType, IndexType> u_csc)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_values();
-    auto ut_col_ptrs = u_csc->get_const_row_ptrs();
-    auto ut_row_idxs = u_csc->get_const_col_idxs();
-    auto ut_vals = u_csc->get_values();
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
+    auto ut_col_ptrs = u_csc.row_ptrs;
+    auto ut_row_idxs = u_csc.col_idxs;
+    auto ut_vals = u_csc.values;
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
 
     auto compute_sum = [&](IndexType row, IndexType col) {
         // find value from A
@@ -327,20 +327,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* lu,
-                    const matrix::Csr<ValueType, IndexType>* a,
-                    const matrix::Csr<ValueType, IndexType>* l,
-                    const matrix::Csr<ValueType, IndexType>* u,
+                    matrix::view::csr<const ValueType, const IndexType> lu,
+                    matrix::view::csr<const ValueType, const IndexType> a,
+                    matrix::view::csr<const ValueType, const IndexType> l,
+                    matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a->get_size()[0];
-    auto l_row_ptrs = l->get_const_row_ptrs();
-    auto l_col_idxs = l->get_const_col_idxs();
-    auto l_vals = l->get_const_values();
-    auto u_row_ptrs = u->get_const_row_ptrs();
-    auto u_col_idxs = u->get_const_col_idxs();
-    auto u_vals = u->get_const_values();
+    auto num_rows = a.size[0];
+    auto l_row_ptrs = l.row_ptrs;
+    auto l_col_idxs = l.col_idxs;
+    auto l_vals = l.values;
+    auto u_row_ptrs = u.row_ptrs;
+    auto u_col_idxs = u.col_idxs;
+    auto u_vals = u.values;
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();

--- a/reference/factorization/par_ilut_kernels.cpp
+++ b/reference/factorization/par_ilut_kernels.cpp
@@ -327,14 +327,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
-                    matrix::view::csr<const ValueType, const IndexType> lu,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* lu,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::csr<const ValueType, const IndexType> l,
                     matrix::view::csr<const ValueType, const IndexType> u,
                     matrix::Csr<ValueType, IndexType>* l_new,
                     matrix::Csr<ValueType, IndexType>* u_new)
 {
-    auto num_rows = a.size[0];
+    auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l.row_ptrs;
     auto l_col_idxs = l.col_idxs;
     auto l_vals = l.values;

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -44,23 +44,23 @@ template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const ReferenceExecutor> exec,
           const matrix::csr::spmv_strategy, const IndexType,
-          const matrix::Csr<MatrixValueType, IndexType>* a,
+          matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
 {
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a->get_const_row_ptrs();
-    auto col_idxs = a->get_const_col_idxs();
+    auto row_ptrs = a.row_ptrs;
+    auto col_idxs = a.col_idxs;
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
 
-    for (size_type row = 0; row < a->get_size()[0]; ++row) {
+    for (size_type row = 0; row < a.size[0]; ++row) {
         for (size_type j = 0; j < c.size[1]; ++j) {
             auto sum = zero<arithmetic_type>();
             for (size_type k = row_ptrs[row];
@@ -84,7 +84,7 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
                    const matrix::csr::spmv_strategy,
                    const IndexType /* max_nnz_per_row */,
                    matrix::view::dense<const MatrixValueType> alpha,
-                   const matrix::Csr<MatrixValueType, IndexType>* a,
+                   matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,
                    matrix::view::dense<const OutputValueType> beta,
                    matrix::view::dense<OutputValueType> c)
@@ -92,17 +92,17 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
     using arithmetic_type =
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
 
-    auto row_ptrs = a->get_const_row_ptrs();
-    auto col_idxs = a->get_const_col_idxs();
+    auto row_ptrs = a.row_ptrs;
+    auto col_idxs = a.col_idxs;
     auto valpha = static_cast<arithmetic_type>(alpha(0, 0));
     auto vbeta = static_cast<arithmetic_type>(beta(0, 0));
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
-    for (size_type row = 0; row < a->get_size()[0]; ++row) {
+    for (size_type row = 0; row < a.size[0]; ++row) {
         for (size_type j = 0; j < c.size[1]; ++j) {
             auto sum = is_zero(vbeta) ? zero(vbeta) : c_vals(row, j) * vbeta;
             for (size_type k = row_ptrs[row];
@@ -199,11 +199,11 @@ void spgemm_accumulate_row2(
 
 template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
-            const matrix::Csr<ValueType, IndexType>* a,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> a,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto num_rows = a->get_size()[0];
+    auto num_rows = a.size[0];
 
     auto c = c_builder->get_matrix();
     // first sweep: count nnz for each row
@@ -212,8 +212,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
-                           b->get_const_device_view(), a_row);
+        spgemm_insert_row2(local_col_idxs, a, b, a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -232,9 +231,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
-                               b->get_const_device_view(), one<ValueType>(),
-                               a_row);
+        spgemm_accumulate_row2(local_row_nzs, a, b, one<ValueType>(), a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -251,13 +248,13 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEMM_KERNEL);
 template <typename ValueType, typename IndexType>
 void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
                      matrix::view::dense<const ValueType> alpha,
-                     const matrix::Csr<ValueType, IndexType>* a,
-                     const matrix::Csr<ValueType, IndexType>* b,
+                     matrix::view::csr<const ValueType, const IndexType> a,
+                     matrix::view::csr<const ValueType, const IndexType> b,
                      matrix::view::dense<const ValueType> beta,
-                     const matrix::Csr<ValueType, IndexType>* d,
+                     matrix::view::csr<const ValueType, const IndexType> d,
                      matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto num_rows = a->get_size()[0];
+    auto num_rows = a.size[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
 
@@ -268,9 +265,8 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row(local_col_idxs, d->get_const_device_view(), a_row);
-        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
-                           b->get_const_device_view(), a_row);
+        spgemm_insert_row(local_col_idxs, d, a_row);
+        spgemm_insert_row2(local_col_idxs, a, b, a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -289,10 +285,8 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row(local_row_nzs, d->get_const_device_view(), vbeta,
-                              a_row);
-        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
-                               b->get_const_device_view(), valpha, a_row);
+        spgemm_accumulate_row(local_row_nzs, d, vbeta, a_row);
+        spgemm_accumulate_row2(local_row_nzs, a, b, valpha, a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -432,12 +426,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
             matrix::view::dense<const ValueType> alpha,
-            const matrix::Csr<ValueType, IndexType>* a,
+            matrix::view::csr<const ValueType, const IndexType> a,
             matrix::view::dense<const ValueType> beta,
-            const matrix::Csr<ValueType, IndexType>* b,
+            matrix::view::csr<const ValueType, const IndexType> b,
             matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
-    auto num_rows = a->get_size()[0];
+    auto num_rows = a.size[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
 
@@ -446,8 +440,7 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [](IndexType) { return IndexType{}; },
+        a, b, [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -466,8 +459,7 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [&](IndexType row) { return c_row_ptrs[row]; },
+        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -54,8 +54,8 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
     auto row_ptrs = a->get_const_row_ptrs();
     auto col_idxs = a->get_const_col_idxs();
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -97,8 +97,8 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
     auto valpha = static_cast<arithmetic_type>(alpha(0, 0));
     auto vbeta = static_cast<arithmetic_type>(beta(0, 0));
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -122,25 +122,25 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_insert_row(unordered_set<IndexType>& cols,
-                       const matrix::Csr<ValueType, IndexType>* c,
+                       matrix::view::csr<const ValueType, const IndexType> c,
                        size_type row)
 {
-    auto row_ptrs = c->get_const_row_ptrs();
-    auto col_idxs = c->get_const_col_idxs();
+    auto row_ptrs = c.row_ptrs;
+    auto col_idxs = c.col_idxs;
     cols.insert(col_idxs + row_ptrs[row], col_idxs + row_ptrs[row + 1]);
 }
 
 
 template <typename ValueType, typename IndexType>
 void spgemm_insert_row2(unordered_set<IndexType>& cols,
-                        const matrix::Csr<ValueType, IndexType>* a,
-                        const matrix::Csr<ValueType, IndexType>* b,
+                        matrix::view::csr<const ValueType, const IndexType> a,
+                        matrix::view::csr<const ValueType, const IndexType> b,
                         size_type row)
 {
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
     for (size_type a_nz = a_row_ptrs[row];
          a_nz < size_type(a_row_ptrs[row + 1]); ++a_nz) {
         auto a_col = a_col_idxs[a_nz];
@@ -152,13 +152,14 @@ void spgemm_insert_row2(unordered_set<IndexType>& cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row(map<IndexType, ValueType>& cols,
-                           const matrix::Csr<ValueType, IndexType>* c,
-                           ValueType scale, size_type row)
+void spgemm_accumulate_row(
+    map<IndexType, ValueType>& cols,
+    matrix::view::csr<const ValueType, const IndexType> c, ValueType scale,
+    size_type row)
 {
-    auto row_ptrs = c->get_const_row_ptrs();
-    auto col_idxs = c->get_const_col_idxs();
-    auto vals = c->get_const_values();
+    auto row_ptrs = c.row_ptrs;
+    auto col_idxs = c.col_idxs;
+    auto vals = c.values;
     for (size_type c_nz = row_ptrs[row]; c_nz < size_type(row_ptrs[row + 1]);
          ++c_nz) {
         auto c_col = col_idxs[c_nz];
@@ -169,17 +170,18 @@ void spgemm_accumulate_row(map<IndexType, ValueType>& cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row2(map<IndexType, ValueType>& cols,
-                            const matrix::Csr<ValueType, IndexType>* a,
-                            const matrix::Csr<ValueType, IndexType>* b,
-                            ValueType scale, size_type row)
+void spgemm_accumulate_row2(
+    map<IndexType, ValueType>& cols,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b, ValueType scale,
+    size_type row)
 {
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
-    auto b_vals = b->get_const_values();
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
+    auto b_vals = b.values;
     for (size_type a_nz = a_row_ptrs[row];
          a_nz < size_type(a_row_ptrs[row + 1]); ++a_nz) {
         auto a_col = a_col_idxs[a_nz];
@@ -210,7 +212,8 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row2(local_col_idxs, a, b, a_row);
+        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
+                           b->get_const_device_view(), a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -229,7 +232,9 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row2(local_row_nzs, a, b, one<ValueType>(), a_row);
+        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
+                               b->get_const_device_view(), one<ValueType>(),
+                               a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -263,8 +268,9 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row(local_col_idxs, d, a_row);
-        spgemm_insert_row2(local_col_idxs, a, b, a_row);
+        spgemm_insert_row(local_col_idxs, d->get_const_device_view(), a_row);
+        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
+                           b->get_const_device_view(), a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -283,8 +289,10 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row(local_row_nzs, d, vbeta, a_row);
-        spgemm_accumulate_row2(local_row_nzs, a, b, valpha, a_row);
+        spgemm_accumulate_row(local_row_nzs, d->get_const_device_view(), vbeta,
+                              a_row);
+        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
+                               b->get_const_device_view(), valpha, a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -301,21 +309,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const ReferenceExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -351,28 +359,29 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
-    const auto d_vals = d->get_const_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
+    const auto d_vals = d.values;
     const auto valpha = alpha(0, 0);
     const auto vbeta = beta(0, 0);
     const auto lookup_storage_offsets =
@@ -437,7 +446,8 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a, b, [](IndexType) { return IndexType{}; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -456,7 +466,8 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;
@@ -472,16 +483,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
-    auto c_row_ptrs = c->get_const_row_ptrs();
-    auto c_col_idxs = c->get_const_col_idxs();
-    auto c_vals = c->get_values();
+    auto c_row_ptrs = c.row_ptrs;
+    auto c_col_idxs = c.col_idxs;
+    auto c_vals = c.values;
 
     abstract_spgeam(
         a, b,
@@ -503,14 +514,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const ReferenceExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
-    auto num_rows = source->get_size()[0];
-    auto num_cols = source->get_size()[1];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
-    auto vals = source->get_const_values();
+    auto num_rows = source.size[0];
+    auto num_cols = source.size[1];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
+    auto vals = source.values;
 
     for (size_type row = 0; row < num_rows; ++row) {
         for (size_type i = row_ptrs[row];
@@ -525,9 +536,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source,
-                      matrix::view::sellp<ValueType, IndexType> result)
+void convert_to_sellp(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    matrix::view::sellp<ValueType, IndexType> result)
 {
     auto num_rows = result.size[0];
     auto num_cols = result.size[1];
@@ -538,9 +550,9 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
     auto slice_size = result.slice_size;
     auto stride_factor = result.stride_factor;
 
-    const auto source_row_ptrs = source->get_const_row_ptrs();
-    const auto source_col_idxs = source->get_const_col_idxs();
-    const auto source_values = source->get_const_values();
+    const auto source_row_ptrs = source.row_ptrs;
+    const auto source_col_idxs = source.col_idxs;
+    const auto source_values = source.values;
 
     auto slice_num = ceildiv(num_rows, slice_size);
     for (size_type slice = 0; slice < slice_num; slice++) {
@@ -573,14 +585,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void convert_to_ell(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* source,
+                    matrix::view::csr<const ValueType, const IndexType> source,
                     matrix::view::ell<ValueType, IndexType> result)
 {
-    const auto num_rows = source->get_size()[0];
-    const auto num_cols = source->get_size()[1];
-    const auto vals = source->get_const_values();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto row_ptrs = source->get_const_row_ptrs();
+    const auto num_rows = source.size[0];
+    const auto num_cols = source.size[1];
+    const auto vals = source.values;
+    const auto col_idxs = source.col_idxs;
+    const auto row_ptrs = source.row_ptrs;
 
     const auto num_stored_elements_per_row = result.num_stored_elements_per_row;
 
@@ -602,20 +614,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
-                      array<ValueType>& values)
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
+    array<ValueType>& values)
 {
     using entry = matrix_data_entry<ValueType, IndexType>;
-    const auto num_rows = source->get_size()[0];
-    const auto num_cols = source->get_size()[1];
+    const auto num_rows = source.size[0];
+    const auto num_cols = source.size[1];
     const auto num_block_rows = num_rows / bs;
     const auto num_block_cols = num_cols / bs;
-    const auto in_row_ptrs = source->get_const_row_ptrs();
-    const auto in_cols = source->get_const_col_idxs();
-    const auto in_vals = source->get_const_values();
-    const auto nnz = source->get_num_stored_elements();
+    const auto in_row_ptrs = source.row_ptrs;
+    const auto in_cols = source.col_idxs;
+    const auto in_vals = source.values;
+    const auto nnz = source.num_stored_elements;
     auto out_row_ptrs = row_ptrs.get_data();
     array<entry> entry_array{exec, nnz};
     auto entries = entry_array.get_data();
@@ -689,20 +702,20 @@ inline void convert_csr_to_csc(size_type num_rows, const IndexType* row_ptrs,
 
 
 template <typename ValueType, typename IndexType, typename UnaryOperator>
-void transpose_and_transform(std::shared_ptr<const ReferenceExecutor> exec,
-                             matrix::Csr<ValueType, IndexType>* trans,
-                             const matrix::Csr<ValueType, IndexType>* orig,
-                             UnaryOperator op)
+void transpose_and_transform(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<ValueType, IndexType> trans,
+    matrix::view::csr<const ValueType, const IndexType> orig, UnaryOperator op)
 {
-    auto trans_row_ptrs = trans->get_row_ptrs();
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto trans_col_idxs = trans->get_col_idxs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto trans_vals = trans->get_values();
-    auto orig_vals = orig->get_const_values();
+    auto trans_row_ptrs = trans.row_ptrs;
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto trans_col_idxs = trans.col_idxs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto trans_vals = trans.values;
+    auto orig_vals = orig.values;
 
-    auto orig_num_cols = orig->get_size()[1];
-    auto orig_num_rows = orig->get_size()[0];
+    auto orig_num_cols = orig.size[1];
+    auto orig_num_rows = orig.size[0];
     auto orig_nnz = orig_row_ptrs[orig_num_rows];
 
     components::fill_array(exec, trans_row_ptrs, orig_num_cols + 1,
@@ -719,8 +732,8 @@ void transpose_and_transform(std::shared_ptr<const ReferenceExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const ReferenceExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return x; });
@@ -731,8 +744,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_TRANSPOSE_KERNEL);
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return conj(x); });
@@ -745,16 +758,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
     size_type res_row = 0;
     for (auto row = row_span.begin; row < row_span.end; ++row) {
         row_nnz.get_data()[res_row] = zero<IndexType>();
-        for (auto nnz = source->get_const_row_ptrs()[row];
-             nnz < source->get_const_row_ptrs()[row + 1]; ++nnz) {
-            if (source->get_const_col_idxs()[nnz] < col_span.end &&
-                source->get_const_col_idxs()[nnz] >= col_span.begin) {
+        for (auto nnz = source.row_ptrs[row]; nnz < source.row_ptrs[row + 1];
+             ++nnz) {
+            if (source.col_idxs[nnz] < col_span.end &&
+                source.col_idxs[nnz] >= col_span.begin) {
                 row_nnz.get_data()[res_row]++;
             }
         }
@@ -769,7 +782,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set, IndexType* row_nnz)
 {
@@ -780,14 +793,14 @@ void calculate_nonzeros_per_row_in_index_set(
     auto num_col_subsets = col_index_set.get_num_subsets();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
-    auto src_ptrs = source->get_const_row_ptrs();
+    auto src_ptrs = source.row_ptrs;
     for (size_type set = 0; set < num_row_subsets; ++set) {
         size_type res_row = row_superset_indices[set];
         for (auto row = row_subset_begin[set]; row < row_subset_end[set];
              ++row) {
             row_nnz[res_row] = zero<IndexType>();
             for (size_type i = src_ptrs[row]; i < src_ptrs[row + 1]; ++i) {
-                auto index = source->get_const_col_idxs()[i];
+                auto index = source.col_idxs[i];
                 if (index >= col_index_set.get_size()) {
                     continue;
                 }
@@ -814,24 +827,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     auto row_offset = row_span.begin;
     auto col_offset = col_span.begin;
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto res_row_ptrs = result->get_row_ptrs();
-    auto res_col_idxs = result->get_col_idxs();
-    auto res_values = result->get_values();
-    const auto src_row_ptrs = source->get_const_row_ptrs();
-    const auto src_col_idxs = source->get_const_col_idxs();
-    const auto src_values = source->get_const_values();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto res_row_ptrs = result.row_ptrs;
+    auto res_col_idxs = result.col_idxs;
+    auto res_values = result.values;
+    const auto src_row_ptrs = source.row_ptrs;
+    const auto src_col_idxs = source.col_idxs;
+    const auto src_values = source.values;
 
     size_type res_nnz = 0;
-    for (size_type nnz = 0; nnz < source->get_num_stored_elements(); ++nnz) {
+    for (size_type nnz = 0; nnz < source.num_stored_elements; ++nnz) {
         if (nnz >= src_row_ptrs[row_offset] &&
             nnz < src_row_ptrs[row_offset + num_rows] &&
             (src_col_idxs[nnz] < (col_offset + num_cols) &&
@@ -850,33 +864,33 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
     auto num_row_subsets = row_index_set.get_num_subsets();
     auto row_subset_begin = row_index_set.get_subsets_begin();
     auto row_subset_end = row_index_set.get_subsets_end();
-    auto res_row_ptrs = result->get_row_ptrs();
-    auto res_col_idxs = result->get_col_idxs();
-    auto res_values = result->get_values();
+    auto res_row_ptrs = result.row_ptrs;
+    auto res_col_idxs = result.col_idxs;
+    auto res_values = result.values;
     auto num_col_subsets = col_index_set.get_num_subsets();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
     auto col_superset_indices = col_index_set.get_superset_indices();
-    const auto src_ptrs = source->get_const_row_ptrs();
-    const auto src_col_idxs = source->get_const_col_idxs();
-    const auto src_values = source->get_const_values();
+    const auto src_ptrs = source.row_ptrs;
+    const auto src_col_idxs = source.col_idxs;
+    const auto src_values = source.values;
 
     size_type res_nnz = 0;
     for (size_type set = 0; set < num_row_subsets; ++set) {
         for (auto row = row_subset_begin[set]; row < row_subset_end[set];
              ++row) {
             for (size_type i = src_ptrs[row]; i < src_ptrs[row + 1]; ++i) {
-                auto index = source->get_const_col_idxs()[i];
+                auto index = source.col_idxs[i];
                 if (index >= col_index_set.get_size()) {
                     continue;
                 }
@@ -906,10 +920,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       const int64*,
-                       matrix::view::hybrid<ValueType, IndexType> result)
+void convert_to_hybrid(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, const int64*,
+    matrix::view::hybrid<ValueType, IndexType> result)
 {
     auto num_rows = result.size[0];
     auto num_cols = result.size[1];
@@ -926,8 +940,8 @@ void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
         }
     }
 
-    const auto csr_row_ptrs = source->get_const_row_ptrs();
-    const auto csr_vals = source->get_const_values();
+    const auto csr_row_ptrs = source.row_ptrs;
+    const auto csr_vals = source.values;
     size_type csr_idx = 0;
     size_type coo_idx = 0;
     for (IndexType row = 0; row < num_rows; row++) {
@@ -936,12 +950,11 @@ void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
             const auto val = csr_vals[csr_idx];
             if (ell_idx < ell_lim) {
                 result.ell_part.val_at(row, ell_idx) = val;
-                result.ell_part.col_at(row, ell_idx) =
-                    source->get_const_col_idxs()[csr_idx];
+                result.ell_part.col_at(row, ell_idx) = source.col_idxs[csr_idx];
                 ell_idx++;
             } else {
                 coo_val[coo_idx] = val;
-                coo_col[coo_idx] = source->get_const_col_idxs()[csr_idx];
+                coo_col[coo_idx] = source.col_idxs[csr_idx];
                 coo_row[coo_idx] = row;
                 coo_idx++;
             }
@@ -957,8 +970,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const ReferenceExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_permute(exec, perm, perm, orig, permuted);
 }
@@ -968,19 +981,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                         const IndexType* row_perm,
-                         const IndexType* column_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const IndexType* row_perm,
+    const IndexType* column_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1008,16 +1021,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const ReferenceExecutor> exec,
                  const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = perm[row];
@@ -1043,16 +1056,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const ReferenceExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1078,16 +1091,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_col_permute(std::shared_ptr<const ReferenceExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* col_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto cp_row_ptrs = col_permuted->get_row_ptrs();
-    auto cp_col_idxs = col_permuted->get_col_idxs();
-    auto cp_vals = col_permuted->get_values();
-    auto num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto cp_row_ptrs = col_permuted.row_ptrs;
+    auto cp_col_idxs = col_permuted.col_idxs;
+    auto cp_vals = col_permuted.values;
+    auto num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto row_begin = in_row_ptrs[row];
@@ -1106,10 +1119,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_scale_permute(exec, scale, perm, scale, perm, orig, permuted);
 }
@@ -1119,21 +1133,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1163,16 +1176,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = perm[row];
@@ -1198,18 +1211,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1235,18 +1249,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_col_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* col_permuted)
+void inv_col_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto cp_row_ptrs = col_permuted->get_row_ptrs();
-    auto cp_col_idxs = col_permuted->get_col_idxs();
-    auto cp_vals = col_permuted->get_values();
-    auto num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto cp_row_ptrs = col_permuted.row_ptrs;
+    auto cp_col_idxs = col_permuted.col_idxs;
+    auto cp_vals = col_permuted.values;
+    auto num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto row_begin = in_row_ptrs[row];
@@ -1267,12 +1282,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const ReferenceExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    auto values = to_sort->get_values();
-    auto row_ptrs = to_sort->get_row_ptrs();
-    auto col_idxs = to_sort->get_col_idxs();
-    const auto number_rows = to_sort->get_size()[0];
+    auto values = to_sort.values;
+    auto row_ptrs = to_sort.row_ptrs;
+    auto col_idxs = to_sort.col_idxs;
+    const auto number_rows = to_sort.size[0];
     for (size_type i = 0; i < number_rows; ++i) {
         auto start_row_idx = row_ptrs[i];
         auto row_nnz = row_ptrs[i + 1] - start_row_idx;
@@ -1290,11 +1305,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
-    const auto row_ptrs = to_check->get_const_row_ptrs();
-    const auto col_idxs = to_check->get_const_col_idxs();
-    const auto size = to_check->get_size();
+    const auto row_ptrs = to_check.row_ptrs;
+    const auto col_idxs = to_check.col_idxs;
+    const auto size = to_check.size;
     is_sorted = true;
     for (size_type i = 0; i < size[0]; ++i) {
         for (auto idx = row_ptrs[i] + 1; idx < row_ptrs[i + 1]; ++idx) {
@@ -1312,12 +1328,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const ReferenceExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto row_ptrs = orig->get_const_row_ptrs();
-    const auto col_idxs = orig->get_const_col_idxs();
-    const auto values = orig->get_const_values();
+    const auto row_ptrs = orig.row_ptrs;
+    const auto col_idxs = orig.col_idxs;
+    const auto values = orig.values;
     const auto diag_size = diag->get_size()[0];
     auto diag_values = diag->get_values();
 
@@ -1337,10 +1353,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_EXTRACT_DIAGONAL);
 template <typename ValueType, typename IndexType>
 void scale(std::shared_ptr<const ReferenceExecutor> exec,
            matrix::view::dense<const ValueType> alpha,
-           matrix::Csr<ValueType, IndexType>* to_scale)
+           matrix::view::csr<ValueType, IndexType> to_scale)
 {
-    const auto nnz = to_scale->get_num_stored_elements();
-    auto values = to_scale->get_values();
+    const auto nnz = to_scale.num_stored_elements;
+    auto values = to_scale.values;
 
     for (size_type idx = 0; idx < nnz; idx++) {
         values[idx] *= alpha(0, 0);
@@ -1353,10 +1369,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SCALE_KERNEL);
 template <typename ValueType, typename IndexType>
 void inv_scale(std::shared_ptr<const ReferenceExecutor> exec,
                matrix::view::dense<const ValueType> alpha,
-               matrix::Csr<ValueType, IndexType>* to_scale)
+               matrix::view::csr<ValueType, IndexType> to_scale)
 {
-    const auto nnz = to_scale->get_num_stored_elements();
-    auto values = to_scale->get_values();
+    const auto nnz = to_scale.num_stored_elements;
+    auto values = to_scale.values;
 
     for (size_type idx = 0; idx < nnz; idx++) {
         values[idx] /= alpha(0, 0);
@@ -1367,14 +1383,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_INV_SCALE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const ReferenceExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
     has_all_diags = true;
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idxs = mtx->get_const_col_idxs();
-    const size_type minsize = std::min(mtx->get_size()[0], mtx->get_size()[1]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idxs = mtx.col_idxs;
+    const size_type minsize = std::min(mtx.size[0], mtx.size[1]);
     for (size_type row = 0; row < minsize; row++) {
         bool row_diag = false;
         for (IndexType iz = row_ptrs[row]; iz < row_ptrs[row + 1]; iz++) {
@@ -1397,15 +1414,15 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const ReferenceExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = static_cast<IndexType>(mtx->get_size()[0]);
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto vals = mtx->get_values();
+    const auto nrows = static_cast<IndexType>(mtx.size[0]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto vals = mtx.values;
     for (IndexType row = 0; row < nrows; row++) {
         for (IndexType iz = row_ptrs[row]; iz < row_ptrs[row + 1]; iz++) {
             vals[iz] *= beta.values[0];
-            if (row == mtx->get_const_col_idxs()[iz]) {
+            if (row == mtx.col_idxs[iz]) {
                 vals[iz] += alpha.values[0];
             }
         }
@@ -1608,15 +1625,16 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_CSR_BENCHMARK_LOOKUP_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           array<ValueType>& sum)
+void row_wise_absolute_sum(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    array<ValueType>& sum)
 {
-    auto row_ptrs = orig->get_const_row_ptrs();
-    auto value_ptr = orig->get_const_values();
+    auto row_ptrs = orig.row_ptrs;
+    auto value_ptr = orig.values;
     auto sum_ptr = sum.get_data();
 
-    for (size_type row = 0; row < orig->get_size()[0]; ++row) {
+    for (size_type row = 0; row < orig.size[0]; ++row) {
         sum_ptr[row] = zero<ValueType>();
         for (size_type k = row_ptrs[row];
              k < static_cast<size_type>(row_ptrs[row + 1]); ++k) {

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -43,7 +43,9 @@ namespace csr {
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const ReferenceExecutor> exec,
-          const matrix::csr::spmv_strategy, const IndexType,
+          const matrix::csr::spmv_strategy,
+          const IndexType /* max_nnz_per_row */,
+          size_type /* num_srow_elements */, const IndexType* /*srow*/,
           matrix::view::csr<const MatrixValueType, const IndexType> a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
@@ -83,6 +85,7 @@ template <typename MatrixValueType, typename InputValueType,
 void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
                    const matrix::csr::spmv_strategy,
                    const IndexType /* max_nnz_per_row */,
+                   size_type /*num_srow_elements */, const IndexType* /*srow*/,
                    matrix::view::dense<const MatrixValueType> alpha,
                    matrix::view::csr<const MatrixValueType, const IndexType> a,
                    matrix::view::dense<const InputValueType> b,

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -57,8 +57,8 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
     auto row_ptrs = a->get_const_row_ptrs();
     auto col_idxs = a->get_const_col_idxs();
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -98,8 +98,8 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
     auto valpha = static_cast<arithmetic_type>(alpha(0, 0));
     auto vbeta = static_cast<arithmetic_type>(beta(0, 0));
 
-    const auto a_vals =
-        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
+    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
+        a->get_const_device_view());
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -123,25 +123,25 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_insert_row(unordered_set<IndexType>& cols,
-                       const matrix::Csr<ValueType, IndexType>* c,
+                       matrix::view::csr<const ValueType, const IndexType> c,
                        size_type row)
 {
-    auto row_ptrs = c->get_const_row_ptrs();
-    auto col_idxs = c->get_const_col_idxs();
+    auto row_ptrs = c.row_ptrs;
+    auto col_idxs = c.col_idxs;
     cols.insert(col_idxs + row_ptrs[row], col_idxs + row_ptrs[row + 1]);
 }
 
 
 template <typename ValueType, typename IndexType>
 void spgemm_insert_row2(unordered_set<IndexType>& cols,
-                        const matrix::Csr<ValueType, IndexType>* a,
-                        const matrix::Csr<ValueType, IndexType>* b,
+                        matrix::view::csr<const ValueType, const IndexType> a,
+                        matrix::view::csr<const ValueType, const IndexType> b,
                         size_type row)
 {
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
     for (size_type a_nz = a_row_ptrs[row];
          a_nz < size_type(a_row_ptrs[row + 1]); ++a_nz) {
         auto a_col = a_col_idxs[a_nz];
@@ -153,13 +153,14 @@ void spgemm_insert_row2(unordered_set<IndexType>& cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row(map<IndexType, ValueType>& cols,
-                           const matrix::Csr<ValueType, IndexType>* c,
-                           ValueType scale, size_type row)
+void spgemm_accumulate_row(
+    map<IndexType, ValueType>& cols,
+    matrix::view::csr<const ValueType, const IndexType> c, ValueType scale,
+    size_type row)
 {
-    auto row_ptrs = c->get_const_row_ptrs();
-    auto col_idxs = c->get_const_col_idxs();
-    auto vals = c->get_const_values();
+    auto row_ptrs = c.row_ptrs;
+    auto col_idxs = c.col_idxs;
+    auto vals = c.values;
     for (size_type c_nz = row_ptrs[row]; c_nz < size_type(row_ptrs[row + 1]);
          ++c_nz) {
         auto c_col = col_idxs[c_nz];
@@ -170,17 +171,18 @@ void spgemm_accumulate_row(map<IndexType, ValueType>& cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row2(map<IndexType, ValueType>& cols,
-                            const matrix::Csr<ValueType, IndexType>* a,
-                            const matrix::Csr<ValueType, IndexType>* b,
-                            ValueType scale, size_type row)
+void spgemm_accumulate_row2(
+    map<IndexType, ValueType>& cols,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b, ValueType scale,
+    size_type row)
 {
-    auto a_row_ptrs = a->get_const_row_ptrs();
-    auto a_col_idxs = a->get_const_col_idxs();
-    auto a_vals = a->get_const_values();
-    auto b_row_ptrs = b->get_const_row_ptrs();
-    auto b_col_idxs = b->get_const_col_idxs();
-    auto b_vals = b->get_const_values();
+    auto a_row_ptrs = a.row_ptrs;
+    auto a_col_idxs = a.col_idxs;
+    auto a_vals = a.values;
+    auto b_row_ptrs = b.row_ptrs;
+    auto b_col_idxs = b.col_idxs;
+    auto b_vals = b.values;
     for (size_type a_nz = a_row_ptrs[row];
          a_nz < size_type(a_row_ptrs[row + 1]); ++a_nz) {
         auto a_col = a_col_idxs[a_nz];
@@ -210,7 +212,8 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row2(local_col_idxs, a, b, a_row);
+        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
+                           b->get_const_device_view(), a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -230,7 +233,9 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row2(local_row_nzs, a, b, one<ValueType>(), a_row);
+        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
+                               b->get_const_device_view(), one<ValueType>(),
+                               a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -263,8 +268,9 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row(local_col_idxs, d, a_row);
-        spgemm_insert_row2(local_col_idxs, a, b, a_row);
+        spgemm_insert_row(local_col_idxs, d->get_const_device_view(), a_row);
+        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
+                           b->get_const_device_view(), a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -284,8 +290,10 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row(local_row_nzs, d, vbeta, a_row);
-        spgemm_accumulate_row2(local_row_nzs, a, b, valpha, a_row);
+        spgemm_accumulate_row(local_row_nzs, d->get_const_device_view(), vbeta,
+                              a_row);
+        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
+                               b->get_const_device_view(), valpha, a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -302,21 +310,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_reuse(std::shared_ptr<const ReferenceExecutor> exec,
-                  const matrix::Csr<ValueType, IndexType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
+                  matrix::view::csr<const ValueType, const IndexType> a,
+                  matrix::view::csr<const ValueType, const IndexType> b,
                   const matrix::csr::lookup_data<IndexType>& c_lookup,
-                  matrix::Csr<ValueType, IndexType>* c)
+                  matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
     const auto lookup_storage_offsets =
         c_lookup.storage_offsets.get_const_data();
     const auto lookup_storage = c_lookup.storage.get_const_data();
@@ -352,28 +360,29 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void advanced_spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::view::dense<const ValueType> alpha,
-                           const matrix::Csr<ValueType, IndexType>* a,
-                           const matrix::Csr<ValueType, IndexType>* b,
-                           matrix::view::dense<const ValueType> beta,
-                           const matrix::Csr<ValueType, IndexType>* d,
-                           const matrix::csr::lookup_data<IndexType>& c_lookup,
-                           matrix::Csr<ValueType, IndexType>* c)
+void advanced_spgemm_reuse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::dense<const ValueType> alpha,
+    matrix::view::csr<const ValueType, const IndexType> a,
+    matrix::view::csr<const ValueType, const IndexType> b,
+    matrix::view::dense<const ValueType> beta,
+    matrix::view::csr<const ValueType, const IndexType> d,
+    const matrix::csr::lookup_data<IndexType>& c_lookup,
+    matrix::view::csr<ValueType, IndexType> c)
 {
-    const auto num_rows = static_cast<IndexType>(c->get_size()[0]);
-    const auto a_row_ptrs = a->get_const_row_ptrs();
-    const auto b_row_ptrs = b->get_const_row_ptrs();
-    const auto c_row_ptrs = c->get_const_row_ptrs();
-    const auto d_row_ptrs = d->get_const_row_ptrs();
-    const auto a_cols = a->get_const_col_idxs();
-    const auto b_cols = b->get_const_col_idxs();
-    const auto c_cols = c->get_const_col_idxs();
-    const auto d_cols = d->get_const_col_idxs();
-    const auto a_vals = a->get_const_values();
-    const auto b_vals = b->get_const_values();
-    const auto c_vals = c->get_values();
-    const auto d_vals = d->get_const_values();
+    const auto num_rows = static_cast<IndexType>(c.size[0]);
+    const auto a_row_ptrs = a.row_ptrs;
+    const auto b_row_ptrs = b.row_ptrs;
+    const auto c_row_ptrs = c.row_ptrs;
+    const auto d_row_ptrs = d.row_ptrs;
+    const auto a_cols = a.col_idxs;
+    const auto b_cols = b.col_idxs;
+    const auto c_cols = c.col_idxs;
+    const auto d_cols = d.col_idxs;
+    const auto a_vals = a.values;
+    const auto b_vals = b.values;
+    const auto c_vals = c.values;
+    const auto d_vals = d.values;
     const auto valpha = alpha(0, 0);
     const auto vbeta = beta(0, 0);
     const auto lookup_storage_offsets =
@@ -437,7 +446,8 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a, b, [](IndexType) { return IndexType{}; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -457,7 +467,8 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
+        a->get_const_device_view(), b->get_const_device_view(),
+        [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;
@@ -473,16 +484,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    const matrix::Csr<ValueType, IndexType>* a,
+                    matrix::view::csr<const ValueType, const IndexType> a,
                     matrix::view::dense<const ValueType> beta,
-                    const matrix::Csr<ValueType, IndexType>* b,
-                    matrix::Csr<ValueType, IndexType>* c)
+                    matrix::view::csr<const ValueType, const IndexType> b,
+                    matrix::view::csr<ValueType, IndexType> c)
 {
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
-    auto c_row_ptrs = c->get_const_row_ptrs();
-    auto c_col_idxs = c->get_const_col_idxs();
-    auto c_vals = c->get_values();
+    auto c_row_ptrs = c.row_ptrs;
+    auto c_col_idxs = c.col_idxs;
+    auto c_vals = c.values;
 
     abstract_spgeam(
         a, b,
@@ -504,14 +515,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void fill_in_dense(std::shared_ptr<const ReferenceExecutor> exec,
-                   const matrix::Csr<ValueType, IndexType>* source,
+                   matrix::view::csr<const ValueType, const IndexType> source,
                    matrix::view::dense<ValueType> result)
 {
-    auto num_rows = source->get_size()[0];
-    auto num_cols = source->get_size()[1];
-    auto row_ptrs = source->get_const_row_ptrs();
-    auto col_idxs = source->get_const_col_idxs();
-    auto vals = source->get_const_values();
+    auto num_rows = source.size[0];
+    auto num_cols = source.size[1];
+    auto row_ptrs = source.row_ptrs;
+    auto col_idxs = source.col_idxs;
+    auto vals = source.values;
 
     for (size_type row = 0; row < num_rows; ++row) {
         for (size_type i = row_ptrs[row];
@@ -526,9 +537,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source,
-                      matrix::view::sellp<ValueType, IndexType> result)
+void convert_to_sellp(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    matrix::view::sellp<ValueType, IndexType> result)
 {
     auto num_rows = result.size[0];
     auto num_cols = result.size[1];
@@ -539,9 +551,9 @@ void convert_to_sellp(std::shared_ptr<const ReferenceExecutor> exec,
     auto slice_size = result.slice_size;
     auto stride_factor = result.stride_factor;
 
-    const auto source_row_ptrs = source->get_const_row_ptrs();
-    const auto source_col_idxs = source->get_const_col_idxs();
-    const auto source_values = source->get_const_values();
+    const auto source_row_ptrs = source.row_ptrs;
+    const auto source_col_idxs = source.col_idxs;
+    const auto source_values = source.values;
 
     auto slice_num = ceildiv(num_rows, slice_size);
     for (size_type slice = 0; slice < slice_num; slice++) {
@@ -574,14 +586,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void convert_to_ell(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* source,
+                    matrix::view::csr<const ValueType, const IndexType> source,
                     matrix::view::ell<ValueType, IndexType> result)
 {
-    const auto num_rows = source->get_size()[0];
-    const auto num_cols = source->get_size()[1];
-    const auto vals = source->get_const_values();
-    const auto col_idxs = source->get_const_col_idxs();
-    const auto row_ptrs = source->get_const_row_ptrs();
+    const auto num_rows = source.size[0];
+    const auto num_cols = source.size[1];
+    const auto vals = source.values;
+    const auto col_idxs = source.col_idxs;
+    const auto row_ptrs = source.row_ptrs;
 
     const auto num_stored_elements_per_row = result.num_stored_elements_per_row;
 
@@ -603,20 +615,21 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* source, int bs,
-                      array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
-                      array<ValueType>& values)
+void convert_to_fbcsr(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, int bs,
+    array<IndexType>& row_ptrs, array<IndexType>& col_idxs,
+    array<ValueType>& values)
 {
     using entry = matrix_data_entry<ValueType, IndexType>;
-    const auto num_rows = source->get_size()[0];
-    const auto num_cols = source->get_size()[1];
+    const auto num_rows = source.size[0];
+    const auto num_cols = source.size[1];
     const auto num_block_rows = num_rows / bs;
     const auto num_block_cols = num_cols / bs;
-    const auto in_row_ptrs = source->get_const_row_ptrs();
-    const auto in_cols = source->get_const_col_idxs();
-    const auto in_vals = source->get_const_values();
-    const auto nnz = source->get_num_stored_elements();
+    const auto in_row_ptrs = source.row_ptrs;
+    const auto in_cols = source.col_idxs;
+    const auto in_vals = source.values;
+    const auto nnz = source.num_stored_elements;
     auto out_row_ptrs = row_ptrs.get_data();
     array<entry> entry_array{exec, nnz};
     auto entries = entry_array.get_data();
@@ -690,20 +703,20 @@ inline void convert_csr_to_csc(size_type num_rows, const IndexType* row_ptrs,
 
 
 template <typename ValueType, typename IndexType, typename UnaryOperator>
-void transpose_and_transform(std::shared_ptr<const ReferenceExecutor> exec,
-                             matrix::Csr<ValueType, IndexType>* trans,
-                             const matrix::Csr<ValueType, IndexType>* orig,
-                             UnaryOperator op)
+void transpose_and_transform(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<ValueType, IndexType> trans,
+    matrix::view::csr<const ValueType, const IndexType> orig, UnaryOperator op)
 {
-    auto trans_row_ptrs = trans->get_row_ptrs();
-    auto orig_row_ptrs = orig->get_const_row_ptrs();
-    auto trans_col_idxs = trans->get_col_idxs();
-    auto orig_col_idxs = orig->get_const_col_idxs();
-    auto trans_vals = trans->get_values();
-    auto orig_vals = orig->get_const_values();
+    auto trans_row_ptrs = trans.row_ptrs;
+    auto orig_row_ptrs = orig.row_ptrs;
+    auto trans_col_idxs = trans.col_idxs;
+    auto orig_col_idxs = orig.col_idxs;
+    auto trans_vals = trans.values;
+    auto orig_vals = orig.values;
 
-    auto orig_num_cols = orig->get_size()[1];
-    auto orig_num_rows = orig->get_size()[0];
+    auto orig_num_cols = orig.size[1];
+    auto orig_num_rows = orig.size[0];
     auto orig_nnz = orig_row_ptrs[orig_num_rows];
 
     components::fill_array(exec, trans_row_ptrs, orig_num_cols + 1,
@@ -720,8 +733,8 @@ void transpose_and_transform(std::shared_ptr<const ReferenceExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void transpose(std::shared_ptr<const ReferenceExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* orig,
-               matrix::Csr<ValueType, IndexType>* trans)
+               matrix::view::csr<const ValueType, const IndexType> orig,
+               matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return x; });
@@ -732,8 +745,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_TRANSPOSE_KERNEL);
 
 template <typename ValueType, typename IndexType>
 void conj_transpose(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* orig,
-                    matrix::Csr<ValueType, IndexType>* trans)
+                    matrix::view::csr<const ValueType, const IndexType> orig,
+                    matrix::view::csr<ValueType, IndexType> trans)
 {
     transpose_and_transform(exec, trans, orig,
                             [](const ValueType x) { return conj(x); });
@@ -746,16 +759,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_span(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source, const span& row_span,
-    const span& col_span, array<IndexType>& row_nnz)
+    matrix::view::csr<const ValueType, const IndexType> source,
+    const span& row_span, const span& col_span, array<IndexType>& row_nnz)
 {
     size_type res_row = 0;
     for (auto row = row_span.begin; row < row_span.end; ++row) {
         row_nnz.get_data()[res_row] = zero<IndexType>();
-        for (auto nnz = source->get_const_row_ptrs()[row];
-             nnz < source->get_const_row_ptrs()[row + 1]; ++nnz) {
-            if (source->get_const_col_idxs()[nnz] < col_span.end &&
-                source->get_const_col_idxs()[nnz] >= col_span.begin) {
+        for (auto nnz = source.row_ptrs[row]; nnz < source.row_ptrs[row + 1];
+             ++nnz) {
+            if (source.col_idxs[nnz] < col_span.end &&
+                source.col_idxs[nnz] >= col_span.begin) {
                 row_nnz.get_data()[res_row]++;
             }
         }
@@ -770,7 +783,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void calculate_nonzeros_per_row_in_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set, IndexType* row_nnz)
 {
@@ -781,14 +794,14 @@ void calculate_nonzeros_per_row_in_index_set(
     auto num_col_subsets = col_index_set.get_num_subsets();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
-    auto src_ptrs = source->get_const_row_ptrs();
+    auto src_ptrs = source.row_ptrs;
     for (size_type set = 0; set < num_row_subsets; ++set) {
         size_type res_row = row_superset_indices[set];
         for (auto row = row_subset_begin[set]; row < row_subset_end[set];
              ++row) {
             row_nnz[res_row] = zero<IndexType>();
             for (size_type i = src_ptrs[row]; i < src_ptrs[row + 1]; ++i) {
-                auto index = source->get_const_col_idxs()[i];
+                auto index = source.col_idxs[i];
                 if (index >= col_index_set.get_size()) {
                     continue;
                 }
@@ -815,24 +828,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_submatrix(std::shared_ptr<const DefaultExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       gko::span row_span, gko::span col_span,
-                       matrix::Csr<ValueType, IndexType>* result)
+void compute_submatrix(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source,
+    gko::span row_span, gko::span col_span,
+    matrix::view::csr<ValueType, IndexType> result)
 {
     auto row_offset = row_span.begin;
     auto col_offset = col_span.begin;
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto res_row_ptrs = result->get_row_ptrs();
-    auto res_col_idxs = result->get_col_idxs();
-    auto res_values = result->get_values();
-    const auto src_row_ptrs = source->get_const_row_ptrs();
-    const auto src_col_idxs = source->get_const_col_idxs();
-    const auto src_values = source->get_const_values();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto res_row_ptrs = result.row_ptrs;
+    auto res_col_idxs = result.col_idxs;
+    auto res_values = result.values;
+    const auto src_row_ptrs = source.row_ptrs;
+    const auto src_col_idxs = source.col_idxs;
+    const auto src_values = source.values;
 
     size_type res_nnz = 0;
-    for (size_type nnz = 0; nnz < source->get_num_stored_elements(); ++nnz) {
+    for (size_type nnz = 0; nnz < source.num_stored_elements; ++nnz) {
         if (nnz >= src_row_ptrs[row_offset] &&
             nnz < src_row_ptrs[row_offset + num_rows] &&
             (src_col_idxs[nnz] < (col_offset + num_cols) &&
@@ -851,33 +865,33 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void compute_submatrix_from_index_set(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* source,
+    matrix::view::csr<const ValueType, const IndexType> source,
     const gko::index_set<IndexType>& row_index_set,
     const gko::index_set<IndexType>& col_index_set,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
     auto num_row_subsets = row_index_set.get_num_subsets();
     auto row_subset_begin = row_index_set.get_subsets_begin();
     auto row_subset_end = row_index_set.get_subsets_end();
-    auto res_row_ptrs = result->get_row_ptrs();
-    auto res_col_idxs = result->get_col_idxs();
-    auto res_values = result->get_values();
+    auto res_row_ptrs = result.row_ptrs;
+    auto res_col_idxs = result.col_idxs;
+    auto res_values = result.values;
     auto num_col_subsets = col_index_set.get_num_subsets();
     auto col_subset_begin = col_index_set.get_subsets_begin();
     auto col_subset_end = col_index_set.get_subsets_end();
     auto col_superset_indices = col_index_set.get_superset_indices();
-    const auto src_ptrs = source->get_const_row_ptrs();
-    const auto src_col_idxs = source->get_const_col_idxs();
-    const auto src_values = source->get_const_values();
+    const auto src_ptrs = source.row_ptrs;
+    const auto src_col_idxs = source.col_idxs;
+    const auto src_values = source.values;
 
     size_type res_nnz = 0;
     for (size_type set = 0; set < num_row_subsets; ++set) {
         for (auto row = row_subset_begin[set]; row < row_subset_end[set];
              ++row) {
             for (size_type i = src_ptrs[row]; i < src_ptrs[row + 1]; ++i) {
-                auto index = source->get_const_col_idxs()[i];
+                auto index = source.col_idxs[i];
                 if (index >= col_index_set.get_size()) {
                     continue;
                 }
@@ -907,10 +921,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
-                       const matrix::Csr<ValueType, IndexType>* source,
-                       const int64*,
-                       matrix::Hybrid<ValueType, IndexType>* result)
+void convert_to_hybrid(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> source, const int64*,
+    matrix::Hybrid<ValueType, IndexType>* result)
 {
     auto num_rows = result->get_size()[0];
     auto num_cols = result->get_size()[1];
@@ -929,8 +943,8 @@ void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
         }
     }
 
-    const auto csr_row_ptrs = source->get_const_row_ptrs();
-    const auto csr_vals = source->get_const_values();
+    const auto csr_row_ptrs = source.row_ptrs;
+    const auto csr_vals = source.values;
     size_type csr_idx = 0;
     size_type coo_idx = 0;
     for (IndexType row = 0; row < num_rows; row++) {
@@ -939,12 +953,11 @@ void convert_to_hybrid(std::shared_ptr<const ReferenceExecutor> exec,
             const auto val = csr_vals[csr_idx];
             if (ell_idx < ell_lim) {
                 result->ell_val_at(row, ell_idx) = val;
-                result->ell_col_at(row, ell_idx) =
-                    source->get_const_col_idxs()[csr_idx];
+                result->ell_col_at(row, ell_idx) = source.col_idxs[csr_idx];
                 ell_idx++;
             } else {
                 coo_val[coo_idx] = val;
-                coo_col[coo_idx] = source->get_const_col_idxs()[csr_idx];
+                coo_col[coo_idx] = source.col_idxs[csr_idx];
                 coo_row[coo_idx] = row;
                 coo_idx++;
             }
@@ -960,8 +973,8 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_symm_permute(std::shared_ptr<const ReferenceExecutor> exec,
                       const IndexType* perm,
-                      const matrix::Csr<ValueType, IndexType>* orig,
-                      matrix::Csr<ValueType, IndexType>* permuted)
+                      matrix::view::csr<const ValueType, const IndexType> orig,
+                      matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_permute(exec, perm, perm, orig, permuted);
 }
@@ -971,19 +984,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                         const IndexType* row_perm,
-                         const IndexType* column_perm,
-                         const matrix::Csr<ValueType, IndexType>* orig,
-                         matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const IndexType* row_perm,
+    const IndexType* column_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1011,16 +1024,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_permute(std::shared_ptr<const ReferenceExecutor> exec,
                  const IndexType* perm,
-                 const matrix::Csr<ValueType, IndexType>* orig,
-                 matrix::Csr<ValueType, IndexType>* row_permuted)
+                 matrix::view::csr<const ValueType, const IndexType> orig,
+                 matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = perm[row];
@@ -1046,16 +1059,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_row_permute(std::shared_ptr<const ReferenceExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* row_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1081,16 +1094,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void inv_col_permute(std::shared_ptr<const ReferenceExecutor> exec,
                      const IndexType* perm,
-                     const matrix::Csr<ValueType, IndexType>* orig,
-                     matrix::Csr<ValueType, IndexType>* col_permuted)
+                     matrix::view::csr<const ValueType, const IndexType> orig,
+                     matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto cp_row_ptrs = col_permuted->get_row_ptrs();
-    auto cp_col_idxs = col_permuted->get_col_idxs();
-    auto cp_vals = col_permuted->get_values();
-    auto num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto cp_row_ptrs = col_permuted.row_ptrs;
+    auto cp_col_idxs = col_permuted.col_idxs;
+    auto cp_vals = col_permuted.values;
+    auto num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto row_begin = in_row_ptrs[row];
@@ -1109,10 +1122,11 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_symm_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                            const ValueType* scale, const IndexType* perm,
-                            const matrix::Csr<ValueType, IndexType>* orig,
-                            matrix::Csr<ValueType, IndexType>* permuted)
+void inv_symm_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
     inv_nonsymm_scale_permute(exec, scale, perm, scale, perm, orig, permuted);
 }
@@ -1122,21 +1136,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_nonsymm_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                               const ValueType* row_scale,
-                               const IndexType* row_perm,
-                               const ValueType* col_scale,
-                               const IndexType* col_perm,
-                               const matrix::Csr<ValueType, IndexType>* orig,
-                               matrix::Csr<ValueType, IndexType>* permuted)
+void inv_nonsymm_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* row_scale,
+    const IndexType* row_perm, const ValueType* col_scale,
+    const IndexType* col_perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto p_row_ptrs = permuted->get_row_ptrs();
-    auto p_col_idxs = permuted->get_col_idxs();
-    auto p_vals = permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto p_row_ptrs = permuted.row_ptrs;
+    auto p_col_idxs = permuted.col_idxs;
+    auto p_vals = permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1166,16 +1179,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void row_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
                        const ValueType* scale, const IndexType* perm,
-                       const matrix::Csr<ValueType, IndexType>* orig,
-                       matrix::Csr<ValueType, IndexType>* row_permuted)
+                       matrix::view::csr<const ValueType, const IndexType> orig,
+                       matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = perm[row];
@@ -1201,18 +1214,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_row_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* row_permuted)
+void inv_row_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> row_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto rp_row_ptrs = row_permuted->get_row_ptrs();
-    auto rp_col_idxs = row_permuted->get_col_idxs();
-    auto rp_vals = row_permuted->get_values();
-    size_type num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto rp_row_ptrs = row_permuted.row_ptrs;
+    auto rp_col_idxs = row_permuted.col_idxs;
+    auto rp_vals = row_permuted.values;
+    size_type num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto src_row = row;
@@ -1238,18 +1252,19 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void inv_col_scale_permute(std::shared_ptr<const ReferenceExecutor> exec,
-                           const ValueType* scale, const IndexType* perm,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           matrix::Csr<ValueType, IndexType>* col_permuted)
+void inv_col_scale_permute(
+    std::shared_ptr<const ReferenceExecutor> exec, const ValueType* scale,
+    const IndexType* perm,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    matrix::view::csr<ValueType, IndexType> col_permuted)
 {
-    auto in_row_ptrs = orig->get_const_row_ptrs();
-    auto in_col_idxs = orig->get_const_col_idxs();
-    auto in_vals = orig->get_const_values();
-    auto cp_row_ptrs = col_permuted->get_row_ptrs();
-    auto cp_col_idxs = col_permuted->get_col_idxs();
-    auto cp_vals = col_permuted->get_values();
-    auto num_rows = orig->get_size()[0];
+    auto in_row_ptrs = orig.row_ptrs;
+    auto in_col_idxs = orig.col_idxs;
+    auto in_vals = orig.values;
+    auto cp_row_ptrs = col_permuted.row_ptrs;
+    auto cp_col_idxs = col_permuted.col_idxs;
+    auto cp_vals = col_permuted.values;
+    auto num_rows = orig.size[0];
 
     for (size_type row = 0; row < num_rows; ++row) {
         auto row_begin = in_row_ptrs[row];
@@ -1270,12 +1285,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void sort_by_column_index(std::shared_ptr<const ReferenceExecutor> exec,
-                          matrix::Csr<ValueType, IndexType>* to_sort)
+                          matrix::view::csr<ValueType, IndexType> to_sort)
 {
-    auto values = to_sort->get_values();
-    auto row_ptrs = to_sort->get_row_ptrs();
-    auto col_idxs = to_sort->get_col_idxs();
-    const auto number_rows = to_sort->get_size()[0];
+    auto values = to_sort.values;
+    auto row_ptrs = to_sort.row_ptrs;
+    auto col_idxs = to_sort.col_idxs;
+    const auto number_rows = to_sort.size[0];
     for (size_type i = 0; i < number_rows; ++i) {
         auto start_row_idx = row_ptrs[i];
         auto row_nnz = row_ptrs[i + 1] - start_row_idx;
@@ -1293,11 +1308,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void is_sorted_by_column_index(
     std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* to_check, bool& is_sorted)
+    matrix::view::csr<const ValueType, const IndexType> to_check,
+    bool& is_sorted)
 {
-    const auto row_ptrs = to_check->get_const_row_ptrs();
-    const auto col_idxs = to_check->get_const_col_idxs();
-    const auto size = to_check->get_size();
+    const auto row_ptrs = to_check.row_ptrs;
+    const auto col_idxs = to_check.col_idxs;
+    const auto size = to_check.size;
     is_sorted = true;
     for (size_type i = 0; i < size[0]; ++i) {
         for (auto idx = row_ptrs[i] + 1; idx < row_ptrs[i + 1]; ++idx) {
@@ -1315,12 +1331,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void extract_diagonal(std::shared_ptr<const ReferenceExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* orig,
+                      matrix::view::csr<const ValueType, const IndexType> orig,
                       matrix::Diagonal<ValueType>* diag)
 {
-    const auto row_ptrs = orig->get_const_row_ptrs();
-    const auto col_idxs = orig->get_const_col_idxs();
-    const auto values = orig->get_const_values();
+    const auto row_ptrs = orig.row_ptrs;
+    const auto col_idxs = orig.col_idxs;
+    const auto values = orig.values;
     const auto diag_size = diag->get_size()[0];
     auto diag_values = diag->get_values();
 
@@ -1340,10 +1356,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_EXTRACT_DIAGONAL);
 template <typename ValueType, typename IndexType>
 void scale(std::shared_ptr<const ReferenceExecutor> exec,
            matrix::view::dense<const ValueType> alpha,
-           matrix::Csr<ValueType, IndexType>* to_scale)
+           matrix::view::csr<ValueType, IndexType> to_scale)
 {
-    const auto nnz = to_scale->get_num_stored_elements();
-    auto values = to_scale->get_values();
+    const auto nnz = to_scale.num_stored_elements;
+    auto values = to_scale.values;
 
     for (size_type idx = 0; idx < nnz; idx++) {
         values[idx] *= alpha(0, 0);
@@ -1356,10 +1372,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SCALE_KERNEL);
 template <typename ValueType, typename IndexType>
 void inv_scale(std::shared_ptr<const ReferenceExecutor> exec,
                matrix::view::dense<const ValueType> alpha,
-               matrix::Csr<ValueType, IndexType>* to_scale)
+               matrix::view::csr<ValueType, IndexType> to_scale)
 {
-    const auto nnz = to_scale->get_num_stored_elements();
-    auto values = to_scale->get_values();
+    const auto nnz = to_scale.num_stored_elements;
+    auto values = to_scale.values;
 
     for (size_type idx = 0; idx < nnz; idx++) {
         values[idx] /= alpha(0, 0);
@@ -1370,14 +1386,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_INV_SCALE_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void check_diagonal_entries_exist(std::shared_ptr<const ReferenceExecutor> exec,
-                                  const matrix::Csr<ValueType, IndexType>* mtx,
-                                  bool& has_all_diags)
+void check_diagonal_entries_exist(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    bool& has_all_diags)
 {
     has_all_diags = true;
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idxs = mtx->get_const_col_idxs();
-    const size_type minsize = std::min(mtx->get_size()[0], mtx->get_size()[1]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idxs = mtx.col_idxs;
+    const size_type minsize = std::min(mtx.size[0], mtx.size[1]);
     for (size_type row = 0; row < minsize; row++) {
         bool row_diag = false;
         for (IndexType iz = row_ptrs[row]; iz < row_ptrs[row + 1]; iz++) {
@@ -1400,15 +1417,15 @@ template <typename ValueType, typename IndexType>
 void add_scaled_identity(std::shared_ptr<const ReferenceExecutor> exec,
                          matrix::view::dense<const ValueType> alpha,
                          matrix::view::dense<const ValueType> beta,
-                         matrix::Csr<ValueType, IndexType>* mtx)
+                         matrix::view::csr<ValueType, IndexType> mtx)
 {
-    const auto nrows = static_cast<IndexType>(mtx->get_size()[0]);
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto vals = mtx->get_values();
+    const auto nrows = static_cast<IndexType>(mtx.size[0]);
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto vals = mtx.values;
     for (IndexType row = 0; row < nrows; row++) {
         for (IndexType iz = row_ptrs[row]; iz < row_ptrs[row + 1]; iz++) {
             vals[iz] *= beta.values[0];
-            if (row == mtx->get_const_col_idxs()[iz]) {
+            if (row == mtx.col_idxs[iz]) {
                 vals[iz] += alpha.values[0];
             }
         }
@@ -1611,15 +1628,16 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(GKO_DECLARE_CSR_BENCHMARK_LOOKUP_KERNEL);
 
 
 template <typename ValueType, typename IndexType>
-void row_wise_absolute_sum(std::shared_ptr<const DefaultExecutor> exec,
-                           const matrix::Csr<ValueType, IndexType>* orig,
-                           array<ValueType>& sum)
+void row_wise_absolute_sum(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> orig,
+    array<ValueType>& sum)
 {
-    auto row_ptrs = orig->get_const_row_ptrs();
-    auto value_ptr = orig->get_const_values();
+    auto row_ptrs = orig.row_ptrs;
+    auto value_ptr = orig.values;
     auto sum_ptr = sum.get_data();
 
-    for (size_type row = 0; row < orig->get_size()[0]; ++row) {
+    for (size_type row = 0; row < orig.size[0]; ++row) {
         sum_ptr[row] = zero<ValueType>();
         for (size_type k = row_ptrs[row];
              k < static_cast<size_type>(row_ptrs[row + 1]); ++k) {

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -57,8 +57,8 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
     auto row_ptrs = a->get_const_row_ptrs();
     auto col_idxs = a->get_const_col_idxs();
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -98,8 +98,8 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
     auto valpha = static_cast<arithmetic_type>(alpha(0, 0));
     auto vbeta = static_cast<arithmetic_type>(beta(0, 0));
 
-    const auto a_vals = acc::helper::build_const_rrm_accessor<arithmetic_type>(
-        a->get_const_device_view());
+    const auto a_vals =
+        acc::helper::build_const_rrm_accessor<arithmetic_type>(a);
     const auto b_vals =
         acc::helper::build_const_rrm_accessor<arithmetic_type>(b);
     auto c_vals = acc::helper::build_rrm_accessor<arithmetic_type>(c);
@@ -123,25 +123,25 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void spgemm_insert_row(unordered_set<IndexType>& cols,
-                       matrix::view::csr<const ValueType, const IndexType> c,
+                       const matrix::Csr<ValueType, IndexType>* c,
                        size_type row)
 {
-    auto row_ptrs = c.row_ptrs;
-    auto col_idxs = c.col_idxs;
+    auto row_ptrs = c->get_const_row_ptrs();
+    auto col_idxs = c->get_const_col_idxs();
     cols.insert(col_idxs + row_ptrs[row], col_idxs + row_ptrs[row + 1]);
 }
 
 
 template <typename ValueType, typename IndexType>
 void spgemm_insert_row2(unordered_set<IndexType>& cols,
-                        matrix::view::csr<const ValueType, const IndexType> a,
-                        matrix::view::csr<const ValueType, const IndexType> b,
+                        const matrix::Csr<ValueType, IndexType>* a,
+                        const matrix::Csr<ValueType, IndexType>* b,
                         size_type row)
 {
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto b_row_ptrs = b.row_ptrs;
-    auto b_col_idxs = b.col_idxs;
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto b_row_ptrs = b->get_const_row_ptrs();
+    auto b_col_idxs = b->get_const_col_idxs();
     for (size_type a_nz = a_row_ptrs[row];
          a_nz < size_type(a_row_ptrs[row + 1]); ++a_nz) {
         auto a_col = a_col_idxs[a_nz];
@@ -153,14 +153,13 @@ void spgemm_insert_row2(unordered_set<IndexType>& cols,
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row(
-    map<IndexType, ValueType>& cols,
-    matrix::view::csr<const ValueType, const IndexType> c, ValueType scale,
-    size_type row)
+void spgemm_accumulate_row(map<IndexType, ValueType>& cols,
+                           const matrix::Csr<ValueType, IndexType>* c,
+                           ValueType scale, size_type row)
 {
-    auto row_ptrs = c.row_ptrs;
-    auto col_idxs = c.col_idxs;
-    auto vals = c.values;
+    auto row_ptrs = c->get_const_row_ptrs();
+    auto col_idxs = c->get_const_col_idxs();
+    auto vals = c->get_const_values();
     for (size_type c_nz = row_ptrs[row]; c_nz < size_type(row_ptrs[row + 1]);
          ++c_nz) {
         auto c_col = col_idxs[c_nz];
@@ -171,18 +170,17 @@ void spgemm_accumulate_row(
 
 
 template <typename ValueType, typename IndexType>
-void spgemm_accumulate_row2(
-    map<IndexType, ValueType>& cols,
-    matrix::view::csr<const ValueType, const IndexType> a,
-    matrix::view::csr<const ValueType, const IndexType> b, ValueType scale,
-    size_type row)
+void spgemm_accumulate_row2(map<IndexType, ValueType>& cols,
+                            const matrix::Csr<ValueType, IndexType>* a,
+                            const matrix::Csr<ValueType, IndexType>* b,
+                            ValueType scale, size_type row)
 {
-    auto a_row_ptrs = a.row_ptrs;
-    auto a_col_idxs = a.col_idxs;
-    auto a_vals = a.values;
-    auto b_row_ptrs = b.row_ptrs;
-    auto b_col_idxs = b.col_idxs;
-    auto b_vals = b.values;
+    auto a_row_ptrs = a->get_const_row_ptrs();
+    auto a_col_idxs = a->get_const_col_idxs();
+    auto a_vals = a->get_const_values();
+    auto b_row_ptrs = b->get_const_row_ptrs();
+    auto b_col_idxs = b->get_const_col_idxs();
+    auto b_vals = b->get_const_values();
     for (size_type a_nz = a_row_ptrs[row];
          a_nz < size_type(a_row_ptrs[row + 1]); ++a_nz) {
         auto a_col = a_col_idxs[a_nz];
@@ -212,8 +210,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
-                           b->get_const_device_view(), a_row);
+        spgemm_insert_row2(local_col_idxs, a, b, a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -233,9 +230,7 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
-                               b->get_const_device_view(), one<ValueType>(),
-                               a_row);
+        spgemm_accumulate_row2(local_row_nzs, a, b, one<ValueType>(), a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -268,9 +263,8 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     unordered_set<IndexType> local_col_idxs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_col_idxs.clear();
-        spgemm_insert_row(local_col_idxs, d->get_const_device_view(), a_row);
-        spgemm_insert_row2(local_col_idxs, a->get_const_device_view(),
-                           b->get_const_device_view(), a_row);
+        spgemm_insert_row(local_col_idxs, d, a_row);
+        spgemm_insert_row2(local_col_idxs, a, b, a_row);
         c_row_ptrs[a_row] = static_cast<IndexType>(local_col_idxs.size());
     }
 
@@ -290,10 +284,8 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
     map<IndexType, ValueType> local_row_nzs(exec);
     for (size_type a_row = 0; a_row < num_rows; ++a_row) {
         local_row_nzs.clear();
-        spgemm_accumulate_row(local_row_nzs, d->get_const_device_view(), vbeta,
-                              a_row);
-        spgemm_accumulate_row2(local_row_nzs, a->get_const_device_view(),
-                               b->get_const_device_view(), valpha, a_row);
+        spgemm_accumulate_row(local_row_nzs, d, vbeta, a_row);
+        spgemm_accumulate_row2(local_row_nzs, a, b, valpha, a_row);
         // store result
         auto c_nz = c_row_ptrs[a_row];
         for (auto pair : local_row_nzs) {
@@ -446,8 +438,7 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_row_ptrs = c->get_row_ptrs();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [](IndexType) { return IndexType{}; },
+        a, b, [](IndexType) { return IndexType{}; },
         [](IndexType, IndexType, ValueType, ValueType, IndexType& nnz) {
             ++nnz;
         },
@@ -467,8 +458,7 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
     auto c_vals = c_vals_array.get_data();
 
     abstract_spgeam(
-        a->get_const_device_view(), b->get_const_device_view(),
-        [&](IndexType row) { return c_row_ptrs[row]; },
+        a, b, [&](IndexType row) { return c_row_ptrs[row]; },
         [&](IndexType, IndexType col, ValueType a_val, ValueType b_val,
             IndexType& nz) {
             c_vals[nz] = valpha * a_val + vbeta * b_val;
@@ -484,9 +474,9 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_CSR_SPGEAM_KERNEL);
 template <typename ValueType, typename IndexType>
 void spgeam_numeric(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::dense<const ValueType> alpha,
-                    matrix::view::csr<const ValueType, const IndexType> a,
+                    const matrix::Csr<ValueType, IndexType>* a,
                     matrix::view::dense<const ValueType> beta,
-                    matrix::view::csr<const ValueType, const IndexType> b,
+                    const matrix::Csr<ValueType, IndexType>* b,
                     matrix::view::csr<ValueType, IndexType> c)
 {
     auto valpha = alpha(0, 0);

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -486,15 +486,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto num_nonzeros = result->get_num_stored_elements();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto num_nonzeros = result.num_stored_elements;
 
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
     size_type cur_ptr = 0;
     row_ptrs[0] = cur_ptr;

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -489,15 +489,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::dense<const ValueType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto num_rows = result->get_size()[0];
-    auto num_cols = result->get_size()[1];
-    auto num_nonzeros = result->get_num_stored_elements();
+    auto num_rows = result.size[0];
+    auto num_cols = result.size[1];
+    auto num_nonzeros = result.num_stored_elements;
 
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
     size_type cur_ptr = 0;
     row_ptrs[0] = cur_ptr;

--- a/reference/matrix/diagonal_kernels.cpp
+++ b/reference/matrix/diagonal_kernels.cpp
@@ -59,15 +59,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_TYPE(
 template <typename ValueType, typename IndexType>
 void apply_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                   const matrix::Diagonal<ValueType>* a,
-                  const matrix::Csr<ValueType, IndexType>* b,
-                  matrix::Csr<ValueType, IndexType>* c, bool inverse)
+                  matrix::view::csr<const ValueType, const IndexType> b,
+                  matrix::view::csr<ValueType, IndexType> c, bool inverse)
 {
     const auto diag_values = a->get_const_values();
-    c->copy_from(b);
-    auto csr_values = c->get_values();
-    const auto csr_row_ptrs = c->get_const_row_ptrs();
+    auto csr_values = c.values;
+    const auto csr_row_ptrs = c.row_ptrs;
 
-    for (size_type row = 0; row < c->get_size()[0]; row++) {
+    for (size_type row = 0; row < c.size[0]; row++) {
         const auto scal =
             inverse ? one<ValueType>() / diag_values[row] : diag_values[row];
         for (size_type idx = csr_row_ptrs[row]; idx < csr_row_ptrs[row + 1];
@@ -84,16 +83,15 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void right_apply_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                         const matrix::Diagonal<ValueType>* a,
-                        const matrix::Csr<ValueType, IndexType>* b,
-                        matrix::Csr<ValueType, IndexType>* c)
+                        matrix::view::csr<const ValueType, const IndexType> b,
+                        matrix::view::csr<ValueType, IndexType> c)
 {
     const auto diag_values = a->get_const_values();
-    c->copy_from(b);
-    auto csr_values = c->get_values();
-    const auto csr_row_ptrs = c->get_const_row_ptrs();
-    const auto csr_col_idxs = c->get_const_col_idxs();
+    auto csr_values = c.values;
+    const auto csr_row_ptrs = c.row_ptrs;
+    const auto csr_col_idxs = c.col_idxs;
 
-    for (size_type row = 0; row < c->get_size()[0]; row++) {
+    for (size_type row = 0; row < c.size[0]; row++) {
         for (size_type idx = csr_row_ptrs[row]; idx < csr_row_ptrs[row + 1];
              idx++) {
             csr_values[idx] *= diag_values[csr_col_idxs[idx]];

--- a/reference/matrix/diagonal_kernels.cpp
+++ b/reference/matrix/diagonal_kernels.cpp
@@ -125,12 +125,12 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                     const matrix::Diagonal<ValueType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     const auto size = source->get_size()[0];
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto csr_values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto csr_values = result.values;
     const auto diag_values = source->get_const_values();
 
     for (size_type i = 0; i < size; i++) {

--- a/reference/matrix/ell_kernels.cpp
+++ b/reference/matrix/ell_kernels.cpp
@@ -203,14 +203,14 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(GKO_DECLARE_ELL_COPY_KERNEL);
 template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                     matrix::view::ell<const ValueType, const IndexType> source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     const auto num_rows = source.size[0];
     const auto max_nnz_per_row = source.num_stored_elements_per_row;
 
-    auto row_ptrs = result->get_row_ptrs();
-    auto col_idxs = result->get_col_idxs();
-    auto values = result->get_values();
+    auto row_ptrs = result.row_ptrs;
+    auto col_idxs = result.col_idxs;
+    auto values = result.values;
 
     size_type cur_ptr = 0;
     row_ptrs[0] = 0;

--- a/reference/matrix/fbcsr_kernels.cpp
+++ b/reference/matrix/fbcsr_kernels.cpp
@@ -224,7 +224,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void convert_to_csr(const std::shared_ptr<const ReferenceExecutor>,
                     const matrix::Fbcsr<ValueType, IndexType>* source,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
     const int bs = source->get_block_size();
     const IndexType nbrows = source->get_num_block_rows();
@@ -233,14 +233,13 @@ void convert_to_csr(const std::shared_ptr<const ReferenceExecutor>,
     const IndexType* const bcolinds = source->get_const_col_idxs();
     const ValueType* const bvals = source->get_const_values();
 
-    assert(nbrows * bs == result->get_size()[0]);
-    assert(nbcols * bs == result->get_size()[1]);
-    assert(source->get_num_stored_elements() ==
-           result->get_num_stored_elements());
+    assert(nbrows * bs == result.size[0]);
+    assert(nbcols * bs == result.size[1]);
+    assert(source->get_num_stored_elements() == result.num_stored_elements);
 
-    IndexType* const row_ptrs = result->get_row_ptrs();
-    IndexType* const col_idxs = result->get_col_idxs();
-    ValueType* const vals = result->get_values();
+    IndexType* const row_ptrs = result.row_ptrs;
+    IndexType* const col_idxs = result.col_idxs;
+    ValueType* const vals = result.values;
 
     const acc::range<acc::block_col_major<const ValueType, 3>> bvalues{
         std::array<acc::size_type, 3>{

--- a/reference/matrix/hybrid_kernels.cpp
+++ b/reference/matrix/hybrid_kernels.cpp
@@ -93,11 +93,11 @@ void convert_to_csr(
     std::shared_ptr<const ReferenceExecutor> exec,
     matrix::view::hybrid<const ValueType, const IndexType> source,
     const IndexType*, const IndexType*,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto csr_val = result->get_values();
-    auto csr_col_idxs = result->get_col_idxs();
-    auto csr_row_ptrs = result->get_row_ptrs();
+    auto csr_val = result.values;
+    auto csr_col_idxs = result.col_idxs;
+    auto csr_row_ptrs = result.row_ptrs;
     const auto ell = source.ell_part;
     const auto max_nnz_per_row = ell.num_stored_elements_per_row;
     const auto coo_val = source.coo_part.values;

--- a/reference/matrix/hybrid_kernels.cpp
+++ b/reference/matrix/hybrid_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -94,11 +94,11 @@ template <typename ValueType, typename IndexType>
 void convert_to_csr(std::shared_ptr<const ReferenceExecutor> exec,
                     const matrix::Hybrid<ValueType, IndexType>* source,
                     const IndexType*, const IndexType*,
-                    matrix::Csr<ValueType, IndexType>* result)
+                    matrix::view::csr<ValueType, IndexType> result)
 {
-    auto csr_val = result->get_values();
-    auto csr_col_idxs = result->get_col_idxs();
-    auto csr_row_ptrs = result->get_row_ptrs();
+    auto csr_val = result.values;
+    auto csr_col_idxs = result.col_idxs;
+    auto csr_row_ptrs = result.row_ptrs;
     const auto ell = source->get_ell();
     const auto max_nnz_per_row = ell->get_num_stored_elements_per_row();
     const auto coo_val = source->get_const_coo_values();

--- a/reference/matrix/sellp_kernels.cpp
+++ b/reference/matrix/sellp_kernels.cpp
@@ -247,7 +247,7 @@ template <typename ValueType, typename IndexType>
 void convert_to_csr(
     std::shared_ptr<const ReferenceExecutor> exec,
     matrix::view::sellp<const ValueType, const IndexType> source,
-    matrix::Csr<ValueType, IndexType>* result)
+    matrix::view::csr<ValueType, IndexType> result)
 {
     auto num_rows = source.size[0];
     auto slice_size = source.slice_size;
@@ -258,9 +258,9 @@ void convert_to_csr(
     const auto source_slice_sets = source.slice_sets;
     const auto source_col_idxs = source.col_idxs;
 
-    auto result_vals = result->get_values();
-    auto result_row_ptrs = result->get_row_ptrs();
-    auto result_col_idxs = result->get_col_idxs();
+    auto result_vals = result.values;
+    auto result_row_ptrs = result.row_ptrs;
+    auto result_col_idxs = result.col_idxs;
 
     size_type cur_ptr = 0;
 

--- a/reference/multigrid/pgm_kernels.cpp
+++ b/reference/multigrid/pgm_kernels.cpp
@@ -160,13 +160,13 @@ GKO_INSTANTIATE_FOR_EACH_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void find_strongest_neighbor(
     std::shared_ptr<const ReferenceExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* weight_mtx,
+    matrix::view::csr<const ValueType, const IndexType> weight_mtx,
     const matrix::Diagonal<ValueType>* diag, array<IndexType>& agg,
     array<IndexType>& strongest_neighbor)
 {
-    const auto row_ptrs = weight_mtx->get_const_row_ptrs();
-    const auto col_idxs = weight_mtx->get_const_col_idxs();
-    const auto vals = weight_mtx->get_const_values();
+    const auto row_ptrs = weight_mtx.row_ptrs;
+    const auto col_idxs = weight_mtx.col_idxs;
+    const auto vals = weight_mtx.values;
     const auto diag_vals = diag->get_const_values();
     for (size_type row = 0; row < agg.get_size(); row++) {
         auto max_weight_unagg = zero<ValueType>();
@@ -213,15 +213,15 @@ GKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void assign_to_exist_agg(std::shared_ptr<const ReferenceExecutor> exec,
-                         const matrix::Csr<ValueType, IndexType>* weight_mtx,
-                         const matrix::Diagonal<ValueType>* diag,
-                         array<IndexType>& agg,
-                         array<IndexType>& intermediate_agg)
+void assign_to_exist_agg(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> weight_mtx,
+    const matrix::Diagonal<ValueType>* diag, array<IndexType>& agg,
+    array<IndexType>& intermediate_agg)
 {
-    const auto row_ptrs = weight_mtx->get_const_row_ptrs();
-    const auto col_idxs = weight_mtx->get_const_col_idxs();
-    const auto vals = weight_mtx->get_const_values();
+    const auto row_ptrs = weight_mtx.row_ptrs;
+    const auto col_idxs = weight_mtx.col_idxs;
+    const auto vals = weight_mtx.values;
     const auto agg_const_val = agg.get_const_data();
     auto agg_val = (intermediate_agg.get_size() > 0)
                        ? intermediate_agg.get_data()

--- a/reference/multigrid/rs_kernels.cpp
+++ b/reference/multigrid/rs_kernels.cpp
@@ -26,13 +26,13 @@ namespace rs {
 
 template <typename ValueType, typename IndexType>
 void check_m_matrix(std::shared_ptr<const ReferenceExecutor> exec,
-                    const matrix::Csr<ValueType, IndexType>* matrix,
+                    matrix::view::csr<const ValueType, const IndexType> matrix,
                     array<bool>& is_m_matrix_array)
 {
-    const auto num_rows = matrix->get_size()[0];
-    const auto row_ptrs = matrix->get_const_row_ptrs();
-    const auto col_idxs = matrix->get_const_col_idxs();
-    const auto values = matrix->get_const_values();
+    const auto num_rows = matrix.size[0];
+    const auto row_ptrs = matrix.row_ptrs;
+    const auto col_idxs = matrix.col_idxs;
+    const auto values = matrix.values;
 
     auto is_m_matrix = is_m_matrix_array.get_data();
 
@@ -69,17 +69,17 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_soc_and_run_rs(std::shared_ptr<const ReferenceExecutor> exec,
-                            const matrix::Csr<ValueType, IndexType>* A,
-                            double theta, array<bool>& is_strong,
-                            array<IndexType>& lambda,
-                            array<IndexType>& cf_marker, IndexType& coarse_size)
+void compute_soc_and_run_rs(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> A, double theta,
+    array<bool>& is_strong, array<IndexType>& lambda,
+    array<IndexType>& cf_marker, IndexType& coarse_size)
 {
     using real_type = remove_complex<ValueType>;
-    const auto n = A->get_size()[0];
-    const auto* a_row_ptrs = A->get_const_row_ptrs();
-    const auto* a_col_idxs = A->get_const_col_idxs();
-    const auto* a_vals = A->get_const_values();
+    const auto n = A.size[0];
+    const auto* a_row_ptrs = A.row_ptrs;
+    const auto* a_col_idxs = A.col_idxs;
+    const auto* a_vals = A.values;
     bool* is_strong_vals = is_strong.get_data();
     auto* lambda_vals = lambda.get_data();
     auto* cf = cf_marker.get_data();
@@ -91,14 +91,14 @@ void compute_soc_and_run_rs(std::shared_ptr<const ReferenceExecutor> exec,
 
         // pass 1: find max off-diagonal
         for (IndexType jj = a_row_ptrs[i]; jj < a_row_ptrs[i + 1]; ++jj) {
-            if (A->get_const_col_idxs()[jj] != i) {
+            if (A.col_idxs[jj] != i) {
                 max_offdiag = std::max(max_offdiag, -real(a_vals[jj]));
             }
         }
 
         // pass 2: set mask
         for (IndexType jj = a_row_ptrs[i]; jj < a_row_ptrs[i + 1]; ++jj) {
-            const auto j = A->get_const_col_idxs()[jj];
+            const auto j = A.col_idxs[jj];
             is_strong_vals[jj] =
                 (j != i && -real(a_vals[jj]) >= theta * max_offdiag);
         }
@@ -178,17 +178,17 @@ void fill_coarse_and_compute_prolong_row_ptrs(
     std::shared_ptr<const ReferenceExecutor> exec,
     const array<IndexType>& cf_marker, array<IndexType>& coarse_rows,
     array<IndexType>& fine_to_coarse,
-    const matrix::Csr<ValueType, IndexType>* A, const array<bool>& is_strong,
-    array<IndexType>& row_ptrs)
+    matrix::view::csr<const ValueType, const IndexType> A,
+    const array<bool>& is_strong, array<IndexType>& row_ptrs)
 {
     const auto* cf = cf_marker.get_const_data();
     auto* coarse_rows_vals = coarse_rows.get_data();
     auto* fine_to_coarse_vals = fine_to_coarse.get_data();
     auto* row_ptrs_vals = row_ptrs.get_data();
     const bool* is_strong_vals = is_strong.get_const_data();
-    const auto n = A->get_size()[0];
-    const auto* a_row_ptrs = A->get_const_row_ptrs();
-    const auto* a_col_idxs = A->get_const_col_idxs();
+    const auto n = A.size[0];
+    const auto* a_row_ptrs = A.row_ptrs;
+    const auto* a_col_idxs = A.col_idxs;
 
     /// 1. FILL COARSE ROW INDEX ARRAY
     IndexType idx = 0;
@@ -231,21 +231,20 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void compute_interpolation(std::shared_ptr<const ReferenceExecutor> exec,
-                           const matrix::Csr<ValueType, IndexType>* A,
-                           const bool* is_strong,
-                           const array<IndexType>& cf_marker,
-                           const IndexType* fine_to_coarse,
-                           matrix::Csr<ValueType, IndexType>* P)
+void compute_interpolation(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> A,
+    const bool* is_strong, const array<IndexType>& cf_marker,
+    const IndexType* fine_to_coarse, matrix::view::csr<ValueType, IndexType> P)
 {
-    const auto n = A->get_size()[0];
-    const auto* a_row_ptrs = A->get_const_row_ptrs();
-    const auto* a_col_idxs = A->get_const_col_idxs();
-    const auto* a_vals = A->get_const_values();
+    const auto n = A.size[0];
+    const auto* a_row_ptrs = A.row_ptrs;
+    const auto* a_col_idxs = A.col_idxs;
+    const auto* a_vals = A.values;
     const auto* cf = cf_marker.get_const_data();
-    auto* p_row_ptrs = P->get_const_row_ptrs();
-    auto* p_col_idxs = P->get_col_idxs();
-    auto* p_vals = P->get_values();
+    auto* p_row_ptrs = P.row_ptrs;
+    auto* p_col_idxs = P.col_idxs;
+    auto* p_vals = P.values;
 
     for (IndexType i = 0; i < n; ++i) {
         auto p_idx = p_row_ptrs[i];

--- a/reference/preconditioner/batch_jacobi_kernels.cpp
+++ b/reference/preconditioner/batch_jacobi_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -58,7 +58,7 @@ GKO_INSTANTIATE_FOR_INT32_TYPE(
 template <typename ValueType, typename IndexType>
 void extract_common_blocks_pattern(
     std::shared_ptr<const DefaultExecutor> exec,
-    const gko::matrix::Csr<ValueType, IndexType>* first_sys_csr,
+    matrix::view::csr<const ValueType, const IndexType> first_sys_csr,
     const size_type num_blocks, const IndexType* cumulative_block_storage,
     const IndexType* block_pointers, const IndexType*,
     IndexType* blocks_pattern)

--- a/reference/preconditioner/batch_jacobi_kernels.hpp
+++ b/reference/preconditioner/batch_jacobi_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2024 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -25,12 +25,13 @@ namespace batch_single_kernels {
 
 template <typename ValueType>
 inline void extract_block_pattern_impl(
-    const size_type k, const matrix::Csr<ValueType, int>* const first_sys_csr,
+    const size_type k,
+    matrix::view::csr<const ValueType, const int> const first_sys_csr,
     const int* const cumulative_block_storage, const int* const block_pointers,
     int* const blocks_pattern)
 {
-    const int* row_ptrs = first_sys_csr->get_const_row_ptrs();
-    const int* col_idxs = first_sys_csr->get_const_col_idxs();
+    const int* row_ptrs = first_sys_csr.row_ptrs;
+    const int* col_idxs = first_sys_csr.col_idxs;
 
     const int row_idx_st = block_pointers[k];
     const int row_idx_end = block_pointers[k + 1];  // exclusive

--- a/reference/preconditioner/isai_kernels.cpp
+++ b/reference/preconditioner/isai_kernels.cpp
@@ -47,8 +47,8 @@ void forall_matching(const IndexType* fst, IndexType fst_size,
 
 template <typename ValueType, typename IndexType, typename Callable>
 void generic_generate(std::shared_ptr<const DefaultExecutor> exec,
-                      const matrix::Csr<ValueType, IndexType>* mtx,
-                      matrix::Csr<ValueType, IndexType>* inverse_mtx,
+                      matrix::view::csr<const ValueType, const IndexType> mtx,
+                      matrix::view::csr<ValueType, IndexType> inverse_mtx,
                       IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs,
                       Callable direct_solve, bool tri)
 {
@@ -66,13 +66,13 @@ void generic_generate(std::shared_ptr<const DefaultExecutor> exec,
     <=> D(i)^T * aiM[i, :]^T = e(i)   =^ Triangular system (Trs)
     Solve Trs, fill in aiM row by row (coalesced access)
     */
-    const auto num_rows = mtx->get_size()[0];
-    const auto m_row_ptrs = mtx->get_const_row_ptrs();
-    const auto m_cols = mtx->get_const_col_idxs();
-    const auto m_vals = mtx->get_const_values();
-    const auto i_row_ptrs = inverse_mtx->get_const_row_ptrs();
-    const auto i_cols = inverse_mtx->get_const_col_idxs();
-    auto i_vals = inverse_mtx->get_values();
+    const auto num_rows = mtx.size[0];
+    const auto m_row_ptrs = mtx.row_ptrs;
+    const auto m_cols = mtx.col_idxs;
+    const auto m_vals = mtx.values;
+    const auto i_row_ptrs = inverse_mtx.row_ptrs;
+    const auto i_cols = inverse_mtx.col_idxs;
+    auto i_vals = inverse_mtx.values;
     // RHS for local dense system
     gko::array<ValueType> rhs_array{exec, row_size_limit};
     auto rhs = rhs_array.get_data();
@@ -173,11 +173,11 @@ void generic_generate(std::shared_ptr<const DefaultExecutor> exec,
 
 
 template <typename ValueType, typename IndexType>
-void generate_tri_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                          const matrix::Csr<ValueType, IndexType>* mtx,
-                          matrix::Csr<ValueType, IndexType>* inverse_mtx,
-                          IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs,
-                          bool lower)
+void generate_tri_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    matrix::view::csr<ValueType, IndexType> inverse_mtx,
+    IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs, bool lower)
 {
     auto trs_solve =
         [lower](const range<accessor::row_major<ValueType, 2>> trisystem,
@@ -249,11 +249,11 @@ inline void swap_rows(IndexType row1, IndexType row2, IndexType block_size,
 
 
 template <typename ValueType, typename IndexType>
-void generate_general_inverse(std::shared_ptr<const DefaultExecutor> exec,
-                              const matrix::Csr<ValueType, IndexType>* mtx,
-                              matrix::Csr<ValueType, IndexType>* inverse_mtx,
-                              IndexType* excess_rhs_ptrs,
-                              IndexType* excess_nz_ptrs, bool spd)
+void generate_general_inverse(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    matrix::view::csr<ValueType, IndexType> inverse_mtx,
+    IndexType* excess_rhs_ptrs, IndexType* excess_nz_ptrs, bool spd)
 {
     using std::swap;
     auto general_solve = [spd](const range<accessor::row_major<ValueType, 2>>
@@ -319,25 +319,25 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 
 template <typename ValueType, typename IndexType>
-void generate_excess_system(std::shared_ptr<const DefaultExecutor>,
-                            const matrix::Csr<ValueType, IndexType>* input,
-                            const matrix::Csr<ValueType, IndexType>* inverse,
-                            const IndexType* excess_rhs_ptrs,
-                            const IndexType* excess_nz_ptrs,
-                            matrix::Csr<ValueType, IndexType>* excess_system,
-                            matrix::view::dense<ValueType> excess_rhs,
-                            size_type e_start, size_type e_end)
+void generate_excess_system(
+    std::shared_ptr<const DefaultExecutor>,
+    matrix::view::csr<const ValueType, const IndexType> input,
+    matrix::view::csr<const ValueType, const IndexType> inverse,
+    const IndexType* excess_rhs_ptrs, const IndexType* excess_nz_ptrs,
+    matrix::view::csr<ValueType, IndexType> excess_system,
+    matrix::view::dense<ValueType> excess_rhs, size_type e_start,
+    size_type e_end)
 {
-    const auto num_rows = input->get_size()[0];
-    const auto m_row_ptrs = input->get_const_row_ptrs();
-    const auto m_cols = input->get_const_col_idxs();
-    const auto m_vals = input->get_const_values();
-    const auto i_row_ptrs = inverse->get_const_row_ptrs();
-    const auto i_cols = inverse->get_const_col_idxs();
+    const auto num_rows = input.size[0];
+    const auto m_row_ptrs = input.row_ptrs;
+    const auto m_cols = input.col_idxs;
+    const auto m_vals = input.values;
+    const auto i_row_ptrs = inverse.row_ptrs;
+    const auto i_cols = inverse.col_idxs;
     const auto e_dim = excess_rhs.size[0];
-    auto e_row_ptrs = excess_system->get_row_ptrs();
-    auto e_cols = excess_system->get_col_idxs();
-    auto e_vals = excess_system->get_values();
+    auto e_row_ptrs = excess_system.row_ptrs;
+    auto e_cols = excess_system.col_idxs;
+    auto e_vals = excess_system.values;
     auto e_rhs = excess_rhs.values;
 
     for (size_type row = e_start; row < e_end; ++row) {
@@ -413,12 +413,12 @@ template <typename ValueType, typename IndexType>
 void scatter_excess_solution(
     std::shared_ptr<const DefaultExecutor>, const IndexType* excess_block_ptrs,
     matrix::view::dense<const ValueType> excess_solution,
-    matrix::Csr<ValueType, IndexType>* inverse, size_type e_start,
+    matrix::view::csr<ValueType, IndexType> inverse, size_type e_start,
     size_type e_end)
 {
     auto excess_values = excess_solution.values;
-    auto values = inverse->get_values();
-    auto row_ptrs = inverse->get_const_row_ptrs();
+    auto values = inverse.values;
+    auto row_ptrs = inverse.row_ptrs;
     auto offset = excess_block_ptrs[e_start];
     for (size_type row = e_start; row < e_end; ++row) {
         const auto excess_begin =

--- a/reference/preconditioner/jacobi_kernels.cpp
+++ b/reference/preconditioner/jacobi_kernels.cpp
@@ -44,12 +44,13 @@ inline bool has_same_nonzero_pattern(const IndexType* prev_row_ptr,
 
 
 template <typename ValueType, typename IndexType>
-size_type find_natural_blocks(const matrix::Csr<ValueType, IndexType>* mtx,
-                              uint32 max_block_size, IndexType* block_ptrs)
+size_type find_natural_blocks(
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    uint32 max_block_size, IndexType* block_ptrs)
 {
-    const auto rows = mtx->get_size()[0];
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idx = mtx->get_const_col_idxs();
+    const auto rows = mtx.size[0];
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idx = mtx.col_idxs;
     block_ptrs[0] = 0;
     if (rows == 0) {
         return 0;
@@ -105,10 +106,11 @@ inline size_type agglomerate_supervariables(uint32 max_block_size,
 
 
 template <typename ValueType, typename IndexType>
-void find_blocks(std::shared_ptr<const DefaultExecutor> exec,
-                 const matrix::Csr<ValueType, IndexType>* system_matrix,
-                 uint32 max_block_size, size_type& num_blocks,
-                 array<IndexType>& block_pointers)
+void find_blocks(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    uint32 max_block_size, size_type& num_blocks,
+    array<IndexType>& block_pointers)
 {
     num_blocks = find_natural_blocks(system_matrix, max_block_size,
                                      block_pointers.get_data());
@@ -124,18 +126,19 @@ namespace {
 
 
 template <typename ValueType, typename IndexType>
-inline void extract_block(const matrix::Csr<ValueType, IndexType>* mtx,
-                          IndexType block_size, IndexType block_start,
-                          ValueType* block, size_type stride)
+inline void extract_block(
+    matrix::view::csr<const ValueType, const IndexType> mtx,
+    IndexType block_size, IndexType block_start, ValueType* block,
+    size_type stride)
 {
     for (int i = 0; i < block_size; ++i) {
         for (int j = 0; j < block_size; ++j) {
             block[i * stride + j] = zero<ValueType>();
         }
     }
-    const auto row_ptrs = mtx->get_const_row_ptrs();
-    const auto col_idxs = mtx->get_const_col_idxs();
-    const auto vals = mtx->get_const_values();
+    const auto row_ptrs = mtx.row_ptrs;
+    const auto col_idxs = mtx.col_idxs;
+    const auto vals = mtx.values;
     for (int row = 0; row < block_size; ++row) {
         const auto start = row_ptrs[block_start + row];
         const auto end = row_ptrs[block_start + row + 1];
@@ -312,7 +315,7 @@ inline bool validate_precision_reduction_feasibility(
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const DefaultExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* system_matrix,
+              matrix::view::csr<const ValueType, const IndexType> system_matrix,
               size_type num_blocks, uint32 max_block_size,
               remove_complex<ValueType> accuracy,
               const preconditioner::block_interleaved_storage_scheme<IndexType>&
@@ -725,17 +728,16 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 
 template <typename ValueType, typename IndexType>
 void scalar_l1(std::shared_ptr<const DefaultExecutor> exec,
-               const matrix::Csr<ValueType, IndexType>* csr,
+               matrix::view::csr<const ValueType, const IndexType> csr,
                matrix::Diagonal<ValueType>* diag)
 {
-    for (IndexType row = 0; row < csr->get_size()[0]; row++) {
+    for (IndexType row = 0; row < csr.size[0]; row++) {
         auto off_diag = zero<ValueType>();
-        for (auto i = csr->get_const_row_ptrs()[row];
-             i < csr->get_const_row_ptrs()[row + 1]; i++) {
-            if (csr->get_const_col_idxs()[i] == row) {
+        for (auto i = csr.row_ptrs[row]; i < csr.row_ptrs[row + 1]; i++) {
+            if (csr.col_idxs[i] == row) {
                 continue;
             }
-            off_diag += abs(csr->get_const_values()[i]);
+            off_diag += abs(csr.values[i]);
         }
         // TODO: It is unclear effect when this applies to negative diagonal
         // value. The reference paper only discusses the positive diagonal
@@ -751,7 +753,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void block_l1(std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,
               const array<IndexType>& block_ptrs,
-              matrix::Csr<ValueType, IndexType>* csr)
+              matrix::view::csr<ValueType, IndexType> csr)
 {
     for (IndexType block_id = 0; block_id < num_blocks; block_id++) {
         auto start = block_ptrs.get_const_data()[block_id];
@@ -759,21 +761,20 @@ void block_l1(std::shared_ptr<const DefaultExecutor> exec, size_type num_blocks,
         for (auto row = start; row < end; row++) {
             auto off_diag = zero<ValueType>();
             IndexType diag_idx = -1;
-            for (auto i = csr->get_const_row_ptrs()[row];
-                 i < csr->get_const_row_ptrs()[row + 1]; i++) {
-                auto col = csr->get_const_col_idxs()[i];
+            for (auto i = csr.row_ptrs[row]; i < csr.row_ptrs[row + 1]; i++) {
+                auto col = csr.col_idxs[i];
                 if (col >= start && col < end) {
                     if (col == row) {
                         diag_idx = i;
                     }
                     continue;
                 }
-                off_diag += abs(csr->get_const_values()[i]);
+                off_diag += abs(csr.values[i]);
             }
             // TODO: It is unclear effect when this applies to negative diagonal
             // value. The reference paper only discusses the positive diagonal
             // value.
-            csr->get_values()[diag_idx] += off_diag;
+            csr.values[diag_idx] += off_diag;
         }
     }
 }

--- a/reference/preconditioner/sor_kernels.cpp
+++ b/reference/preconditioner/sor_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,8 +21,9 @@ namespace sor {
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx)
 {
     auto inv_weight = one(weight) / weight;
     factorization::helpers::initialize_l(
@@ -39,9 +40,10 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename ValueType, typename IndexType>
 void initialize_weighted_l_u(
     std::shared_ptr<const DefaultExecutor> exec,
-    const matrix::Csr<ValueType, IndexType>* system_matrix,
-    remove_complex<ValueType> weight, matrix::Csr<ValueType, IndexType>* l_mtx,
-    matrix::Csr<ValueType, IndexType>* u_mtx)
+    matrix::view::csr<const ValueType, const IndexType> system_matrix,
+    remove_complex<ValueType> weight,
+    matrix::view::csr<ValueType, IndexType> l_mtx,
+    matrix::view::csr<ValueType, IndexType> u_mtx)
 {
     auto inv_weight = one(weight) / weight;
     auto inv_two_minus_weight =

--- a/reference/solver/lower_trs_kernels.cpp
+++ b/reference/solver/lower_trs_kernels.cpp
@@ -35,7 +35,7 @@ void should_perform_transpose(std::shared_ptr<const ReferenceExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const ReferenceExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -56,7 +56,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const ReferenceExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,
@@ -64,12 +64,12 @@ void solve(std::shared_ptr<const ReferenceExecutor> exec,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> x)
 {
-    auto row_ptrs = matrix->get_const_row_ptrs();
-    auto col_idxs = matrix->get_const_col_idxs();
-    auto vals = matrix->get_const_values();
+    auto row_ptrs = matrix.row_ptrs;
+    auto col_idxs = matrix.col_idxs;
+    auto vals = matrix.values;
 
     for (size_type j = 0; j < b.size[1]; ++j) {
-        for (size_type row = 0; row < matrix->get_size()[0]; ++row) {
+        for (size_type row = 0; row < matrix.size[0]; ++row) {
             auto diag = one<ValueType>();
             bool found_diag = false;
             x(row, j) = b(row, j);

--- a/reference/solver/upper_trs_kernels.cpp
+++ b/reference/solver/upper_trs_kernels.cpp
@@ -35,7 +35,7 @@ void should_perform_transpose(std::shared_ptr<const ReferenceExecutor> exec,
 
 template <typename ValueType, typename IndexType>
 void generate(std::shared_ptr<const ReferenceExecutor> exec,
-              const matrix::Csr<ValueType, IndexType>* matrix,
+              matrix::view::csr<const ValueType, const IndexType> matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
               const size_type num_rhs)
@@ -56,7 +56,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
  */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const ReferenceExecutor> exec,
-           const matrix::Csr<ValueType, IndexType>* matrix,
+           matrix::view::csr<const ValueType, const IndexType> matrix,
            const solver::SolveStruct* solve_struct, bool unit_diag,
            const solver::trisolve_algorithm algorithm,
            std::optional<matrix::view::dense<ValueType>> trans_b,
@@ -64,14 +64,13 @@ void solve(std::shared_ptr<const ReferenceExecutor> exec,
            matrix::view::dense<const ValueType> b,
            matrix::view::dense<ValueType> x)
 {
-    auto row_ptrs = matrix->get_const_row_ptrs();
-    auto col_idxs = matrix->get_const_col_idxs();
-    auto vals = matrix->get_const_values();
+    auto row_ptrs = matrix.row_ptrs;
+    auto col_idxs = matrix.col_idxs;
+    auto vals = matrix.values;
 
     for (size_type j = 0; j < b.size[1]; ++j) {
-        for (size_type inv_row = 0; inv_row < matrix->get_size()[0];
-             ++inv_row) {
-            auto row = matrix->get_size()[0] - 1 - inv_row;
+        for (size_type inv_row = 0; inv_row < matrix.size[0]; ++inv_row) {
+            auto row = matrix.size[0] - 1 - inv_row;
             auto diag = one<ValueType>();
             bool found_diag = false;
             x(row, j) = b(row, j);

--- a/reference/test/factorization/cholesky_kernels.cpp
+++ b/reference/test/factorization/cholesky_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -278,8 +278,8 @@ TYPED_TEST(Cholesky, KernelSymbolicCount)
             gko::array<index_type> row_nnz{this->ref, this->num_rows};
 
             gko::kernels::reference::cholesky::symbolic_count(
-                this->ref, this->mtx.get(), *this->forest, row_nnz.get_data(),
-                this->tmp);
+                this->ref, this->mtx->get_const_device_view(), *this->forest,
+                row_nnz.get_data(), this->tmp);
 
             GKO_ASSERT_ARRAY_EQ(row_nnz, this->ref_row_nnz);
         },
@@ -297,14 +297,14 @@ TYPED_TEST(Cholesky, KernelSymbolicFactorize)
             gko::factorization::compute_elimination_forest(this->mtx.get(),
                                                            this->forest);
             gko::kernels::reference::cholesky::symbolic_count(
-                this->ref, this->mtx.get(), *this->forest,
+                this->ref, this->mtx->get_const_device_view(), *this->forest,
                 this->l_factor->get_row_ptrs(), this->tmp);
             gko::kernels::reference::components::prefix_sum_nonnegative(
                 this->ref, this->l_factor->get_row_ptrs(), this->num_rows + 1);
 
             gko::kernels::reference::cholesky::symbolic_factorize(
-                this->ref, this->mtx.get(), *this->forest, this->l_factor.get(),
-                this->tmp);
+                this->ref, this->mtx->get_const_device_view(), *this->forest,
+                this->l_factor->get_device_view(), this->tmp);
 
             GKO_ASSERT_MTX_EQ_SPARSITY(this->l_factor, this->l_factor_ref);
         },
@@ -361,7 +361,7 @@ TYPED_TEST(Cholesky, KernelForestFromFactorPlusPostprocessing)
                                       static_cast<index_type>(this->num_rows)};
 
             gko::kernels::reference::elimination_forest::from_factor(
-                this->ref, combined_factor.get(), forest);
+                this->ref, combined_factor->get_const_device_view(), forest);
 
             this->assert_equal_forests(forest, *forest_ref);
         },
@@ -383,11 +383,11 @@ TYPED_TEST(Cholesky, KernelInitializeWorks)
                 this->ref, this->combined->get_num_stored_elements()};
 
             gko::kernels::reference::cholesky::initialize(
-                this->ref, this->mtx.get(),
+                this->ref, this->mtx->get_const_device_view(),
                 this->lookup.storage_offsets.get_const_data(),
                 this->lookup.row_descs.get_const_data(),
                 this->lookup.storage.get_const_data(), diag_idxs.get_data(),
-                transpose_idxs.get_data(), this->combined.get());
+                transpose_idxs.get_data(), this->combined->get_device_view());
 
             GKO_ASSERT_MTX_NEAR(this->mtx, this->combined, 0.0);
             for (gko::size_type row = 0; row < this->num_rows; row++) {
@@ -427,18 +427,18 @@ TYPED_TEST(Cholesky, KernelFactorizeWorks)
                 this->ref, this->combined->get_num_stored_elements()};
             gko::array<int> tmp{this->ref};
             gko::kernels::reference::cholesky::initialize(
-                this->ref, this->mtx.get(),
+                this->ref, this->mtx->get_const_device_view(),
                 this->lookup.storage_offsets.get_const_data(),
                 this->lookup.row_descs.get_const_data(),
                 this->lookup.storage.get_const_data(), diag_idxs.get_data(),
-                transpose_idxs.get_data(), this->combined.get());
+                transpose_idxs.get_data(), this->combined->get_device_view());
 
             gko::kernels::reference::cholesky::factorize(
                 this->ref, this->lookup.storage_offsets.get_const_data(),
                 this->lookup.row_descs.get_const_data(),
                 this->lookup.storage.get_const_data(), diag_idxs.get_data(),
-                transpose_idxs.get_data(), *this->forest, this->combined.get(),
-                true, tmp);
+                transpose_idxs.get_data(), *this->forest,
+                this->combined->get_device_view(), true, tmp);
 
             GKO_ASSERT_MTX_NEAR(this->combined, this->combined_ref,
                                 r<value_type>::value);

--- a/reference/test/factorization/lu_kernels.cpp
+++ b/reference/test/factorization/lu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -184,9 +184,10 @@ TYPED_TEST(Lu, KernelInitializeWorks)
         gko::array<index_type> diag_idxs{this->ref, this->num_rows};
 
         gko::kernels::reference::lu_factorization::initialize(
-            this->ref, this->mtx.get(), this->storage_offsets.get_const_data(),
+            this->ref, this->mtx->get_const_device_view(),
+            this->storage_offsets.get_const_data(),
             this->row_descs.get_const_data(), this->storage.get_const_data(),
-            diag_idxs.get_data(), this->mtx_lu.get());
+            diag_idxs.get_data(), this->mtx_lu->get_device_view());
 
         GKO_ASSERT_MTX_NEAR(this->mtx, this->mtx_lu, 0.0);
         for (gko::size_type row = 0; row < this->num_rows; row++) {
@@ -211,14 +212,16 @@ TYPED_TEST(Lu, KernelFactorizeWorks)
         gko::array<index_type> diag_idxs{this->ref, this->num_rows};
         gko::array<int> tmp{this->ref};
         gko::kernels::reference::lu_factorization::initialize(
-            this->ref, this->mtx.get(), this->storage_offsets.get_const_data(),
+            this->ref, this->mtx->get_const_device_view(),
+            this->storage_offsets.get_const_data(),
             this->row_descs.get_const_data(), this->storage.get_const_data(),
-            diag_idxs.get_data(), this->mtx_lu.get());
+            diag_idxs.get_data(), this->mtx_lu->get_device_view());
 
         gko::kernels::reference::lu_factorization::factorize(
             this->ref, this->storage_offsets.get_const_data(),
             this->row_descs.get_const_data(), this->storage.get_const_data(),
-            diag_idxs.get_const_data(), this->mtx_lu.get(), true, tmp);
+            diag_idxs.get_const_data(), this->mtx_lu->get_device_view(), true,
+            tmp);
 
         GKO_ASSERT_MTX_NEAR(this->mtx_lu, mtx_lu_ref,
                             30 * r<value_type>::value);
@@ -341,7 +344,8 @@ TYPED_TEST(Lu, ValidateValidFactors)
         bool valid = false;
 
         gko::kernels::reference::factorization::symbolic_validate(
-            this->ref, this->mtx.get(), this->mtx_lu.get(),
+            this->ref, this->mtx->get_const_device_view(),
+            this->mtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->mtx_lu.get()), valid);
 
         ASSERT_TRUE(valid);
@@ -364,7 +368,8 @@ TYPED_TEST(Lu, ValidateInvalidFactorsIdentity)
         this->mtx_lu->read(data);
 
         gko::kernels::reference::factorization::symbolic_validate(
-            this->ref, this->mtx.get(), this->mtx_lu.get(),
+            this->ref, this->mtx->get_const_device_view(),
+            this->mtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->mtx_lu.get()), valid);
 
         ASSERT_FALSE(valid);
@@ -386,7 +391,8 @@ TYPED_TEST(Lu, ValidateInvalidFactorsMissing)
         this->mtx_lu->read(data);
 
         gko::kernels::reference::factorization::symbolic_validate(
-            this->ref, this->mtx.get(), this->mtx_lu.get(),
+            this->ref, this->mtx->get_const_device_view(),
+            this->mtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->mtx_lu.get()), valid);
 
         ASSERT_FALSE(valid);
@@ -411,7 +417,8 @@ TYPED_TEST(Lu, ValidateInvalidFactorsExtra)
         this->mtx_lu->read(data);
 
         gko::kernels::reference::factorization::symbolic_validate(
-            this->ref, this->mtx.get(), this->mtx_lu.get(),
+            this->ref, this->mtx->get_const_device_view(),
+            this->mtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->mtx_lu.get()), valid);
 
         ASSERT_FALSE(valid);

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -111,7 +111,7 @@ TYPED_TEST(ParIc, KernelCompute)
 {
     gko::kernels::reference::par_ic_factorization::compute_factor(
         this->ref, 1, this->mtx_l_system_coo->get_const_device_view(),
-        this->mtx_l_system.get());
+        this->mtx_l_system->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);
 }
@@ -120,7 +120,7 @@ TYPED_TEST(ParIc, KernelCompute)
 TYPED_TEST(ParIc, KernelInit)
 {
     gko::kernels::reference::par_ic_factorization::init_factor(
-        this->ref, this->mtx_l_system.get());
+        this->ref, this->mtx_l_system->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_init_expect, this->tol);
 }

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -148,7 +148,8 @@ TYPED_TEST(ParIct, KernelInitializeRowPtrsL)
     auto row_ptrs = res_mtx_l->get_const_row_ptrs();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l(
-        this->ref, this->mtx_system.get(), res_mtx_l->get_row_ptrs());
+        this->ref, this->mtx_system->get_const_device_view(),
+        res_mtx_l->get_row_ptrs());
 
     ASSERT_EQ(row_ptrs[0], 0);
     ASSERT_EQ(row_ptrs[1], 1);
@@ -166,9 +167,11 @@ TYPED_TEST(ParIct, KernelInitializeL)
     auto row_ptrs = res_mtx_l->get_const_row_ptrs();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l(
-        this->ref, this->mtx_init.get(), res_mtx_l->get_row_ptrs());
+        this->ref, this->mtx_init->get_const_device_view(),
+        res_mtx_l->get_row_ptrs());
     gko::kernels::reference::factorization::initialize_l(
-        this->ref, this->mtx_init.get(), res_mtx_l.get(), true);
+        this->ref, this->mtx_init->get_const_device_view(),
+        res_mtx_l->get_device_view(), true);
 
     GKO_ASSERT_MTX_NEAR(res_mtx_l, this->mtx_l_init_expect, this->tol);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_init_expect);
@@ -183,8 +186,9 @@ TYPED_TEST(ParIct, KernelAddCandidates)
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, this->mtx_llh.get(), this->mtx_system.get(),
-        this->mtx_l.get(),
+        this->ref, this->mtx_llh->get_const_device_view(),
+        this->mtx_system->get_const_device_view(),
+        this->mtx_l->get_const_device_view(),
         gko::matrix::make_builder_unique_ptr(res_mtx_l).get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
@@ -201,7 +205,8 @@ TYPED_TEST(ParIct, KernelComputeLU)
     this->mtx_l_system->convert_to(mtx_l_coo);
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
-        this->ref, this->mtx_system.get(), this->mtx_l_system.get(),
+        this->ref, this->mtx_system->get_const_device_view(),
+        this->mtx_l_system->get_device_view(),
         mtx_l_coo->get_const_device_view());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -185,8 +185,7 @@ TYPED_TEST(ParIct, KernelAddCandidates)
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, this->mtx_llh->get_const_device_view(),
-        this->mtx_system->get_const_device_view(),
+        this->ref, this->mtx_llh.get(), this->mtx_system.get(),
         this->mtx_l->get_const_device_view(), res_mtx_l.get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -148,7 +148,8 @@ TYPED_TEST(ParIct, KernelInitializeRowPtrsL)
     auto row_ptrs = res_mtx_l->get_const_row_ptrs();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l(
-        this->ref, this->mtx_system.get(), res_mtx_l->get_row_ptrs());
+        this->ref, this->mtx_system->get_const_device_view(),
+        res_mtx_l->get_row_ptrs());
 
     ASSERT_EQ(row_ptrs[0], 0);
     ASSERT_EQ(row_ptrs[1], 1);
@@ -166,9 +167,11 @@ TYPED_TEST(ParIct, KernelInitializeL)
     auto row_ptrs = res_mtx_l->get_const_row_ptrs();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l(
-        this->ref, this->mtx_init.get(), res_mtx_l->get_row_ptrs());
+        this->ref, this->mtx_init->get_const_device_view(),
+        res_mtx_l->get_row_ptrs());
     gko::kernels::reference::factorization::initialize_l(
-        this->ref, this->mtx_init.get(), res_mtx_l.get(), true);
+        this->ref, this->mtx_init->get_const_device_view(),
+        res_mtx_l->get_device_view(), true);
 
     GKO_ASSERT_MTX_NEAR(res_mtx_l, this->mtx_l_init_expect, this->tol);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_init_expect);
@@ -182,8 +185,9 @@ TYPED_TEST(ParIct, KernelAddCandidates)
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, this->mtx_llh.get(), this->mtx_system.get(),
-        this->mtx_l.get(), res_mtx_l.get());
+        this->ref, this->mtx_llh->get_const_device_view(),
+        this->mtx_system->get_const_device_view(),
+        this->mtx_l->get_const_device_view(), res_mtx_l.get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, this->mtx_l_add_expect, this->tol);
@@ -199,7 +203,8 @@ TYPED_TEST(ParIct, KernelComputeLU)
     this->mtx_l_system->convert_to(mtx_l_coo);
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
-        this->ref, this->mtx_system.get(), this->mtx_l_system.get(),
+        this->ref, this->mtx_system->get_const_device_view(),
+        this->mtx_l_system->get_device_view(),
         mtx_l_coo->get_const_device_view());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -289,7 +289,8 @@ TYPED_TEST(ParIlu, KernelInitializeRowPtrsLU)
     auto u_row_ptrs = u_row_ptrs_vector.data();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
-        this->ref, this->mtx_csr_small.get(), l_row_ptrs, u_row_ptrs);
+        this->ref, this->mtx_csr_small->get_const_device_view(), l_row_ptrs,
+        u_row_ptrs);
 
     ASSERT_TRUE(std::equal(l_row_ptrs, l_row_ptrs + num_row_ptrs,
                            small_csr_l_expected->get_const_row_ptrs()));
@@ -317,7 +318,7 @@ TYPED_TEST(ParIlu, KernelInitializeRowPtrsLUZeroMatrix)
     auto u_row_ptrs = u_row_ptrs_vector.data();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
-        this->ref, empty_mtx.get(), l_row_ptrs, u_row_ptrs);
+        this->ref, empty_mtx->get_const_device_view(), l_row_ptrs, u_row_ptrs);
 
     ASSERT_TRUE(std::equal(l_row_ptrs, l_row_ptrs + num_row_ptrs,
                            empty_mtx_l_expected->get_const_row_ptrs()));
@@ -352,7 +353,8 @@ TYPED_TEST(ParIlu, KernelInitializeLU)
     std::copy(u_row_ptrs.begin(), u_row_ptrs.end(), actual_u->get_row_ptrs());
 
     gko::kernels::reference::factorization::initialize_l_u(
-        this->ref, this->mtx_csr_small.get(), actual_l.get(), actual_u.get());
+        this->ref, this->mtx_csr_small->get_const_device_view(),
+        actual_l->get_device_view(), actual_u->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(actual_l, expected_l, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(actual_u, expected_u, r<value_type>::value);
@@ -369,7 +371,8 @@ TYPED_TEST(ParIlu, KernelInitializeLUZeroMatrix)
     actual_u->copy_from(this->identity);
 
     gko::kernels::reference::factorization::initialize_l_u(
-        this->ref, this->empty_csr.get(), actual_l.get(), actual_u.get());
+        this->ref, this->empty_csr->get_const_device_view(),
+        actual_l->get_device_view(), actual_u->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(actual_l, this->identity, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(actual_u, this->identity, r<value_type>::value);
@@ -407,8 +410,8 @@ TYPED_TEST(ParIlu, KernelComputeLU)
         static_cast<Dense*>(u_expected_lin_op.release()));
 
     gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
-        this->ref, iterations, mtx_coo->get_const_device_view(), l_csr.get(),
-        u_csr.get());
+        this->ref, iterations, mtx_coo->get_const_device_view(),
+        l_csr->get_device_view(), u_csr->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(l_csr, this->small_l_expected, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(u_csr, u_expected, r<value_type>::value);

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -289,7 +289,8 @@ TYPED_TEST(ParIlu, KernelInitializeRowPtrsLU)
     auto u_row_ptrs = u_row_ptrs_vector.data();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
-        this->ref, this->mtx_csr_small.get(), l_row_ptrs, u_row_ptrs);
+        this->ref, this->mtx_csr_small->get_const_device_view(), l_row_ptrs,
+        u_row_ptrs);
 
     ASSERT_TRUE(std::equal(l_row_ptrs, l_row_ptrs + num_row_ptrs,
                            small_csr_l_expected->get_const_row_ptrs()));
@@ -316,7 +317,7 @@ TYPED_TEST(ParIlu, KernelInitializeRowPtrsLUZeroMatrix)
     auto u_row_ptrs = u_row_ptrs_vector.data();
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
-        this->ref, empty_mtx.get(), l_row_ptrs, u_row_ptrs);
+        this->ref, empty_mtx->get_const_device_view(), l_row_ptrs, u_row_ptrs);
 
     ASSERT_TRUE(std::equal(l_row_ptrs, l_row_ptrs + num_row_ptrs,
                            empty_mtx_l_expected->get_const_row_ptrs()));
@@ -351,7 +352,8 @@ TYPED_TEST(ParIlu, KernelInitializeLU)
     std::copy(u_row_ptrs.begin(), u_row_ptrs.end(), actual_u->get_row_ptrs());
 
     gko::kernels::reference::factorization::initialize_l_u(
-        this->ref, this->mtx_csr_small.get(), actual_l.get(), actual_u.get());
+        this->ref, this->mtx_csr_small->get_const_device_view(),
+        actual_l->get_device_view(), actual_u->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(actual_l, expected_l, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(actual_u, expected_u, r<value_type>::value);
@@ -368,7 +370,8 @@ TYPED_TEST(ParIlu, KernelInitializeLUZeroMatrix)
     actual_u->copy_from(this->identity);
 
     gko::kernels::reference::factorization::initialize_l_u(
-        this->ref, this->empty_csr.get(), actual_l.get(), actual_u.get());
+        this->ref, this->empty_csr->get_const_device_view(),
+        actual_l->get_device_view(), actual_u->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(actual_l, this->identity, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(actual_u, this->identity, r<value_type>::value);
@@ -406,8 +409,8 @@ TYPED_TEST(ParIlu, KernelComputeLU)
         static_cast<Dense*>(u_expected_lin_op.release()));
 
     gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
-        this->ref, iterations, mtx_coo->get_const_device_view(), l_csr.get(),
-        u_csr.get());
+        this->ref, iterations, mtx_coo->get_const_device_view(),
+        l_csr->get_device_view(), u_csr->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(l_csr, this->small_l_expected, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(u_csr, u_expected, r<value_type>::value);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -190,7 +190,7 @@ protected:
         gko::array<ValueType> tmp(ref);
         gko::array<gko::remove_complex<ValueType>> tmp2(ref);
         gko::kernels::reference::par_ilut_factorization::threshold_select(
-            ref, mtx.get(), rank, tmp, tmp2, result);
+            ref, mtx->get_const_device_view(), rank, tmp, tmp2, result);
 
         ASSERT_NEAR(result, expected, tolerance);
     }
@@ -213,8 +213,8 @@ protected:
             gko::as<Mtx>(lower ? expected->clone() : expected->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, &res_mtx_builder,
-            res_mtx_coo.get(), lower);
+            ref, local_mtx->get_const_device_view(), threshold,
+            &res_mtx_builder, res_mtx_coo.get(), lower);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(local_expected, res_mtx);
         GKO_ASSERT_MTX_NEAR(local_expected, res_mtx, 0);
@@ -242,11 +242,12 @@ protected:
         auto tmp = gko::array<typename Mtx::value_type>{exec};
         gko::remove_complex<typename Mtx::value_type> threshold{};
         gko::kernels::reference::par_ilut_factorization::
-            threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    &res_mtx_builder, res_mtx_coo.get());
+            threshold_filter_approx(ref, mtx->get_const_device_view(), rank,
+                                    tmp, threshold, &res_mtx_builder,
+                                    res_mtx_coo.get());
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, mtx.get(), threshold, &res_mtx2_builder, res_mtx_coo2.get(),
-            true);
+            ref, mtx->get_const_device_view(), threshold, &res_mtx2_builder,
+            res_mtx_coo2.get(), true);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx);
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx2);
@@ -334,7 +335,7 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx1.get(), 0.0,
+        this->ref, this->mtx1->get_const_device_view(), 0.0,
         gko::matrix::make_builder_unique_ptr(res_mtx).get(), null_coo, true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
@@ -417,7 +418,7 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCoo)
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx1.get(), rank, tmp, threshold,
+        this->ref, this->mtx1->get_const_device_view(), rank, tmp, threshold,
         gko::matrix::make_builder_unique_ptr(res_mtx).get(), null_coo);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
@@ -463,8 +464,10 @@ TYPED_TEST(ParIlut, KernelAddCandidates)
     auto res_mtx_u = Csr::create(this->exec, this->mtx_system->get_size());
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
-        this->ref, this->mtx_lu.get(), this->mtx_system.get(),
-        this->mtx_l.get(), this->mtx_u.get(),
+        this->ref, this->mtx_lu->get_const_device_view(),
+        this->mtx_system->get_const_device_view(),
+        this->mtx_l->get_const_device_view(),
+        this->mtx_u->get_const_device_view(),
         gko::matrix::make_builder_unique_ptr(res_mtx_l).get(),
         gko::matrix::make_builder_unique_ptr(res_mtx_u).get());
 
@@ -487,9 +490,11 @@ TYPED_TEST(ParIlut, KernelComputeLU)
     auto mtx_u_csc = gko::as<Csr>(mtx_u_transp.get());
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
-        this->ref, this->mtx_system.get(), this->mtx_l_system.get(),
-        mtx_l_coo->get_const_device_view(), this->mtx_u_system.get(),
-        mtx_u_coo->get_const_device_view(), mtx_u_csc);
+        this->ref, this->mtx_system->get_const_device_view(),
+        this->mtx_l_system->get_device_view(),
+        mtx_l_coo->get_const_device_view(),
+        this->mtx_u_system->get_device_view(),
+        mtx_u_coo->get_const_device_view(), mtx_u_csc->get_device_view());
     auto mtx_utt = gko::as<Csr>(mtx_u_csc->transpose());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -459,8 +459,7 @@ TYPED_TEST(ParIlut, KernelAddCandidates)
     auto res_mtx_u = Csr::create(this->exec, this->mtx_system->get_size());
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
-        this->ref, this->mtx_lu->get_const_device_view(),
-        this->mtx_system->get_const_device_view(),
+        this->ref, this->mtx_lu.get(), this->mtx_system.get(),
         this->mtx_l->get_const_device_view(),
         this->mtx_u->get_const_device_view(), res_mtx_l.get(), res_mtx_u.get());
 

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -190,7 +190,7 @@ protected:
         gko::array<ValueType> tmp(ref);
         gko::array<gko::remove_complex<ValueType>> tmp2(ref);
         gko::kernels::reference::par_ilut_factorization::threshold_select(
-            ref, mtx.get(), rank, tmp, tmp2, result);
+            ref, mtx->get_const_device_view(), rank, tmp, tmp2, result);
 
         ASSERT_NEAR(result, expected, tolerance);
     }
@@ -210,8 +210,8 @@ protected:
             gko::as<Mtx>(lower ? expected->clone() : expected->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, res_mtx.get(), res_mtx_coo.get(),
-            lower);
+            ref, local_mtx->get_const_device_view(), threshold, res_mtx.get(),
+            res_mtx_coo.get(), lower);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(local_expected, res_mtx);
         GKO_ASSERT_MTX_NEAR(local_expected, res_mtx, 0);
@@ -233,11 +233,12 @@ protected:
         auto tmp = gko::array<typename Mtx::value_type>{exec};
         gko::remove_complex<typename Mtx::value_type> threshold{};
         gko::kernels::reference::par_ilut_factorization::
-            threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    res_mtx.get(), res_mtx_coo.get());
+            threshold_filter_approx(ref, mtx->get_const_device_view(), rank,
+                                    tmp, threshold, res_mtx.get(),
+                                    res_mtx_coo.get());
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, mtx.get(), threshold, res_mtx2.get(), res_mtx_coo2.get(),
-            true);
+            ref, mtx->get_const_device_view(), threshold, res_mtx2.get(),
+            res_mtx_coo2.get(), true);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx);
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx2);
@@ -328,7 +329,8 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx1.get(), 0.0, res_mtx.get(), null_coo, true);
+        this->ref, this->mtx1->get_const_device_view(), 0.0, res_mtx.get(),
+        null_coo, true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
     GKO_ASSERT_MTX_NEAR(this->mtx1, res_mtx, 0);
@@ -410,8 +412,8 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCoo)
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx1.get(), rank, tmp, threshold, res_mtx.get(),
-        null_coo);
+        this->ref, this->mtx1->get_const_device_view(), rank, tmp, threshold,
+        res_mtx.get(), null_coo);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
     GKO_ASSERT_MTX_NEAR(this->mtx1, res_mtx, 0);
@@ -457,8 +459,10 @@ TYPED_TEST(ParIlut, KernelAddCandidates)
     auto res_mtx_u = Csr::create(this->exec, this->mtx_system->get_size());
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
-        this->ref, this->mtx_lu.get(), this->mtx_system.get(),
-        this->mtx_l.get(), this->mtx_u.get(), res_mtx_l.get(), res_mtx_u.get());
+        this->ref, this->mtx_lu->get_const_device_view(),
+        this->mtx_system->get_const_device_view(),
+        this->mtx_l->get_const_device_view(),
+        this->mtx_u->get_const_device_view(), res_mtx_l.get(), res_mtx_u.get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, this->mtx_u_add_expect);
@@ -480,9 +484,11 @@ TYPED_TEST(ParIlut, KernelComputeLU)
     auto mtx_u_csc = gko::as<Csr>(mtx_u_transp.get());
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
-        this->ref, this->mtx_system.get(), this->mtx_l_system.get(),
-        mtx_l_coo->get_const_device_view(), this->mtx_u_system.get(),
-        mtx_u_coo->get_const_device_view(), mtx_u_csc);
+        this->ref, this->mtx_system->get_const_device_view(),
+        this->mtx_l_system->get_device_view(),
+        mtx_l_coo->get_const_device_view(),
+        this->mtx_u_system->get_device_view(),
+        mtx_u_coo->get_const_device_view(), mtx_u_csc->get_device_view());
     auto mtx_utt = gko::as<Csr>(mtx_u_csc->transpose());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l_system, this->mtx_l_it_expect, this->tol);

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -2544,7 +2544,7 @@ TYPED_TEST(Csr, CanDetectMissingDiagonalEntry)
     bool has_diags{};
 
     gko::kernels::reference::csr::check_diagonal_entries_exist(
-        this->exec, b.get(), has_diags);
+        this->exec, b->get_const_device_view(), has_diags);
 
     ASSERT_FALSE(has_diags);
 }
@@ -2561,7 +2561,7 @@ TYPED_TEST(Csr, CanDetectWhenAllDiagonalEntriesArePresent)
     bool has_diags{};
 
     gko::kernels::reference::csr::check_diagonal_entries_exist(
-        this->exec, b.get(), has_diags);
+        this->exec, b->get_const_device_view(), has_diags);
 
     ASSERT_TRUE(has_diags);
 }
@@ -2913,7 +2913,7 @@ TYPED_TEST(Csr, CanComputeRowWiseAbsoluteSum)
         {-gko::one<value_type>()}, this->exec));
 
     gko::kernels::reference::csr::row_wise_absolute_sum(
-        this->exec, this->mtx3_sorted.get(), sum);
+        this->exec, this->mtx3_sorted->get_const_device_view(), sum);
 
     gko::array<value_type> sum_result(this->exec, {3, 12, 5});
     GKO_ASSERT_ARRAY_EQ(sum, sum_result);

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -2545,7 +2545,7 @@ TYPED_TEST(Csr, CanDetectMissingDiagonalEntry)
     bool has_diags{};
 
     gko::kernels::reference::csr::check_diagonal_entries_exist(
-        this->exec, b.get(), has_diags);
+        this->exec, b->get_const_device_view(), has_diags);
 
     ASSERT_FALSE(has_diags);
 }
@@ -2562,7 +2562,7 @@ TYPED_TEST(Csr, CanDetectWhenAllDiagonalEntriesArePresent)
     bool has_diags{};
 
     gko::kernels::reference::csr::check_diagonal_entries_exist(
-        this->exec, b.get(), has_diags);
+        this->exec, b->get_const_device_view(), has_diags);
 
     ASSERT_TRUE(has_diags);
 }
@@ -2915,7 +2915,7 @@ TYPED_TEST(Csr, CanComputeRowWiseAbsoluteSum)
         {-gko::one<value_type>()}, this->exec));
 
     gko::kernels::reference::csr::row_wise_absolute_sum(
-        this->exec, this->mtx3_sorted.get(), sum);
+        this->exec, this->mtx3_sorted->get_const_device_view(), sum);
 
     gko::array<value_type> sum_result(this->exec, {3, 12, 5});
     GKO_ASSERT_ARRAY_EQ(sum, sum_result);

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -392,8 +392,8 @@ TYPED_TEST(Pgm, FindStrongestNeighbor)
     }
 
     gko::kernels::reference::pgm::find_strongest_neighbor(
-        this->exec, this->weight.get(), this->mtx_diag.get(), agg,
-        strongest_neighbor);
+        this->exec, this->weight->get_const_device_view(), this->mtx_diag.get(),
+        agg, strongest_neighbor);
 
     ASSERT_EQ(snb_vals[0], 2);
     ASSERT_EQ(snb_vals[1], 0);
@@ -417,8 +417,8 @@ TYPED_TEST(Pgm, AssignToExistAgg)
     agg_vals[4] = -1;
 
     gko::kernels::reference::pgm::assign_to_exist_agg(
-        this->exec, this->weight.get(), this->mtx_diag.get(), agg,
-        intermediate_agg);
+        this->exec, this->weight->get_const_device_view(), this->mtx_diag.get(),
+        agg, intermediate_agg);
 
     ASSERT_EQ(agg_vals[0], 0);
     ASSERT_EQ(agg_vals[1], 1);

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -458,8 +458,8 @@ TYPED_TEST(Pgm, FindStrongestNeighbor)
     }
 
     gko::kernels::reference::pgm::find_strongest_neighbor(
-        this->exec, this->weight.get(), this->mtx_diag.get(), agg,
-        strongest_neighbor);
+        this->exec, this->weight->get_const_device_view(), this->mtx_diag.get(),
+        agg, strongest_neighbor);
 
     ASSERT_EQ(snb_vals[0], 2);
     ASSERT_EQ(snb_vals[1], 0);
@@ -483,8 +483,8 @@ TYPED_TEST(Pgm, AssignToExistAgg)
     agg_vals[4] = -1;
 
     gko::kernels::reference::pgm::assign_to_exist_agg(
-        this->exec, this->weight.get(), this->mtx_diag.get(), agg,
-        intermediate_agg);
+        this->exec, this->weight->get_const_device_view(), this->mtx_diag.get(),
+        agg, intermediate_agg);
 
     ASSERT_EQ(agg_vals[0], 0);
     ASSERT_EQ(agg_vals[1], 1);

--- a/reference/test/multigrid/rs_kernels.cpp
+++ b/reference/test/multigrid/rs_kernels.cpp
@@ -68,7 +68,8 @@ TEST_F(Rs, ComputeSocAndRunRs)
     index_type coarse{};
 
     gko::kernels::reference::rs::compute_soc_and_run_rs(
-        exec, A.get(), 0.5, is_strong_empty, lambda, cf, coarse);
+        exec, A->get_const_device_view(), 0.5, is_strong_empty, lambda, cf,
+        coarse);
 
     // all off-diagonals are strong
     std::vector<bool> expected_soc{false, true, true,  false, true, true, false,
@@ -95,7 +96,8 @@ TEST_F(Rs, FillCoarseAndComputeProlongRowPtrs)
     gko::array<index_type> coarse(exec, 2);
 
     gko::kernels::reference::rs::fill_coarse_and_compute_prolong_row_ptrs(
-        exec, cf, coarse, f2c, A.get(), is_strong_prefilled, p_row_ptrs);
+        exec, cf, coarse, f2c, A->get_const_device_view(), is_strong_prefilled,
+        p_row_ptrs);
 
     // C-points (1, 3) map to (0, 1)
     ASSERT_EQ(f2c.get_const_data()[0], -1);
@@ -120,8 +122,8 @@ TEST_F(Rs, ComputeInterpolation)
                     P->get_row_ptrs());
 
     gko::kernels::reference::rs::compute_interpolation(
-        exec, A.get(), is_strong_prefilled.get_const_data(), cf,
-        f2c.get_const_data(), P.get());
+        exec, A->get_const_device_view(), is_strong_prefilled.get_const_data(),
+        cf, f2c.get_const_data(), P->get_device_view());
 
     auto p_vals = P->get_const_values();
     auto p_cols = P->get_const_col_idxs();

--- a/reference/test/preconditioner/isai_kernels.cpp
+++ b/reference/test/preconditioner/isai_kernels.cpp
@@ -360,8 +360,8 @@ TYPED_TEST(Isai, KernelGenerateA)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, this->a_csr.get(), result.get(), a1.get_data(),
-        a2.get_data(), false);
+        this->exec, this->a_csr->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_csr_inv);
     GKO_ASSERT_MTX_NEAR(result, this->a_csr_inv, r<value_type>::value);
@@ -386,8 +386,8 @@ TYPED_TEST(Isai, KernelGenerateA2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, a_transpose.get(), result.get(), a1.get_data(),
-        a2.get_data(), false);
+        this->exec, a_transpose->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), false);
 
     const auto expected = this->transpose(this->a_csr_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
@@ -412,8 +412,8 @@ TYPED_TEST(Isai, KernelGenerateAsparse)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, this->a_sparse.get(), result.get(), a1.get_data(),
-        a2.get_data(), false);
+        this->exec, this->a_sparse->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_sparse_inv);
     GKO_ASSERT_MTX_NEAR(result, this->a_sparse_inv, r<value_type>::value);
@@ -444,8 +444,8 @@ TYPED_TEST(Isai, KernelGenerateALongrow)
     std::fill_n(a2_expect.get_data() + 36, 65, 509);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, this->a_csr_longrow.get(), result.get(), a1.get_data(),
-        a2.get_data(), false);
+        this->exec, this->a_csr_longrow->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_csr_longrow_inv_partial);
     GKO_ASSERT_MTX_NEAR(result, this->a_csr_longrow_inv_partial,
@@ -475,8 +475,9 @@ TYPED_TEST(Isai, KernelGenerateExcessALongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(122, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, this->a_csr_longrow.get(), this->a_csr_longrow.get(),
-        a1.get_const_data(), a2.get_const_data(), result.get(),
+        this->exec, this->a_csr_longrow->get_const_device_view(),
+        this->a_csr_longrow->get_const_device_view(), a1.get_const_data(),
+        a2.get_const_data(), result->get_device_view(),
         result_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->a_csr_longrow_e);
@@ -499,8 +500,8 @@ TYPED_TEST(Isai, KernelGenerateL1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, this->l_csr.get(), result.get(), a1.get_data(),
-        a2.get_data(), true);
+        this->exec, this->l_csr->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_csr_inv);
     GKO_ASSERT_MTX_NEAR(result, this->l_csr_inv, r<value_type>::value);
@@ -525,8 +526,8 @@ TYPED_TEST(Isai, KernelGenerateL2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, l_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
-        true);
+        this->exec, l_mtx->get_const_device_view(), result->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
 
     const auto expected = this->transpose(this->u_csr_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
@@ -551,8 +552,8 @@ TYPED_TEST(Isai, KernelGenerateLsparse1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, this->l_sparse.get(), result.get(), a1.get_data(),
-        a2.get_data(), true);
+        this->exec, this->l_sparse->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_sparse_inv);
     GKO_ASSERT_MTX_NEAR(result, this->l_sparse_inv, r<value_type>::value);
@@ -576,8 +577,8 @@ TYPED_TEST(Isai, KernelGenerateLsparse2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, this->l_sparse2.get(), result.get(), a1.get_data(),
-        a2.get_data(), true);
+        this->exec, this->l_sparse2->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_sparse2_inv);
     GKO_ASSERT_MTX_NEAR(result, this->l_sparse2_inv, r<value_type>::value);
@@ -602,8 +603,8 @@ TYPED_TEST(Isai, KernelGenerateLsparse3)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, l_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
-        true);
+        this->exec, l_mtx->get_const_device_view(), result->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
 
     // Results in a slightly different version than u_sparse_inv->transpose()
     // because a different row-sparsity pattern is used in u_sparse vs. l_mtx
@@ -645,8 +646,8 @@ TYPED_TEST(Isai, KernelGenerateLLongrow)
     a2_expect.get_data()[35] = 248;
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, this->l_csr_longrow.get(), result.get(), a1.get_data(),
-        a2.get_data(), true);
+        this->exec, this->l_csr_longrow->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_csr_longrow_inv_partial);
     GKO_ASSERT_MTX_NEAR(result, this->l_csr_longrow_inv_partial,
@@ -678,8 +679,9 @@ TYPED_TEST(Isai, KernelGenerateExcessLLongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(66, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, this->l_csr_longrow.get(), this->l_csr_longrow.get(),
-        a1.get_const_data(), a2.get_const_data(), result.get(),
+        this->exec, this->l_csr_longrow->get_const_device_view(),
+        this->l_csr_longrow->get_const_device_view(), a1.get_const_data(),
+        a2.get_const_data(), result->get_device_view(),
         result_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->l_csr_longrow_e);
@@ -703,8 +705,8 @@ TYPED_TEST(Isai, KernelGenerateU1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
-        false);
+        this->exec, u_mtx->get_const_device_view(), result->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
 
     auto expected = this->transpose(this->l_csr_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
@@ -729,8 +731,8 @@ TYPED_TEST(Isai, KernelGenerateU2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, this->u_csr.get(), result.get(), a1.get_data(),
-        a2.get_data(), false);
+        this->exec, this->u_csr->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_csr_inv);
     GKO_ASSERT_MTX_NEAR(result, this->u_csr_inv, r<value_type>::value);
@@ -755,8 +757,8 @@ TYPED_TEST(Isai, KernelGenerateUsparse1)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
-        false);
+        this->exec, u_mtx->get_const_device_view(), result->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
 
     const auto expected = this->transpose(this->l_sparse_inv);
     GKO_ASSERT_MTX_EQ_SPARSITY(result, expected);
@@ -782,8 +784,8 @@ TYPED_TEST(Isai, KernelGenerateUsparse2)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, u_mtx.get(), result.get(), a1.get_data(), a2.get_data(),
-        false);
+        this->exec, u_mtx->get_const_device_view(), result->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
 
     // Results in a slightly different version than l_sparse2_inv->transpose()
     // because a different row-sparsity pattern is used in l_sparse2 vs. u_mtx
@@ -816,8 +818,8 @@ TYPED_TEST(Isai, KernelGenerateUsparse3)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, this->u_sparse.get(), result.get(), a1.get_data(),
-        a2.get_data(), false);
+        this->exec, this->u_sparse->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_sparse_inv);
     GKO_ASSERT_MTX_NEAR(result, this->u_sparse_inv, r<value_type>::value);
@@ -846,8 +848,8 @@ TYPED_TEST(Isai, KernelGenerateULongrow)
     std::fill_n(a2_expect.get_data() + 3, 33, 153);
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        this->exec, this->u_csr_longrow.get(), result.get(), a1.get_data(),
-        a2.get_data(), false);
+        this->exec, this->u_csr_longrow->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_csr_longrow_inv_partial);
     GKO_ASSERT_MTX_NEAR(result, this->u_csr_longrow_inv_partial,
@@ -875,8 +877,9 @@ TYPED_TEST(Isai, KernelGenerateExcessULongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(33, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, this->u_csr_longrow.get(), this->u_csr_longrow.get(),
-        a1.get_const_data(), a2.get_const_data(), result.get(),
+        this->exec, this->u_csr_longrow->get_const_device_view(),
+        this->u_csr_longrow->get_const_device_view(), a1.get_const_data(),
+        a2.get_const_data(), result->get_device_view(),
         result_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->u_csr_longrow_e);
@@ -899,8 +902,8 @@ TYPED_TEST(Isai, KernelGenerateSpd)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, this->spd_csr.get(), result.get(), a1.get_data(),
-        a2.get_data(), true);
+        this->exec, this->spd_csr->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_csr_inv);
     GKO_ASSERT_MTX_NEAR(result, this->spd_csr_inv, r<value_type>::value);
@@ -924,8 +927,8 @@ TYPED_TEST(Isai, KernelGenerateSpdsparse)
     std::fill_n(zeros.get_data(), num_rows + 1, 0);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, this->spd_sparse.get(), result.get(), a1.get_data(),
-        a2.get_data(), true);
+        this->exec, this->spd_sparse->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_sparse_inv);
     GKO_ASSERT_MTX_NEAR(result, this->spd_sparse_inv, r<value_type>::value);
@@ -954,8 +957,8 @@ TYPED_TEST(Isai, KernelGenerateSpdLongrow)
     std::fill_n(a2_expect.get_data() + 36, 65, 338);
 
     gko::kernels::reference::isai::generate_general_inverse(
-        this->exec, this->spd_csr_longrow.get(), result.get(), a1.get_data(),
-        a2.get_data(), true);
+        this->exec, this->spd_csr_longrow->get_const_device_view(),
+        result->get_device_view(), a1.get_data(), a2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_csr_longrow_inv_partial);
     GKO_ASSERT_MTX_NEAR(result, this->spd_csr_longrow_inv_partial,
@@ -983,10 +986,10 @@ TYPED_TEST(Isai, KernelGenerateExcessSpdLongrow)
     auto result_rhs = Dense::create(this->exec, gko::dim<2>(36, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        this->exec, this->spd_csr_longrow.get(),
-        this->spd_csr_longrow_inv_partial.get(), a1.get_const_data(),
-        a2.get_const_data(), result.get(), result_rhs->get_device_view(), 0,
-        num_rows);
+        this->exec, this->spd_csr_longrow->get_const_device_view(),
+        this->spd_csr_longrow_inv_partial->get_const_device_view(),
+        a1.get_const_data(), a2.get_const_data(), result->get_device_view(),
+        result_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result, this->spd_csr_longrow_e);
     GKO_ASSERT_MTX_NEAR(result, this->spd_csr_longrow_e, 0);
@@ -1019,7 +1022,7 @@ TYPED_TEST(Isai, KernelScatterExcessSolution)
 
     gko::kernels::reference::isai::scatter_excess_solution(
         this->exec, ptrs.get_const_data(), sol->get_const_device_view(),
-        mtx.get(), 0, 6);
+        mtx->get_device_view(), 0, 6);
 
     GKO_ASSERT_MTX_NEAR(mtx, expect, 0);
 }

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -1143,8 +1143,8 @@ TYPED_TEST(Jacobi, ScalarL1Diag)
     auto diag = mtx->extract_diagonal();
     auto diag_val = diag->get_const_values();
 
-    gko::kernels::reference::jacobi::scalar_l1(this->exec, mtx.get(),
-                                               diag.get());
+    gko::kernels::reference::jacobi::scalar_l1(
+        this->exec, mtx->get_const_device_view(), diag.get());
 
     EXPECT_EQ(diag_val[0], value_type{2.0});
     EXPECT_EQ(diag_val[1], value_type{4.0});
@@ -1175,7 +1175,7 @@ TYPED_TEST(Jacobi, BlockL1)
     gko::array<index_type> block_ptr(this->exec, {0, 1, 2, 4});
 
     gko::kernels::reference::jacobi::block_l1(this->exec, 3, block_ptr,
-                                              mtx.get());
+                                              mtx->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l({{2.0, 1.0, 0.0, 0.0},

--- a/reference/test/preconditioner/jacobi_kernels.cpp
+++ b/reference/test/preconditioner/jacobi_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -1141,8 +1141,8 @@ TYPED_TEST(Jacobi, ScalarL1Diag)
     auto diag = mtx->extract_diagonal();
     auto diag_val = diag->get_const_values();
 
-    gko::kernels::reference::jacobi::scalar_l1(this->exec, mtx.get(),
-                                               diag.get());
+    gko::kernels::reference::jacobi::scalar_l1(
+        this->exec, mtx->get_const_device_view(), diag.get());
 
     EXPECT_EQ(diag_val[0], value_type{2.0});
     EXPECT_EQ(diag_val[1], value_type{4.0});
@@ -1173,7 +1173,7 @@ TYPED_TEST(Jacobi, BlockL1)
     gko::array<index_type> block_ptr(this->exec, {0, 1, 2, 4});
 
     gko::kernels::reference::jacobi::block_l1(this->exec, 3, block_ptr,
-                                              mtx.get());
+                                              mtx->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(mtx,
                         l({{2.0, 1.0, 0.0, 0.0},

--- a/reference/test/preconditioner/sor_kernels.cpp
+++ b/reference/test/preconditioner/sor_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -66,7 +66,8 @@ TYPED_TEST(Sor, CanInitializeLFactor)
         gko::initialize<gko::matrix::Dense<value_type>>({0.0}, this->exec));
 
     gko::kernels::reference::sor::initialize_weighted_l(
-        this->exec, this->mtx.get(), 1.0, result.get());
+        this->exec, this->mtx->get_const_device_view(), 1.0,
+        result->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(result, this->expected_l, 0.0);
 }
@@ -88,7 +89,8 @@ TYPED_TEST(Sor, CanInitializeLFactorWithWeight)
                                   this->exec);
 
     gko::kernels::reference::sor::initialize_weighted_l(
-        this->exec, this->mtx.get(), 0.5f, result.get());
+        this->exec, this->mtx->get_const_device_view(), 0.5f,
+        result->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(result, expected_l, r<value_type>::value);
 }
@@ -105,7 +107,8 @@ TYPED_TEST(Sor, CanInitializeLAndUFactor)
         gko::initialize<gko::matrix::Dense<value_type>>({0.0}, this->exec));
 
     gko::kernels::reference::sor::initialize_weighted_l_u(
-        this->exec, this->mtx.get(), 1.0, result_l.get(), result_u.get());
+        this->exec, this->mtx->get_const_device_view(), 1.0,
+        result_l->get_device_view(), result_u->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(result_l, this->expected_l, 0.0);
     GKO_ASSERT_MTX_NEAR(result_u, this->expected_u, 0.0);
@@ -143,7 +146,8 @@ TYPED_TEST(Sor, CanInitializeLAndUFactorWithWeight)
         this->exec);
 
     gko::kernels::reference::sor::initialize_weighted_l_u(
-        this->exec, this->mtx.get(), factor, result_l.get(), result_u.get());
+        this->exec, this->mtx->get_const_device_view(), factor,
+        result_l->get_device_view(), result_u->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(result_l, expected_l, r<value_type>::value);
     GKO_ASSERT_MTX_NEAR(result_u, expected_u, r<value_type>::value);

--- a/reference/test/reorder/mc64_kernels.cpp
+++ b/reference/test/reorder/mc64_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -190,7 +190,8 @@ TYPED_TEST(Mc64, InitializeWeightsSum)
         std::numeric_limits<typename TestFixture::real_type>::infinity());
 
     gko::experimental::reorder::mc64::initialize_weights(
-        this->mtx.get(), this->weights, this->dual_u, this->row_maxima,
+        this->mtx->get_const_device_view(), this->weights, this->dual_u,
+        this->row_maxima,
         gko::experimental::reorder::mc64_strategy::max_diagonal_sum);
 
     this->assert_array_near(this->weights, this->initialized_weights_sum,
@@ -208,7 +209,8 @@ TYPED_TEST(Mc64, InitializeWeightsProduct)
         std::numeric_limits<typename TestFixture::real_type>::infinity());
 
     gko::experimental::reorder::mc64::initialize_weights(
-        this->mtx.get(), this->weights, this->dual_u, this->row_maxima,
+        this->mtx->get_const_device_view(), this->weights, this->dual_u,
+        this->row_maxima,
         gko::experimental::reorder::mc64_strategy::max_diagonal_product);
 
     this->assert_array_near(this->weights, this->initialized_weights_product,

--- a/test/factorization/cholesky_kernels.cpp
+++ b/test/factorization/cholesky_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -218,9 +218,11 @@ TYPED_TEST(CholeskySymbolic, KernelSymbolicCount)
         gko::array<index_type> drow_nnz{this->exec, mtx->get_size()[0]};
 
         gko::kernels::reference::cholesky::symbolic_count(
-            this->ref, mtx.get(), *forest, row_nnz.get_data(), this->tmp);
+            this->ref, mtx->get_const_device_view(), *forest,
+            row_nnz.get_data(), this->tmp);
         gko::kernels::GKO_DEVICE_NAMESPACE::cholesky::symbolic_count(
-            this->exec, dmtx.get(), *dforest, drow_nnz.get_data(), this->dtmp);
+            this->exec, dmtx->get_const_device_view(), *dforest,
+            drow_nnz.get_data(), this->dtmp);
 
         GKO_ASSERT_ARRAY_EQ(drow_nnz, row_nnz);
     }
@@ -242,7 +244,8 @@ TYPED_TEST(CholeskySymbolic, KernelSymbolicFactorize)
         gko::factorization::compute_elimination_forest(mtx.get(), forest);
         gko::array<index_type> row_ptrs{this->ref, num_rows + 1};
         gko::kernels::reference::cholesky::symbolic_count(
-            this->ref, mtx.get(), *forest, row_ptrs.get_data(), this->tmp);
+            this->ref, mtx->get_const_device_view(), *forest,
+            row_ptrs.get_data(), this->tmp);
         gko::kernels::reference::components::prefix_sum_nonnegative(
             this->ref, row_ptrs.get_data(), num_rows + 1);
         const auto nnz =
@@ -259,12 +262,15 @@ TYPED_TEST(CholeskySymbolic, KernelSymbolicFactorize)
         gko::factorization::compute_elimination_forest(dmtx.get(), dforest);
         gko::array<index_type> dtmp_ptrs{this->exec, num_rows + 1};
         gko::kernels::GKO_DEVICE_NAMESPACE::cholesky::symbolic_count(
-            this->exec, dmtx.get(), *dforest, dtmp_ptrs.get_data(), this->dtmp);
+            this->exec, dmtx->get_const_device_view(), *dforest,
+            dtmp_ptrs.get_data(), this->dtmp);
 
         gko::kernels::reference::cholesky::symbolic_factorize(
-            this->ref, mtx.get(), *forest, l_factor.get(), this->tmp);
+            this->ref, mtx->get_const_device_view(), *forest,
+            l_factor->get_device_view(), this->tmp);
         gko::kernels::GKO_DEVICE_NAMESPACE::cholesky::symbolic_factorize(
-            this->exec, dmtx.get(), *dforest, dl_factor.get(), this->dtmp);
+            this->exec, dmtx->get_const_device_view(), *dforest,
+            dl_factor->get_device_view(), this->dtmp);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(dl_factor, l_factor);
     }
@@ -309,7 +315,7 @@ TYPED_TEST(CholeskySymbolic, KernelForestFromFactorWorks)
                                    static_cast<index_type>(mtx->get_size()[0])};
 
         gko::kernels::GKO_DEVICE_NAMESPACE::elimination_forest::from_factor(
-            this->exec, dfactors.get(), dforest);
+            this->exec, dfactors->get_const_device_view(), dforest);
 
         this->assert_equal_forests(*forest, dforest);
     }
@@ -425,17 +431,17 @@ TYPED_TEST(Cholesky, KernelInitializeIsEquivalentToRef)
         gko::array<index_type> dtranspose_idxs{this->exec, nnz};
 
         gko::kernels::reference::cholesky::initialize(
-            this->ref, this->mtx.get(),
+            this->ref, this->mtx->get_const_device_view(),
             this->lookup.storage_offsets.get_const_data(),
             this->lookup.row_descs.get_const_data(),
             this->lookup.storage.get_const_data(), diag_idxs.get_data(),
-            transpose_idxs.get_data(), this->mtx_chol.get());
+            transpose_idxs.get_data(), this->mtx_chol->get_device_view());
         gko::kernels::GKO_DEVICE_NAMESPACE::cholesky::initialize(
-            this->exec, this->dmtx.get(),
+            this->exec, this->dmtx->get_const_device_view(),
             this->dlookup.storage_offsets.get_const_data(),
             this->dlookup.row_descs.get_const_data(),
             this->dlookup.storage.get_const_data(), ddiag_idxs.get_data(),
-            dtranspose_idxs.get_data(), this->dmtx_chol.get());
+            dtranspose_idxs.get_data(), this->dmtx_chol->get_device_view());
 
         GKO_ASSERT_MTX_NEAR(this->dmtx_chol, this->dmtx_chol, 0.0);
         GKO_ASSERT_ARRAY_EQ(diag_idxs, ddiag_idxs);
@@ -456,30 +462,30 @@ TYPED_TEST(Cholesky, KernelFactorizeIsEquivalentToRef)
         gko::array<int> tmp{this->ref};
         gko::array<int> dtmp{this->exec};
         gko::kernels::reference::cholesky::initialize(
-            this->ref, this->mtx.get(),
+            this->ref, this->mtx->get_const_device_view(),
             this->lookup.storage_offsets.get_const_data(),
             this->lookup.row_descs.get_const_data(),
             this->lookup.storage.get_const_data(), diag_idxs.get_data(),
-            transpose_idxs.get_data(), this->mtx_chol.get());
+            transpose_idxs.get_data(), this->mtx_chol->get_device_view());
         gko::kernels::GKO_DEVICE_NAMESPACE::cholesky::initialize(
-            this->exec, this->dmtx.get(),
+            this->exec, this->dmtx->get_const_device_view(),
             this->dlookup.storage_offsets.get_const_data(),
             this->dlookup.row_descs.get_const_data(),
             this->dlookup.storage.get_const_data(), ddiag_idxs.get_data(),
-            dtranspose_idxs.get_data(), this->dmtx_chol.get());
+            dtranspose_idxs.get_data(), this->dmtx_chol->get_device_view());
 
         gko::kernels::reference::cholesky::factorize(
             this->ref, this->lookup.storage_offsets.get_const_data(),
             this->lookup.row_descs.get_const_data(),
             this->lookup.storage.get_const_data(), diag_idxs.get_const_data(),
             transpose_idxs.get_const_data(), *this->forest,
-            this->mtx_chol.get(), true, tmp);
+            this->mtx_chol->get_device_view(), true, tmp);
         gko::kernels::GKO_DEVICE_NAMESPACE::cholesky::factorize(
             this->exec, this->dlookup.storage_offsets.get_const_data(),
             this->dlookup.row_descs.get_const_data(),
             this->dlookup.storage.get_const_data(), ddiag_idxs.get_const_data(),
             dtranspose_idxs.get_const_data(), *this->dforest,
-            this->dmtx_chol.get(), true, dtmp);
+            this->dmtx_chol->get_device_view(), true, dtmp);
 
         GKO_ASSERT_MTX_NEAR(this->mtx_chol, this->dmtx_chol,
                             r<value_type>::value);

--- a/test/factorization/factorization_kernels.cpp
+++ b/test/factorization/factorization_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -45,9 +45,9 @@ TEST_F(Factorization, InitializeRowPtrsLSameAsRef)
     gko::array<index_type> dl_ptrs{exec, mtx->get_size()[0] + 1};
 
     gko::kernels::reference::factorization::initialize_row_ptrs_l(
-        ref, mtx.get(), l_ptrs.get_data());
+        ref, mtx->get_const_device_view(), l_ptrs.get_data());
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::initialize_row_ptrs_l(
-        exec, dmtx.get(), dl_ptrs.get_data());
+        exec, dmtx->get_const_device_view(), dl_ptrs.get_data());
 
     GKO_ASSERT_ARRAY_EQ(l_ptrs, dl_ptrs);
 }
@@ -57,7 +57,7 @@ TEST_F(Factorization, InitializeLSameAsRef)
 {
     gko::array<index_type> l_ptrs{ref, mtx->get_size()[0] + 1};
     gko::kernels::reference::factorization::initialize_row_ptrs_l(
-        ref, mtx.get(), l_ptrs.get_data());
+        ref, mtx->get_const_device_view(), l_ptrs.get_data());
     auto nnz =
         static_cast<gko::size_type>(l_ptrs.get_data()[mtx->get_size()[0]]);
     auto l_mtx =
@@ -69,9 +69,11 @@ TEST_F(Factorization, InitializeLSameAsRef)
         SCOPED_TRACE("diag_sqrt: " + std::to_string(diag_sqrt));
 
         gko::kernels::reference::factorization::initialize_l(
-            ref, mtx.get(), l_mtx.get(), diag_sqrt);
+            ref, mtx->get_const_device_view(), l_mtx->get_device_view(),
+            diag_sqrt);
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::initialize_l(
-            exec, dmtx.get(), dl_mtx.get(), diag_sqrt);
+            exec, dmtx->get_const_device_view(), dl_mtx->get_device_view(),
+            diag_sqrt);
 
         GKO_ASSERT_MTX_NEAR(l_mtx, dl_mtx,
                             diag_sqrt ? r<value_type>::value : 0.0);

--- a/test/factorization/lu_kernels.cpp
+++ b/test/factorization/lu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -139,17 +139,17 @@ TYPED_TEST(Lu, KernelInitializeIsEquivalentToRef)
         gko::array<index_type> ddiag_idxs{this->exec, this->num_rows};
 
         gko::kernels::reference::lu_factorization::initialize(
-            this->ref, this->mtx.get(),
+            this->ref, this->mtx->get_const_device_view(),
             this->lookup.storage_offsets.get_const_data(),
             this->lookup.row_descs.get_const_data(),
             this->lookup.storage.get_const_data(), diag_idxs.get_data(),
-            this->mtx_lu.get());
+            this->mtx_lu->get_device_view());
         gko::kernels::GKO_DEVICE_NAMESPACE::lu_factorization::initialize(
-            this->exec, this->dmtx.get(),
+            this->exec, this->dmtx->get_const_device_view(),
             this->dlookup.storage_offsets.get_const_data(),
             this->dlookup.row_descs.get_const_data(),
             this->dlookup.storage.get_const_data(), ddiag_idxs.get_data(),
-            this->dmtx_lu.get());
+            this->dmtx_lu->get_device_view());
 
         GKO_ASSERT_MTX_NEAR(this->dmtx_lu, this->dmtx_lu, 0.0);
         GKO_ASSERT_ARRAY_EQ(diag_idxs, ddiag_idxs);
@@ -167,28 +167,28 @@ TYPED_TEST(Lu, KernelFactorizeIsEquivalentToRef)
         gko::array<int> tmp{this->ref};
         gko::array<int> dtmp{this->exec};
         gko::kernels::reference::lu_factorization::initialize(
-            this->ref, this->mtx.get(),
+            this->ref, this->mtx->get_const_device_view(),
             this->lookup.storage_offsets.get_const_data(),
             this->lookup.row_descs.get_const_data(),
             this->lookup.storage.get_const_data(), diag_idxs.get_data(),
-            this->mtx_lu.get());
+            this->mtx_lu->get_device_view());
         gko::kernels::GKO_DEVICE_NAMESPACE::lu_factorization::initialize(
-            this->exec, this->dmtx.get(),
+            this->exec, this->dmtx->get_const_device_view(),
             this->dlookup.storage_offsets.get_const_data(),
             this->dlookup.row_descs.get_const_data(),
             this->dlookup.storage.get_const_data(), ddiag_idxs.get_data(),
-            this->dmtx_lu.get());
+            this->dmtx_lu->get_device_view());
 
         gko::kernels::reference::lu_factorization::factorize(
             this->ref, this->lookup.storage_offsets.get_const_data(),
             this->lookup.row_descs.get_const_data(),
             this->lookup.storage.get_const_data(), diag_idxs.get_const_data(),
-            this->mtx_lu.get(), true, tmp);
+            this->mtx_lu->get_device_view(), true, tmp);
         gko::kernels::GKO_DEVICE_NAMESPACE::lu_factorization::factorize(
             this->exec, this->dlookup.storage_offsets.get_const_data(),
             this->dlookup.row_descs.get_const_data(),
             this->dlookup.storage.get_const_data(), ddiag_idxs.get_const_data(),
-            this->dmtx_lu.get(), true, dtmp);
+            this->dmtx_lu->get_device_view(), true, dtmp);
 
         GKO_ASSERT_MTX_NEAR(this->mtx_lu, this->dmtx_lu, r<value_type>::value);
     });
@@ -203,7 +203,8 @@ TYPED_TEST(Lu, KernelValidateValidFactors)
         bool valid = false;
 
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::symbolic_validate(
-            this->exec, this->dmtx.get(), this->dmtx_lu.get(),
+            this->exec, this->dmtx->get_const_device_view(),
+            this->dmtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->dmtx_lu.get()), valid);
 
         ASSERT_TRUE(valid);
@@ -227,7 +228,8 @@ TYPED_TEST(Lu, KernelValidateInvalidFactorsIdentity)
         this->dmtx_lu->read(data);
 
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::symbolic_validate(
-            this->exec, this->dmtx.get(), this->dmtx_lu.get(),
+            this->exec, this->dmtx->get_const_device_view(),
+            this->dmtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->dmtx_lu.get()), valid);
 
         ASSERT_FALSE(valid);
@@ -249,7 +251,8 @@ TYPED_TEST(Lu, KernelValidateInvalidFactorsMissing)
         this->dmtx_lu->read(data);
 
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::symbolic_validate(
-            this->exec, this->dmtx.get(), this->dmtx_lu.get(),
+            this->exec, this->dmtx->get_const_device_view(),
+            this->dmtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->dmtx_lu.get()), valid);
 
         ASSERT_FALSE(valid);
@@ -276,7 +279,8 @@ TYPED_TEST(Lu, KernelValidateInvalidFactorsExtra)
         this->dmtx_lu->read(data);
 
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::symbolic_validate(
-            this->exec, this->dmtx.get(), this->dmtx_lu.get(),
+            this->exec, this->dmtx->get_const_device_view(),
+            this->dmtx_lu->get_const_device_view(),
             gko::matrix::csr::build_lookup(this->dmtx_lu.get()), valid);
 
         ASSERT_FALSE(valid);

--- a/test/factorization/par_ic_kernels.cpp
+++ b/test/factorization/par_ic_kernels.cpp
@@ -56,16 +56,18 @@ protected:
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
                 mtx_l_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l(
-                ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs());
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_row_ptrs());
             auto l_nnz =
                 mtx_l_ani->get_const_row_ptrs()[mtx_ani->get_size()[0]];
             l_builder.get_col_idx_array().resize_and_reset(l_nnz);
             l_builder.get_value_array().resize_and_reset(l_nnz);
             gko::kernels::reference::factorization::initialize_l(
-                ref, mtx_ani.get(), mtx_l_ani.get(), false);
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_device_view(), false);
             mtx_l_ani_init = gko::clone(ref, mtx_l_ani);
             gko::kernels::reference::par_ic_factorization::init_factor(
-                ref, mtx_l_ani_init.get());
+                ref, mtx_l_ani_init->get_device_view());
         }
         dmtx_ani->copy_from(mtx_ani);
         dmtx_l_ani->copy_from(mtx_l_ani);
@@ -94,9 +96,9 @@ TYPED_TEST(ParIc, KernelInitFactorIsEquivalentToRef)
     using value_type = typename TestFixture::value_type;
 
     gko::kernels::reference::par_ic_factorization::init_factor(
-        this->ref, this->mtx_l.get());
+        this->ref, this->mtx_l->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ic_factorization::init_factor(
-        this->exec, this->dmtx_l.get());
+        this->exec, this->dmtx_l->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(this->mtx_l, this->dmtx_l, r<value_type>::value);
 }
@@ -129,10 +131,10 @@ TYPED_TEST(ParIc, KernelComputeFactorIsEquivalentToRef)
 
     gko::kernels::reference::par_ic_factorization::compute_factor(
         this->ref, 1, mtx_l_coo->get_const_device_view(),
-        this->mtx_l_ani_init.get());
+        this->mtx_l_ani_init->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ic_factorization::compute_factor(
         this->exec, 100, dmtx_l_coo->get_const_device_view(),
-        this->dmtx_l_ani_init.get());
+        this->dmtx_l_ani_init->get_device_view());
 
     GKO_EXPECT_MTX_NEAR(this->mtx_l_ani_init, this->dmtx_l_ani_init, tol);
 }

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -67,13 +67,15 @@ protected:
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
                 mtx_l_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l(
-                ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs());
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_row_ptrs());
             auto l_nnz =
                 mtx_l_ani->get_const_row_ptrs()[mtx_ani->get_size()[0]];
             l_builder.get_col_idx_array().resize_and_reset(l_nnz);
             l_builder.get_value_array().resize_and_reset(l_nnz);
             gko::kernels::reference::factorization::initialize_l(
-                ref, mtx_ani.get(), mtx_l_ani.get(), true);
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_device_view(), true);
         }
         dmtx_ani->copy_from(mtx_ani);
         dmtx_l_ani->copy_from(mtx_l_ani);
@@ -121,10 +123,14 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
     auto dres_mtx_l = Csr::create(this->exec, this->mtx_size);
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, mtx_llh.get(), this->mtx.get(), this->mtx_l.get(),
+        this->ref, mtx_llh->get_const_device_view(),
+        this->mtx->get_const_device_view(),
+        this->mtx_l->get_const_device_view(),
         gko::matrix::make_builder_unique_ptr(res_mtx_l).get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::add_candidates(
-        this->exec, dmtx_llh.get(), this->dmtx.get(), this->dmtx_l.get(),
+        this->exec, dmtx_llh->get_const_device_view(),
+        this->dmtx->get_const_device_view(),
+        this->dmtx_l->get_const_device_view(),
         gko::matrix::make_builder_unique_ptr(dres_mtx_l).get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
@@ -149,12 +155,12 @@ TYPED_TEST(ParIct, KernelComputeFactorIsEquivalentToRef)
     dmtx_l_coo->copy_from(mtx_l_coo);
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
-        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(),
-        mtx_l_coo->get_const_device_view());
+        this->ref, this->mtx_ani->get_const_device_view(),
+        this->mtx_l_ani->get_device_view(), mtx_l_coo->get_const_device_view());
     for (int i = 0; i < 20; ++i) {
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::
-            compute_factor(this->exec, this->dmtx_ani.get(),
-                           this->dmtx_l_ani.get(),
+            compute_factor(this->exec, this->dmtx_ani->get_const_device_view(),
+                           this->dmtx_l_ani->get_device_view(),
                            dmtx_l_coo->get_const_device_view());
     }
 

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -67,13 +67,15 @@ protected:
             gko::matrix::CsrBuilder<value_type, index_type> l_builder(
                 mtx_l_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l(
-                ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs());
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_row_ptrs());
             auto l_nnz =
                 mtx_l_ani->get_const_row_ptrs()[mtx_ani->get_size()[0]];
             l_builder.get_col_idx_array().resize_and_reset(l_nnz);
             l_builder.get_value_array().resize_and_reset(l_nnz);
             gko::kernels::reference::factorization::initialize_l(
-                ref, mtx_ani.get(), mtx_l_ani.get(), true);
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_device_view(), true);
         }
         dmtx_ani->copy_from(mtx_ani);
         dmtx_l_ani->copy_from(mtx_l_ani);
@@ -121,11 +123,13 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
     auto dres_mtx_l = Csr::create(this->exec, this->mtx_size);
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, mtx_llh.get(), this->mtx.get(), this->mtx_l.get(),
-        res_mtx_l.get());
+        this->ref, mtx_llh->get_const_device_view(),
+        this->mtx->get_const_device_view(),
+        this->mtx_l->get_const_device_view(), res_mtx_l.get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::add_candidates(
-        this->exec, dmtx_llh.get(), this->dmtx.get(), this->dmtx_l.get(),
-        dres_mtx_l.get());
+        this->exec, dmtx_llh->get_const_device_view(),
+        this->dmtx->get_const_device_view(),
+        this->dmtx_l->get_const_device_view(), dres_mtx_l.get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, dres_mtx_l, r<value_type>::value);
@@ -149,12 +153,12 @@ TYPED_TEST(ParIct, KernelComputeFactorIsEquivalentToRef)
     dmtx_l_coo->copy_from(mtx_l_coo);
 
     gko::kernels::reference::par_ict_factorization::compute_factor(
-        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(),
-        mtx_l_coo->get_const_device_view());
+        this->ref, this->mtx_ani->get_const_device_view(),
+        this->mtx_l_ani->get_device_view(), mtx_l_coo->get_const_device_view());
     for (int i = 0; i < 20; ++i) {
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::
-            compute_factor(this->exec, this->dmtx_ani.get(),
-                           this->dmtx_l_ani.get(),
+            compute_factor(this->exec, this->dmtx_ani->get_const_device_view(),
+                           this->dmtx_l_ani->get_device_view(),
                            dmtx_l_coo->get_const_device_view());
     }
 

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -123,12 +123,10 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
     auto dres_mtx_l = Csr::create(this->exec, this->mtx_size);
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, mtx_llh->get_const_device_view(),
-        this->mtx->get_const_device_view(),
+        this->ref, mtx_llh.get(), this->mtx.get(),
         this->mtx_l->get_const_device_view(), res_mtx_l.get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::add_candidates(
-        this->exec, dmtx_llh->get_const_device_view(),
-        this->dmtx->get_const_device_view(),
+        this->exec, dmtx_llh.get(), this->dmtx.get(),
         this->dmtx_l->get_const_device_view(), dres_mtx_l.get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -83,9 +83,10 @@ protected:
                              index_type* dl_row_ptrs, index_type* du_row_ptrs)
     {
         gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
-            ref, mtx.get(), l_row_ptrs, u_row_ptrs);
+            ref, mtx->get_const_device_view(), l_row_ptrs, u_row_ptrs);
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::
-            initialize_row_ptrs_l_u(exec, dmtx.get(), dl_row_ptrs, du_row_ptrs);
+            initialize_row_ptrs_l_u(exec, dmtx->get_const_device_view(),
+                                    dl_row_ptrs, du_row_ptrs);
     }
 
     void initialize_lu(std::unique_ptr<Csr>& l, std::unique_ptr<Csr>& u,
@@ -115,9 +116,11 @@ protected:
         exec->copy(num_row_ptrs, du_row_ptrs.get_data(), du->get_row_ptrs());
 
         gko::kernels::reference::factorization::initialize_l_u(
-            ref, mtx.get(), l.get(), u.get());
+            ref, mtx->get_const_device_view(), l->get_device_view(),
+            u->get_device_view());
         gko::kernels::GKO_DEVICE_NAMESPACE::factorization::initialize_l_u(
-            exec, dmtx.get(), dl.get(), du.get());
+            exec, dmtx->get_const_device_view(), dl->get_device_view(),
+            du->get_device_view());
     }
 
     void compute_lu(std::unique_ptr<Csr>& l, std::unique_ptr<Csr>& u,
@@ -133,11 +136,12 @@ protected:
         auto u_transpose_dmtx = gko::as<Csr>(du->transpose());
 
         gko::kernels::reference::par_ilu_factorization::compute_l_u_factors(
-            ref, iterations, coo->get_const_device_view(), l.get(),
-            u_transpose_mtx.get());
+            ref, iterations, coo->get_const_device_view(), l->get_device_view(),
+            u_transpose_mtx->get_device_view());
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilu_factorization::
             compute_l_u_factors(exec, iterations, dcoo->get_const_device_view(),
-                                dl.get(), u_transpose_dmtx.get());
+                                dl->get_device_view(),
+                                u_transpose_dmtx->get_device_view());
         auto u_lin_op = u_transpose_mtx->transpose();
         u = gko::as<Csr>(std::move(u_lin_op));
         auto du_lin_op = u_transpose_dmtx->transpose();

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -98,8 +98,8 @@ protected:
             gko::matrix::CsrBuilder<value_type, index_type> u_builder(
                 mtx_u_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
-                ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs(),
-                mtx_u_ani->get_row_ptrs());
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_row_ptrs(), mtx_u_ani->get_row_ptrs());
             auto l_nnz =
                 mtx_l_ani->get_const_row_ptrs()[mtx_ani->get_size()[0]];
             auto u_nnz =
@@ -109,11 +109,13 @@ protected:
             u_builder.get_col_idx_array().resize_and_reset(u_nnz);
             u_builder.get_value_array().resize_and_reset(u_nnz);
             gko::kernels::reference::factorization::initialize_l_u(
-                ref, mtx_ani.get(), mtx_l_ani.get(), mtx_u_ani.get());
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_device_view(), mtx_u_ani->get_device_view());
             mtx_ut_ani = Csr::create(ref, mtx_ani->get_size(),
                                      mtx_u_ani->get_num_stored_elements());
-            gko::kernels::reference::csr::transpose(ref, mtx_u_ani.get(),
-                                                    mtx_ut_ani.get());
+            gko::kernels::reference::csr::transpose(
+                ref, mtx_u_ani->get_const_device_view(),
+                mtx_ut_ani->get_device_view());
         }
         dmtx_ani->copy_from(mtx_ani);
         dmtx_l_ani->copy_from(mtx_l_ani);
@@ -138,9 +140,10 @@ protected:
         gko::array<gko::remove_complex<ValueType>> dtmp2(exec);
 
         gko::kernels::reference::par_ilut_factorization::threshold_select(
-            ref, mtx.get(), rank, tmp, tmp2, res);
+            ref, mtx->get_const_device_view(), rank, tmp, tmp2, res);
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_select(exec, dmtx.get(), rank, dtmp, dtmp2, dres);
+            threshold_select(exec, dmtx->get_const_device_view(), rank, dtmp,
+                             dtmp2, dres);
 
         ASSERT_NEAR(res, dres, tolerance);
     }
@@ -161,11 +164,12 @@ protected:
             gko::as<Mtx>(lower ? dmtx->clone() : dmtx->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold,
+            ref, local_mtx->get_const_device_view(), threshold,
             gko::matrix::make_builder_unique_ptr(res).get(), res_coo.get(),
             lower);
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_filter(exec, local_dmtx.get(), threshold,
+            threshold_filter(exec, local_dmtx->get_const_device_view(),
+                             threshold,
                              gko::matrix::make_builder_unique_ptr(dres).get(),
                              dres_coo.get(), lower);
 
@@ -198,11 +202,11 @@ protected:
 
         gko::kernels::reference::par_ilut_factorization::
             threshold_filter_approx(
-                ref, mtx.get(), rank, tmp, threshold,
+                ref, mtx->get_const_device_view(), rank, tmp, threshold,
                 gko::matrix::make_builder_unique_ptr(res).get(), res_coo.get());
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
             threshold_filter_approx(
-                exec, dmtx.get(), rank, dtmp, dthreshold,
+                exec, dmtx->get_const_device_view(), rank, dtmp, dthreshold,
                 gko::matrix::make_builder_unique_ptr(dres).get(),
                 dres_coo.get());
 
@@ -299,10 +303,10 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCooIsEquivalentToRef)
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx_l.get(), 0.5,
+        this->ref, this->mtx_l->get_const_device_view(), 0.5,
         gko::matrix::make_builder_unique_ptr(res).get(), null_coo, true);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-        threshold_filter(this->exec, this->dmtx_l.get(), 0.5,
+        threshold_filter(this->exec, this->dmtx_l->get_const_device_view(), 0.5,
                          gko::matrix::make_builder_unique_ptr(dres).get(),
                          null_coo, true);
 
@@ -371,12 +375,13 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCooIsEquivalentToRef)
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx_l.get(), rank, tmp, threshold,
+        this->ref, this->mtx_l->get_const_device_view(), rank, tmp, threshold,
         gko::matrix::make_builder_unique_ptr(res).get(), null_coo);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
         threshold_filter_approx(
-            this->exec, this->dmtx_l.get(), rank, dtmp, dthreshold,
-            gko::matrix::make_builder_unique_ptr(dres).get(), null_coo);
+            this->exec, this->dmtx_l->get_const_device_view(), rank, dtmp,
+            dthreshold, gko::matrix::make_builder_unique_ptr(dres).get(),
+            null_coo);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -458,13 +463,17 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
     auto dres_mtx_u = Csr::create(this->exec, square_size);
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
-        this->ref, mtx_lu.get(), this->mtx_square.get(), this->mtx_l2.get(),
-        this->mtx_u.get(),
+        this->ref, mtx_lu->get_const_device_view(),
+        this->mtx_square->get_const_device_view(),
+        this->mtx_l2->get_const_device_view(),
+        this->mtx_u->get_const_device_view(),
         gko::matrix::make_builder_unique_ptr(res_mtx_l).get(),
         gko::matrix::make_builder_unique_ptr(res_mtx_u).get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::add_candidates(
-        this->exec, dmtx_lu.get(), this->dmtx_square.get(), this->dmtx_l2.get(),
-        this->dmtx_u.get(),
+        this->exec, dmtx_lu->get_const_device_view(),
+        this->dmtx_square->get_const_device_view(),
+        this->dmtx_l2->get_const_device_view(),
+        this->dmtx_u->get_const_device_view(),
         gko::matrix::make_builder_unique_ptr(dres_mtx_l).get(),
         gko::matrix::make_builder_unique_ptr(dres_mtx_u).get());
 
@@ -496,15 +505,19 @@ TYPED_TEST(ParIlut, KernelComputeLUIsEquivalentToRef)
     dmtx_u_coo->copy_from(mtx_u_coo);
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
-        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(),
-        mtx_l_coo->get_const_device_view(), this->mtx_u_ani.get(),
-        mtx_u_coo->get_const_device_view(), this->mtx_ut_ani.get());
+        this->ref, this->mtx_ani->get_const_device_view(),
+        this->mtx_l_ani->get_device_view(), mtx_l_coo->get_const_device_view(),
+        this->mtx_u_ani->get_device_view(), mtx_u_coo->get_const_device_view(),
+        this->mtx_ut_ani->get_device_view());
     for (int i = 0; i < 20; ++i) {
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            compute_l_u_factors(
-                this->exec, this->dmtx_ani.get(), this->dmtx_l_ani.get(),
-                dmtx_l_coo->get_const_device_view(), this->dmtx_u_ani.get(),
-                dmtx_u_coo->get_const_device_view(), this->dmtx_ut_ani.get());
+            compute_l_u_factors(this->exec,
+                                this->dmtx_ani->get_const_device_view(),
+                                this->dmtx_l_ani->get_device_view(),
+                                dmtx_l_coo->get_const_device_view(),
+                                this->dmtx_u_ani->get_device_view(),
+                                dmtx_u_coo->get_const_device_view(),
+                                this->dmtx_ut_ani->get_device_view());
     }
     auto dmtx_utt_ani = gko::as<Csr>(this->dmtx_ut_ani->transpose());
 

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -98,8 +98,8 @@ protected:
             gko::matrix::CsrBuilder<value_type, index_type> u_builder(
                 mtx_u_ani);
             gko::kernels::reference::factorization::initialize_row_ptrs_l_u(
-                ref, mtx_ani.get(), mtx_l_ani->get_row_ptrs(),
-                mtx_u_ani->get_row_ptrs());
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_row_ptrs(), mtx_u_ani->get_row_ptrs());
             auto l_nnz =
                 mtx_l_ani->get_const_row_ptrs()[mtx_ani->get_size()[0]];
             auto u_nnz =
@@ -109,11 +109,13 @@ protected:
             u_builder.get_col_idx_array().resize_and_reset(u_nnz);
             u_builder.get_value_array().resize_and_reset(u_nnz);
             gko::kernels::reference::factorization::initialize_l_u(
-                ref, mtx_ani.get(), mtx_l_ani.get(), mtx_u_ani.get());
+                ref, mtx_ani->get_const_device_view(),
+                mtx_l_ani->get_device_view(), mtx_u_ani->get_device_view());
             mtx_ut_ani = Csr::create(ref, mtx_ani->get_size(),
                                      mtx_u_ani->get_num_stored_elements());
-            gko::kernels::reference::csr::transpose(ref, mtx_u_ani.get(),
-                                                    mtx_ut_ani.get());
+            gko::kernels::reference::csr::transpose(
+                ref, mtx_u_ani->get_const_device_view(),
+                mtx_ut_ani->get_device_view());
         }
         dmtx_ani->copy_from(mtx_ani);
         dmtx_l_ani->copy_from(mtx_l_ani);
@@ -138,9 +140,10 @@ protected:
         gko::array<gko::remove_complex<ValueType>> dtmp2(exec);
 
         gko::kernels::reference::par_ilut_factorization::threshold_select(
-            ref, mtx.get(), rank, tmp, tmp2, res);
+            ref, mtx->get_const_device_view(), rank, tmp, tmp2, res);
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_select(exec, dmtx.get(), rank, dtmp, dtmp2, dres);
+            threshold_select(exec, dmtx->get_const_device_view(), rank, dtmp,
+                             dtmp2, dres);
 
         ASSERT_NEAR(res, dres, tolerance);
     }
@@ -161,10 +164,11 @@ protected:
             gko::as<Mtx>(lower ? dmtx->clone() : dmtx->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, res.get(), res_coo.get(), lower);
+            ref, local_mtx->get_const_device_view(), threshold, res.get(),
+            res_coo.get(), lower);
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_filter(exec, local_dmtx.get(), threshold, dres.get(),
-                             dres_coo.get(), lower);
+            threshold_filter(exec, local_dmtx->get_const_device_view(),
+                             threshold, dres.get(), dres_coo.get(), lower);
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
         GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -194,11 +198,12 @@ protected:
         gko::remove_complex<ValueType> dthreshold{};
 
         gko::kernels::reference::par_ilut_factorization::
-            threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    res.get(), res_coo.get());
+            threshold_filter_approx(ref, mtx->get_const_device_view(), rank,
+                                    tmp, threshold, res.get(), res_coo.get());
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_filter_approx(exec, dmtx.get(), rank, dtmp, dthreshold,
-                                    dres.get(), dres_coo.get());
+            threshold_filter_approx(exec, dmtx->get_const_device_view(), rank,
+                                    dtmp, dthreshold, dres.get(),
+                                    dres_coo.get());
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
         GKO_ASSERT_MTX_NEAR(res, res_coo, 0);
@@ -293,10 +298,11 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCooIsEquivalentToRef)
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx_l.get(), 0.5, res.get(), null_coo, true);
+        this->ref, this->mtx_l->get_const_device_view(), 0.5, res.get(),
+        null_coo, true);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-        threshold_filter(this->exec, this->dmtx_l.get(), 0.5, dres.get(),
-                         null_coo, true);
+        threshold_filter(this->exec, this->dmtx_l->get_const_device_view(), 0.5,
+                         dres.get(), null_coo, true);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -363,11 +369,12 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCooIsEquivalentToRef)
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx_l.get(), rank, tmp, threshold, res.get(),
-        null_coo);
+        this->ref, this->mtx_l->get_const_device_view(), rank, tmp, threshold,
+        res.get(), null_coo);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-        threshold_filter_approx(this->exec, this->dmtx_l.get(), rank, dtmp,
-                                dthreshold, dres.get(), null_coo);
+        threshold_filter_approx(this->exec,
+                                this->dmtx_l->get_const_device_view(), rank,
+                                dtmp, dthreshold, dres.get(), null_coo);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -449,11 +456,16 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
     auto dres_mtx_u = Csr::create(this->exec, square_size);
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
-        this->ref, mtx_lu.get(), this->mtx_square.get(), this->mtx_l2.get(),
-        this->mtx_u.get(), res_mtx_l.get(), res_mtx_u.get());
+        this->ref, mtx_lu->get_const_device_view(),
+        this->mtx_square->get_const_device_view(),
+        this->mtx_l2->get_const_device_view(),
+        this->mtx_u->get_const_device_view(), res_mtx_l.get(), res_mtx_u.get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::add_candidates(
-        this->exec, dmtx_lu.get(), this->dmtx_square.get(), this->dmtx_l2.get(),
-        this->dmtx_u.get(), dres_mtx_l.get(), dres_mtx_u.get());
+        this->exec, dmtx_lu->get_const_device_view(),
+        this->dmtx_square->get_const_device_view(),
+        this->dmtx_l2->get_const_device_view(),
+        this->dmtx_u->get_const_device_view(), dres_mtx_l.get(),
+        dres_mtx_u.get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, dres_mtx_u);
@@ -483,15 +495,19 @@ TYPED_TEST(ParIlut, KernelComputeLUIsEquivalentToRef)
     dmtx_u_coo->copy_from(mtx_u_coo);
 
     gko::kernels::reference::par_ilut_factorization::compute_l_u_factors(
-        this->ref, this->mtx_ani.get(), this->mtx_l_ani.get(),
-        mtx_l_coo->get_const_device_view(), this->mtx_u_ani.get(),
-        mtx_u_coo->get_const_device_view(), this->mtx_ut_ani.get());
+        this->ref, this->mtx_ani->get_const_device_view(),
+        this->mtx_l_ani->get_device_view(), mtx_l_coo->get_const_device_view(),
+        this->mtx_u_ani->get_device_view(), mtx_u_coo->get_const_device_view(),
+        this->mtx_ut_ani->get_device_view());
     for (int i = 0; i < 20; ++i) {
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            compute_l_u_factors(
-                this->exec, this->dmtx_ani.get(), this->dmtx_l_ani.get(),
-                dmtx_l_coo->get_const_device_view(), this->dmtx_u_ani.get(),
-                dmtx_u_coo->get_const_device_view(), this->dmtx_ut_ani.get());
+            compute_l_u_factors(this->exec,
+                                this->dmtx_ani->get_const_device_view(),
+                                this->dmtx_l_ani->get_device_view(),
+                                dmtx_l_coo->get_const_device_view(),
+                                this->dmtx_u_ani->get_device_view(),
+                                dmtx_u_coo->get_const_device_view(),
+                                this->dmtx_ut_ani->get_device_view());
     }
     auto dmtx_utt_ani = gko::as<Csr>(this->dmtx_ut_ani->transpose());
 

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -456,13 +456,11 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
     auto dres_mtx_u = Csr::create(this->exec, square_size);
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
-        this->ref, mtx_lu->get_const_device_view(),
-        this->mtx_square->get_const_device_view(),
+        this->ref, mtx_lu.get(), this->mtx_square.get(),
         this->mtx_l2->get_const_device_view(),
         this->mtx_u->get_const_device_view(), res_mtx_l.get(), res_mtx_u.get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::add_candidates(
-        this->exec, dmtx_lu->get_const_device_view(),
-        this->dmtx_square->get_const_device_view(),
+        this->exec, dmtx_lu.get(), this->dmtx_square.get(),
         this->dmtx_l2->get_const_device_view(),
         this->dmtx_u->get_const_device_view(), dres_mtx_l.get(),
         dres_mtx_u.get());

--- a/test/matrix/csr_kernels.cpp
+++ b/test/matrix/csr_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -86,9 +86,10 @@ TEST_F(Csr, RowWiseSumIsEquivalentToRef)
     gko::array<value_type> sum{ref, x->get_size()[0]};
     gko::array<value_type> dsum{exec, dx->get_size()[0]};
 
-    gko::kernels::reference::csr::row_wise_absolute_sum(ref, x.get(), sum);
+    gko::kernels::reference::csr::row_wise_absolute_sum(
+        ref, x->get_const_device_view(), sum);
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::row_wise_absolute_sum(
-        exec, dx.get(), dsum);
+        exec, dx->get_const_device_view(), dsum);
 
     GKO_ASSERT_ARRAY_EQ(sum, dsum);
 }

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -1681,9 +1681,10 @@ TEST_F(Csr, CalculateNnzPerRowInSpanIsEquivalentToRef)
     auto drow_nnz = gko::array<int>(this->exec, row_nnz);
 
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_span(
-        this->ref, this->mtx2.get(), rspan, cspan, row_nnz);
+        this->ref, this->mtx2->get_const_device_view(), rspan, cspan, row_nnz);
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::calculate_nonzeros_per_row_in_span(
-        this->exec, this->dmtx2.get(), rspan, cspan, drow_nnz);
+        this->exec, this->dmtx2->get_const_device_view(), rspan, cspan,
+        drow_nnz);
 
     GKO_ASSERT_ARRAY_EQ(row_nnz, drow_nnz);
 }
@@ -1699,7 +1700,7 @@ TEST_F(Csr, ComputeSubmatrixIsEquivalentToRef)
     auto row_nnz = gko::array<int>(this->ref, rspan.length() + 1);
     row_nnz.fill(gko::zero<int>());
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_span(
-        this->ref, this->mtx2.get(), rspan, cspan, row_nnz);
+        this->ref, this->mtx2->get_const_device_view(), rspan, cspan, row_nnz);
     gko::kernels::reference::components::prefix_sum_nonnegative(
         this->ref, row_nnz.get_data(), row_nnz.get_size());
     auto num_nnz = row_nnz.get_data()[rspan.length()];
@@ -1716,10 +1717,12 @@ TEST_F(Csr, ComputeSubmatrixIsEquivalentToRef)
                     std::move(drow_nnz));
 
 
-    gko::kernels::reference::csr::compute_submatrix(this->ref, this->mtx2.get(),
-                                                    rspan, cspan, smat1.get());
+    gko::kernels::reference::csr::compute_submatrix(
+        this->ref, this->mtx2->get_const_device_view(), rspan, cspan,
+        smat1->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::compute_submatrix(
-        this->exec, this->dmtx2.get(), rspan, cspan, sdmat1.get());
+        this->exec, this->dmtx2->get_const_device_view(), rspan, cspan,
+        sdmat1->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(sdmat1, smat1, 0.0);
 }
@@ -1743,10 +1746,12 @@ TEST_F(Csr, CalculateNnzPerRowInIndexSetIsEquivalentToRef)
     auto drow_nnz = gko::array<int>(this->exec, row_nnz);
 
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_index_set(
-        this->ref, this->mtx2.get(), rset, cset, row_nnz.get_data());
+        this->ref, this->mtx2->get_const_device_view(), rset, cset,
+        row_nnz.get_data());
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::
         calculate_nonzeros_per_row_in_index_set(
-            this->exec, this->dmtx2.get(), drset, dcset, drow_nnz.get_data());
+            this->exec, this->dmtx2->get_const_device_view(), drset, dcset,
+            drow_nnz.get_data());
 
     GKO_ASSERT_ARRAY_EQ(row_nnz, drow_nnz);
 }
@@ -1765,7 +1770,8 @@ TEST_F(Csr, ComputeSubmatrixFromIndexSetIsEquivalentToRef)
     auto row_nnz = gko::array<int>(this->ref, rset.get_size() + 1);
     row_nnz.fill(gko::zero<int>());
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_index_set(
-        this->ref, this->mtx2.get(), rset, cset, row_nnz.get_data());
+        this->ref, this->mtx2->get_const_device_view(), rset, cset,
+        row_nnz.get_data());
     gko::kernels::reference::components::prefix_sum_nonnegative(
         this->ref, row_nnz.get_data(), row_nnz.get_size());
     auto num_nnz = row_nnz.get_data()[rset.get_size()];
@@ -1782,9 +1788,11 @@ TEST_F(Csr, ComputeSubmatrixFromIndexSetIsEquivalentToRef)
                     std::move(drow_nnz));
 
     gko::kernels::reference::csr::compute_submatrix_from_index_set(
-        this->ref, this->mtx2.get(), rset, cset, smat1.get());
+        this->ref, this->mtx2->get_const_device_view(), rset, cset,
+        smat1->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::compute_submatrix_from_index_set(
-        this->exec, this->dmtx2.get(), drset, dcset, sdmat1.get());
+        this->exec, this->dmtx2->get_const_device_view(), drset, dcset,
+        sdmat1->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(sdmat1, smat1, 0.0);
 }
@@ -1839,7 +1847,7 @@ TEST_F(Csr, CanDetectMissingDiagonalEntry)
     bool has_diags = true;
 
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::check_diagonal_entries_exist(
-        exec, mtx.get(), has_diags);
+        exec, mtx->get_const_device_view(), has_diags);
 
     ASSERT_FALSE(has_diags);
 }
@@ -1854,7 +1862,7 @@ TEST_F(Csr, CanDetectWhenAllDiagonalEntriesArePresent)
     bool has_diags = true;
 
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::check_diagonal_entries_exist(
-        exec, mtx.get(), has_diags);
+        exec, mtx->get_const_device_view(), has_diags);
 
     ASSERT_TRUE(has_diags);
 }

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -1655,9 +1655,10 @@ TEST_F(Csr, CalculateNnzPerRowInSpanIsEquivalentToRef)
     auto drow_nnz = gko::array<int>(this->exec, row_nnz);
 
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_span(
-        this->ref, this->mtx2.get(), rspan, cspan, row_nnz);
+        this->ref, this->mtx2->get_const_device_view(), rspan, cspan, row_nnz);
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::calculate_nonzeros_per_row_in_span(
-        this->exec, this->dmtx2.get(), rspan, cspan, drow_nnz);
+        this->exec, this->dmtx2->get_const_device_view(), rspan, cspan,
+        drow_nnz);
 
     GKO_ASSERT_ARRAY_EQ(row_nnz, drow_nnz);
 }
@@ -1673,7 +1674,7 @@ TEST_F(Csr, ComputeSubmatrixIsEquivalentToRef)
     auto row_nnz = gko::array<int>(this->ref, rspan.length() + 1);
     row_nnz.fill(gko::zero<int>());
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_span(
-        this->ref, this->mtx2.get(), rspan, cspan, row_nnz);
+        this->ref, this->mtx2->get_const_device_view(), rspan, cspan, row_nnz);
     gko::kernels::reference::components::prefix_sum_nonnegative(
         this->ref, row_nnz.get_data(), row_nnz.get_size());
     auto num_nnz = row_nnz.get_data()[rspan.length()];
@@ -1690,10 +1691,12 @@ TEST_F(Csr, ComputeSubmatrixIsEquivalentToRef)
                     std::move(drow_nnz));
 
 
-    gko::kernels::reference::csr::compute_submatrix(this->ref, this->mtx2.get(),
-                                                    rspan, cspan, smat1.get());
+    gko::kernels::reference::csr::compute_submatrix(
+        this->ref, this->mtx2->get_const_device_view(), rspan, cspan,
+        smat1->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::compute_submatrix(
-        this->exec, this->dmtx2.get(), rspan, cspan, sdmat1.get());
+        this->exec, this->dmtx2->get_const_device_view(), rspan, cspan,
+        sdmat1->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(sdmat1, smat1, 0.0);
 }
@@ -1717,10 +1720,12 @@ TEST_F(Csr, CalculateNnzPerRowInIndexSetIsEquivalentToRef)
     auto drow_nnz = gko::array<int>(this->exec, row_nnz);
 
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_index_set(
-        this->ref, this->mtx2.get(), rset, cset, row_nnz.get_data());
+        this->ref, this->mtx2->get_const_device_view(), rset, cset,
+        row_nnz.get_data());
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::
         calculate_nonzeros_per_row_in_index_set(
-            this->exec, this->dmtx2.get(), drset, dcset, drow_nnz.get_data());
+            this->exec, this->dmtx2->get_const_device_view(), drset, dcset,
+            drow_nnz.get_data());
 
     GKO_ASSERT_ARRAY_EQ(row_nnz, drow_nnz);
 }
@@ -1739,7 +1744,8 @@ TEST_F(Csr, ComputeSubmatrixFromIndexSetIsEquivalentToRef)
     auto row_nnz = gko::array<int>(this->ref, rset.get_size() + 1);
     row_nnz.fill(gko::zero<int>());
     gko::kernels::reference::csr::calculate_nonzeros_per_row_in_index_set(
-        this->ref, this->mtx2.get(), rset, cset, row_nnz.get_data());
+        this->ref, this->mtx2->get_const_device_view(), rset, cset,
+        row_nnz.get_data());
     gko::kernels::reference::components::prefix_sum_nonnegative(
         this->ref, row_nnz.get_data(), row_nnz.get_size());
     auto num_nnz = row_nnz.get_data()[rset.get_size()];
@@ -1756,9 +1762,11 @@ TEST_F(Csr, ComputeSubmatrixFromIndexSetIsEquivalentToRef)
                     std::move(drow_nnz));
 
     gko::kernels::reference::csr::compute_submatrix_from_index_set(
-        this->ref, this->mtx2.get(), rset, cset, smat1.get());
+        this->ref, this->mtx2->get_const_device_view(), rset, cset,
+        smat1->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::compute_submatrix_from_index_set(
-        this->exec, this->dmtx2.get(), drset, dcset, sdmat1.get());
+        this->exec, this->dmtx2->get_const_device_view(), drset, dcset,
+        sdmat1->get_device_view());
 
     GKO_ASSERT_MTX_NEAR(sdmat1, smat1, 0.0);
 }
@@ -1813,7 +1821,7 @@ TEST_F(Csr, CanDetectMissingDiagonalEntry)
     bool has_diags = true;
 
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::check_diagonal_entries_exist(
-        exec, mtx.get(), has_diags);
+        exec, mtx->get_const_device_view(), has_diags);
 
     ASSERT_FALSE(has_diags);
 }
@@ -1828,7 +1836,7 @@ TEST_F(Csr, CanDetectWhenAllDiagonalEntriesArePresent)
     bool has_diags = true;
 
     gko::kernels::GKO_DEVICE_NAMESPACE::csr::check_diagonal_entries_exist(
-        exec, mtx.get(), has_diags);
+        exec, mtx->get_const_device_view(), has_diags);
 
     ASSERT_TRUE(has_diags);
 }

--- a/test/matrix/device_views.cpp
+++ b/test/matrix/device_views.cpp
@@ -122,24 +122,27 @@ void assert_csr_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
     gko::array<ValueType> values{exec, 3};
     gko::array<IndexType> row_ptrs{exec, 3};
     gko::array<IndexType> col_idxs{exec, 3};
+    gko::array<IndexType> srow{exec, 2};
     values.fill(gko::one<ValueType>());
     row_ptrs.fill(IndexType{0});
     col_idxs.fill(IndexType{1});
+    srow.fill(IndexType{2});
     gko::kernels::GKO_DEVICE_NAMESPACE::run_kernel(
         exec,
         [] GKO_KERNEL(auto i, auto values, auto row_ptrs, auto col_idxs,
-                      auto correct) {
+                      auto srow, auto correct) {
             using vt = std::decay_t<decltype(values[0])>;
             using it = std::decay_t<decltype(row_ptrs[0])>;
-            gko::matrix::view::csr<vt, it> view{gko::dim<2>{3, 3}, 3, values,
-                                                row_ptrs, col_idxs};
+            gko::matrix::view::csr<vt, it> view{
+                gko::dim<2>{3, 3}, 3, values, row_ptrs, col_idxs, 2, srow};
             if (view.size == gko::dim<2>(3, 3) &&
                 view.num_stored_elements == 3 && view.values == values &&
-                view.row_ptrs == row_ptrs && view.col_idxs == col_idxs) {
+                view.row_ptrs == row_ptrs && view.col_idxs == col_idxs &&
+                view.num_srow_elements == 2 && view.srow == srow) {
                 *correct = true;
             }
         },
-        1, values, row_ptrs, col_idxs, correct);
+        1, values, row_ptrs, col_idxs, srow, correct);
     ASSERT_TRUE(get_element(correct, 0));
 }
 

--- a/test/matrix/device_views.cpp
+++ b/test/matrix/device_views.cpp
@@ -103,6 +103,55 @@ TYPED_TEST(CooView, WorksOnDevice)
 
 
 template <typename ValueIndexType>
+class CsrView : public CommonTestFixture {
+public:
+    using value_type =
+        typename std::tuple_element<0, decltype(ValueIndexType())>::type;
+    using index_type =
+        typename std::tuple_element<1, decltype(ValueIndexType())>::type;
+};
+
+TYPED_TEST_SUITE(CsrView, gko::test::ValueIndexTypes,
+                 PairTypenameNameGenerator);
+
+
+template <typename ValueType, typename IndexType>
+void assert_csr_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
+{
+    gko::array<bool> correct{exec, {false}};
+    gko::array<ValueType> values{exec, 3};
+    gko::array<IndexType> row_ptrs{exec, 3};
+    gko::array<IndexType> col_idxs{exec, 3};
+    values.fill(gko::one<ValueType>());
+    row_ptrs.fill(IndexType{0});
+    col_idxs.fill(IndexType{1});
+    gko::kernels::GKO_DEVICE_NAMESPACE::run_kernel(
+        exec,
+        [] GKO_KERNEL(auto i, auto values, auto row_ptrs, auto col_idxs,
+                      auto correct) {
+            using vt = std::decay_t<decltype(values[0])>;
+            using it = std::decay_t<decltype(row_ptrs[0])>;
+            gko::matrix::view::csr<vt, it> view{gko::dim<2>{3, 3}, 3, values,
+                                                row_ptrs, col_idxs};
+            if (view.size == gko::dim<2>(3, 3) &&
+                view.num_stored_elements == 3 && view.values == values &&
+                view.row_ptrs == row_ptrs && view.col_idxs == col_idxs) {
+                *correct = true;
+            }
+        },
+        1, values, row_ptrs, col_idxs, correct);
+    ASSERT_TRUE(get_element(correct, 0));
+}
+
+TYPED_TEST(CsrView, WorksOnDevice)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    assert_csr_view<value_type, index_type>(this->exec);
+}
+
+
+template <typename ValueIndexType>
 class EllView : public CommonTestFixture {
 public:
     using value_type =

--- a/test/matrix/device_views.cpp
+++ b/test/matrix/device_views.cpp
@@ -122,27 +122,26 @@ void assert_csr_view(std::shared_ptr<const gko::EXEC_TYPE> exec)
     gko::array<ValueType> values{exec, 3};
     gko::array<IndexType> row_ptrs{exec, 3};
     gko::array<IndexType> col_idxs{exec, 3};
-    gko::array<IndexType> srow{exec, 2};
     values.fill(gko::one<ValueType>());
     row_ptrs.fill(IndexType{0});
     col_idxs.fill(IndexType{1});
-    srow.fill(IndexType{2});
+
     gko::kernels::GKO_DEVICE_NAMESPACE::run_kernel(
         exec,
         [] GKO_KERNEL(auto i, auto values, auto row_ptrs, auto col_idxs,
-                      auto srow, auto correct) {
+                      auto correct) {
             using vt = std::decay_t<decltype(values[0])>;
             using it = std::decay_t<decltype(row_ptrs[0])>;
-            gko::matrix::view::csr<vt, it> view{
-                gko::dim<2>{3, 3}, 3, values, row_ptrs, col_idxs, 2, srow};
+            gko::matrix::view::csr<vt, it> view{gko::dim<2>{3, 3}, 3, values,
+                                                row_ptrs, col_idxs};
             if (view.size == gko::dim<2>(3, 3) &&
                 view.num_stored_elements == 3 && view.values == values &&
-                view.row_ptrs == row_ptrs && view.col_idxs == col_idxs &&
-                view.num_srow_elements == 2 && view.srow == srow) {
+                view.row_ptrs == row_ptrs && view.col_idxs == col_idxs) {
                 *correct = true;
             }
         },
-        1, values, row_ptrs, col_idxs, srow, correct);
+        1, values, row_ptrs, col_idxs, correct);
+
     ASSERT_TRUE(get_element(correct, 0));
 }
 

--- a/test/multigrid/pgm_kernels.cpp
+++ b/test/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -204,9 +204,10 @@ TEST_F(Pgm, FindStrongestNeighborIsEquivalentToRef)
     auto d_snb = d_strongest_neighbor;
 
     gko::kernels::reference::pgm::find_strongest_neighbor(
-        ref, weight_csr.get(), weight_diag.get(), agg, snb);
+        ref, weight_csr->get_const_device_view(), weight_diag.get(), agg, snb);
     gko::kernels::GKO_DEVICE_NAMESPACE::pgm::find_strongest_neighbor(
-        exec, d_weight_csr.get(), d_weight_diag.get(), d_agg, d_snb);
+        exec, d_weight_csr->get_const_device_view(), d_weight_diag.get(), d_agg,
+        d_snb);
 
     GKO_ASSERT_ARRAY_EQ(d_snb, snb);
 }
@@ -221,9 +222,11 @@ TEST_F(Pgm, AssignToExistAggIsEquivalentToRef)
     auto d_intermediate_agg = d_x;
 
     gko::kernels::reference::pgm::assign_to_exist_agg(
-        ref, weight_csr.get(), weight_diag.get(), x, intermediate_agg);
+        ref, weight_csr->get_const_device_view(), weight_diag.get(), x,
+        intermediate_agg);
     gko::kernels::GKO_DEVICE_NAMESPACE::pgm::assign_to_exist_agg(
-        exec, d_weight_csr.get(), d_weight_diag.get(), d_x, d_intermediate_agg);
+        exec, d_weight_csr->get_const_device_view(), d_weight_diag.get(), d_x,
+        d_intermediate_agg);
 
     GKO_ASSERT_ARRAY_EQ(d_x, x);
 }
@@ -237,7 +240,8 @@ TEST_F(Pgm, AssignToExistAggUnderteminsticIsEquivalentToRef)
     index_type d_num_unagg;
 
     gko::kernels::GKO_DEVICE_NAMESPACE::pgm::assign_to_exist_agg(
-        exec, d_weight_csr.get(), d_weight_diag.get(), d_x, d_intermediate_agg);
+        exec, d_weight_csr->get_const_device_view(), d_weight_diag.get(), d_x,
+        d_intermediate_agg);
     gko::kernels::GKO_DEVICE_NAMESPACE::pgm::count_unagg(exec, d_agg,
                                                          &d_num_unagg);
 

--- a/test/preconditioner/isai_kernels.cpp
+++ b/test/preconditioner/isai_kernels.cpp
@@ -117,10 +117,11 @@ TEST_F(Isai, IsaiGenerateLinverseShortIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_tri_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        true);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, r<value_type>::value);
@@ -140,10 +141,11 @@ TEST_F(Isai, IsaiGenerateUinverseShortIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_tri_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        false);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, r<value_type>::value);
@@ -163,10 +165,11 @@ TEST_F(Isai, IsaiGenerateAinverseShortIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_general_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        false);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, r<value_type>::value);
@@ -186,10 +189,11 @@ TEST_F(Isai, IsaiGenerateSpdinverseShortIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_general_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        true);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 15 * r<value_type>::value);
@@ -209,10 +213,11 @@ TEST_F(Isai, IsaiGenerateLinverseLongIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_tri_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        true);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, r<value_type>::value);
@@ -232,10 +237,11 @@ TEST_F(Isai, IsaiGenerateUinverseLongIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_tri_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        false);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, r<value_type>::value);
@@ -255,10 +261,11 @@ TEST_F(Isai, IsaiGenerateAinverseLongIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_general_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        false);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 100 * r<value_type>::value);
@@ -278,10 +285,11 @@ TEST_F(Isai, IsaiGenerateSpdinverseLongIsEquivalentToRef)
     auto da2 = da1;
 
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_general_inverse(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_data(), da2.get_data(),
-        false);
+        exec, d_mtx->get_const_device_view(), d_inverse->get_device_view(),
+        da1.get_data(), da2.get_data(), false);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(inverse, d_inverse);
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 10 * r<value_type>::value);
@@ -298,7 +306,8 @@ TEST_F(Isai, IsaiGenerateExcessLinverseLongIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::array<index_type> da1(exec, a1);
     gko::array<index_type> da2(exec, a2);
     auto e_dim = a1.get_data()[num_rows];
@@ -309,12 +318,14 @@ TEST_F(Isai, IsaiGenerateExcessLinverseLongIsEquivalentToRef)
     auto de_rhs = Dense::create(exec, gko::dim<2>(e_dim, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        ref, mtx.get(), inverse.get(), a1.get_const_data(), a2.get_const_data(),
-        excess.get(), e_rhs->get_device_view(), 0, num_rows);
+        ref, mtx->get_const_device_view(), inverse->get_const_device_view(),
+        a1.get_const_data(), a2.get_const_data(), excess->get_device_view(),
+        e_rhs->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_excess_system(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_const_data(),
-        da2.get_const_data(), dexcess.get(), de_rhs->get_device_view(), 0,
-        num_rows);
+        exec, d_mtx->get_const_device_view(),
+        d_inverse->get_const_device_view(), da1.get_const_data(),
+        da2.get_const_data(), dexcess->get_device_view(),
+        de_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(excess, dexcess);
     GKO_ASSERT_MTX_NEAR(excess, dexcess, 0);
@@ -330,7 +341,8 @@ TEST_F(Isai, IsaiGenerateExcessUinverseLongIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::array<index_type> da1(exec, a1);
     gko::array<index_type> da2(exec, a2);
     auto e_dim = a1.get_data()[num_rows];
@@ -341,12 +353,14 @@ TEST_F(Isai, IsaiGenerateExcessUinverseLongIsEquivalentToRef)
     auto de_rhs = Dense::create(exec, gko::dim<2>(e_dim, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        ref, mtx.get(), inverse.get(), a1.get_const_data(), a2.get_const_data(),
-        excess.get(), e_rhs->get_device_view(), 0, num_rows);
+        ref, mtx->get_const_device_view(), inverse->get_const_device_view(),
+        a1.get_const_data(), a2.get_const_data(), excess->get_device_view(),
+        e_rhs->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_excess_system(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_const_data(),
-        da2.get_const_data(), dexcess.get(), de_rhs->get_device_view(), 0,
-        num_rows);
+        exec, d_mtx->get_const_device_view(),
+        d_inverse->get_const_device_view(), da1.get_const_data(),
+        da2.get_const_data(), dexcess->get_device_view(),
+        de_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(excess, dexcess);
     GKO_ASSERT_MTX_NEAR(excess, dexcess, 0);
@@ -362,7 +376,8 @@ TEST_F(Isai, IsaiGenerateExcessAinverseLongIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::array<index_type> da1(exec, a1);
     gko::array<index_type> da2(exec, a2);
     auto e_dim = a1.get_data()[num_rows];
@@ -373,12 +388,14 @@ TEST_F(Isai, IsaiGenerateExcessAinverseLongIsEquivalentToRef)
     auto de_rhs = Dense::create(exec, gko::dim<2>(e_dim, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        ref, mtx.get(), inverse.get(), a1.get_const_data(), a2.get_const_data(),
-        excess.get(), e_rhs->get_device_view(), 0, num_rows);
+        ref, mtx->get_const_device_view(), inverse->get_const_device_view(),
+        a1.get_const_data(), a2.get_const_data(), excess->get_device_view(),
+        e_rhs->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_excess_system(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_const_data(),
-        da2.get_const_data(), dexcess.get(), de_rhs->get_device_view(), 0,
-        num_rows);
+        exec, d_mtx->get_const_device_view(),
+        d_inverse->get_const_device_view(), da1.get_const_data(),
+        da2.get_const_data(), dexcess->get_device_view(),
+        de_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(excess, dexcess);
     GKO_ASSERT_MTX_NEAR(excess, dexcess, 0);
@@ -394,7 +411,8 @@ TEST_F(Isai, IsaiGenerateExcessSpdinverseLongIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::array<index_type> da1(exec, a1);
     gko::array<index_type> da2(exec, a2);
     auto e_dim = a1.get_data()[num_rows];
@@ -405,12 +423,14 @@ TEST_F(Isai, IsaiGenerateExcessSpdinverseLongIsEquivalentToRef)
     auto de_rhs = Dense::create(exec, gko::dim<2>(e_dim, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        ref, mtx.get(), inverse.get(), a1.get_const_data(), a2.get_const_data(),
-        excess.get(), e_rhs->get_device_view(), 0, num_rows);
+        ref, mtx->get_const_device_view(), inverse->get_const_device_view(),
+        a1.get_const_data(), a2.get_const_data(), excess->get_device_view(),
+        e_rhs->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_excess_system(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_const_data(),
-        da2.get_const_data(), dexcess.get(), de_rhs->get_device_view(), 0,
-        num_rows);
+        exec, d_mtx->get_const_device_view(),
+        d_inverse->get_const_device_view(), da1.get_const_data(),
+        da2.get_const_data(), dexcess->get_device_view(),
+        de_rhs->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(excess, dexcess);
     GKO_ASSERT_MTX_NEAR(excess, dexcess, 0);
@@ -426,7 +446,8 @@ TEST_F(Isai, IsaiGeneratePartialExcessIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::array<index_type> da1(exec, a1);
     gko::array<index_type> da2(exec, a2);
     auto e_dim = a1.get_data()[10] - a1.get_data()[5];
@@ -437,12 +458,14 @@ TEST_F(Isai, IsaiGeneratePartialExcessIsEquivalentToRef)
     auto de_rhs = Dense::create(exec, gko::dim<2>(e_dim, 1));
 
     gko::kernels::reference::isai::generate_excess_system(
-        ref, mtx.get(), inverse.get(), a1.get_const_data(), a2.get_const_data(),
-        excess.get(), e_rhs->get_device_view(), 5u, 10u);
+        ref, mtx->get_const_device_view(), inverse->get_const_device_view(),
+        a1.get_const_data(), a2.get_const_data(), excess->get_device_view(),
+        e_rhs->get_device_view(), 5u, 10u);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::generate_excess_system(
-        exec, d_mtx.get(), d_inverse.get(), da1.get_const_data(),
-        da2.get_const_data(), dexcess.get(), de_rhs->get_device_view(), 5u,
-        10u);
+        exec, d_mtx->get_const_device_view(),
+        d_inverse->get_const_device_view(), da1.get_const_data(),
+        da2.get_const_data(), dexcess->get_device_view(),
+        de_rhs->get_device_view(), 5u, 10u);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(excess, dexcess);
     GKO_ASSERT_MTX_NEAR(excess, dexcess, 0);
@@ -458,7 +481,8 @@ TEST_F(Isai, IsaiScaleExcessSolutionIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::array<index_type> da1(exec, a1);
     auto e_dim = a1.get_data()[num_rows];
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
@@ -482,7 +506,8 @@ TEST_F(Isai, IsaiScalePartialExcessSolutionIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::array<index_type> da1(exec, a1);
     auto e_dim = a1.get_data()[10] - a1.get_data()[5];
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
@@ -505,7 +530,8 @@ TEST_F(Isai, IsaiScatterExcessSolutionLIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::array<index_type> da1(exec, a1);
     auto e_dim = a1.get_data()[num_rows];
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
@@ -514,11 +540,11 @@ TEST_F(Isai, IsaiScatterExcessSolutionLIsEquivalentToRef)
     d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
-        ref, a1.get_const_data(), e_rhs->get_const_device_view(), inverse.get(),
-        0, num_rows);
+        ref, a1.get_const_data(), e_rhs->get_const_device_view(),
+        inverse->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::scatter_excess_solution(
         exec, da1.get_const_data(), de_rhs->get_const_device_view(),
-        d_inverse.get(), 0, num_rows);
+        d_inverse->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 0);
     ASSERT_GT(e_dim, 0);
@@ -532,7 +558,8 @@ TEST_F(Isai, IsaiScatterExcessSolutionUIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_tri_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::array<index_type> da1(exec, a1);
     auto e_dim = a1.get_data()[num_rows];
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
@@ -542,11 +569,11 @@ TEST_F(Isai, IsaiScatterExcessSolutionUIsEquivalentToRef)
     d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
-        ref, a1.get_const_data(), e_rhs->get_const_device_view(), inverse.get(),
-        0, num_rows);
+        ref, a1.get_const_data(), e_rhs->get_const_device_view(),
+        inverse->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::scatter_excess_solution(
         exec, da1.get_const_data(), de_rhs->get_const_device_view(),
-        d_inverse.get(), 0, num_rows);
+        d_inverse->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 0);
     ASSERT_GT(e_dim, 0);
@@ -560,7 +587,8 @@ TEST_F(Isai, IsaiScatterExcessSolutionAIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), false);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), false);
     gko::array<index_type> da1(exec, a1);
     auto e_dim = a1.get_data()[num_rows];
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
@@ -570,11 +598,11 @@ TEST_F(Isai, IsaiScatterExcessSolutionAIsEquivalentToRef)
     d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
-        ref, a1.get_const_data(), e_rhs->get_const_device_view(), inverse.get(),
-        0, num_rows);
+        ref, a1.get_const_data(), e_rhs->get_const_device_view(),
+        inverse->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::scatter_excess_solution(
         exec, da1.get_const_data(), de_rhs->get_const_device_view(),
-        d_inverse.get(), 0, num_rows);
+        d_inverse->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 0);
     ASSERT_GT(e_dim, 0);
@@ -588,7 +616,8 @@ TEST_F(Isai, IsaiScatterExcessSolutionSpdIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::array<index_type> da1(exec, a1);
     auto e_dim = a1.get_data()[num_rows];
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
@@ -598,11 +627,11 @@ TEST_F(Isai, IsaiScatterExcessSolutionSpdIsEquivalentToRef)
     d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
-        ref, a1.get_const_data(), e_rhs->get_const_device_view(), inverse.get(),
-        0, num_rows);
+        ref, a1.get_const_data(), e_rhs->get_const_device_view(),
+        inverse->get_device_view(), 0, num_rows);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::scatter_excess_solution(
         exec, da1.get_const_data(), de_rhs->get_const_device_view(),
-        d_inverse.get(), 0, num_rows);
+        d_inverse->get_device_view(), 0, num_rows);
 
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 0);
     ASSERT_GT(e_dim, 0);
@@ -616,7 +645,8 @@ TEST_F(Isai, IsaiScatterPartialExcessSolutionIsEquivalentToRef)
     gko::array<index_type> a1(ref, num_rows + 1);
     auto a2 = a1;
     gko::kernels::reference::isai::generate_general_inverse(
-        ref, mtx.get(), inverse.get(), a1.get_data(), a2.get_data(), true);
+        ref, mtx->get_const_device_view(), inverse->get_device_view(),
+        a1.get_data(), a2.get_data(), true);
     gko::array<index_type> da1(exec, a1);
     auto e_dim = a1.get_data()[10] - a1.get_data()[5];
     auto e_rhs = Dense::create(ref, gko::dim<2>(e_dim, 1));
@@ -626,11 +656,11 @@ TEST_F(Isai, IsaiScatterPartialExcessSolutionIsEquivalentToRef)
     d_inverse->copy_from(inverse);
 
     gko::kernels::reference::isai::scatter_excess_solution(
-        ref, a1.get_const_data(), e_rhs->get_const_device_view(), inverse.get(),
-        5u, 10u);
+        ref, a1.get_const_data(), e_rhs->get_const_device_view(),
+        inverse->get_device_view(), 5u, 10u);
     gko::kernels::GKO_DEVICE_NAMESPACE::isai::scatter_excess_solution(
         exec, da1.get_const_data(), de_rhs->get_const_device_view(),
-        d_inverse.get(), 5u, 10u);
+        d_inverse->get_device_view(), 5u, 10u);
 
     GKO_ASSERT_MTX_NEAR(inverse, d_inverse, 0);
     ASSERT_GT(e_dim, 0);

--- a/test/preconditioner/sor_kernels.cpp
+++ b/test/preconditioner/sor_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -74,10 +74,11 @@ protected:
 
 TEST_F(Sor, InitializeWeightedLFactorIsSameAsReference)
 {
-    gko::kernels::reference::sor::initialize_weighted_l(ref, mtx.get(), 1.24,
-                                                        result_l.get());
+    gko::kernels::reference::sor::initialize_weighted_l(
+        ref, mtx->get_const_device_view(), 1.24, result_l->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::sor::initialize_weighted_l(
-        exec, d_mtx.get(), 1.24, d_result_l.get());
+        exec, d_mtx->get_const_device_view(), 1.24,
+        d_result_l->get_device_view());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result_l, d_result_l);
     GKO_ASSERT_MTX_NEAR(result_l, d_result_l, r<value_type>::value);
@@ -87,9 +88,11 @@ TEST_F(Sor, InitializeWeightedLFactorIsSameAsReference)
 TEST_F(Sor, InitializeWeightedLAndUFactorIsSameAsReference)
 {
     gko::kernels::reference::sor::initialize_weighted_l_u(
-        ref, mtx.get(), 1.24, result_l.get(), result_u.get());
+        ref, mtx->get_const_device_view(), 1.24, result_l->get_device_view(),
+        result_u->get_device_view());
     gko::kernels::GKO_DEVICE_NAMESPACE::sor::initialize_weighted_l_u(
-        exec, d_mtx.get(), 1.24, d_result_l.get(), d_result_u.get());
+        exec, d_mtx->get_const_device_view(), 1.24,
+        d_result_l->get_device_view(), d_result_u->get_device_view());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(result_l, d_result_l);
     GKO_ASSERT_MTX_EQ_SPARSITY(result_u, d_result_u);


### PR DESCRIPTION
This PR adds CSR device view and only changes the interface allowing device view without further changes.

The device view only contains the common csr (no strategy and srow in this PR)
Also, some functions requiring copy, get_executor, or CsrBuilder are not considered in this PR.

In the last commit, I revert some functions which call `get_const_device_view()` from the backend because we disallow that due to the circular dependence issue.
It can be done add another free function, but I keep it until we check how to deal the above restriction.