### PR TITLE
Workaround fix for avoiding recompilation on instantiation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -290,7 +290,7 @@ build/amd/nompi/gcc/rocm720/release/shared:
     - .build_and_test_tum_template
     - .default_variables
     - .full_test_condition
-    - .use_tum-amd
+    - .use_tum-amd-mi210
   variables:
     BUILD_HIP: "ON"
     BUILD_OMP: "OFF"
@@ -481,7 +481,7 @@ build/nogpu/mpi/gcc13/noomp/release/shared:
     BUILD_TYPE: "Release"
     BUILD_HWLOC: "OFF"
     BUILD_MPI: "ON"
-    MODULE_LOAD: "cmake/3.18.6 gcc/13.3.0 openmpi"
+    MODULE_LOAD: "cmake/3.18.6 gcc/13.3.0 openmpi/5.0.7"
 
 # spack oneapi 2023.1
 build/icpx20231/gpu/release/shared:

--- a/cuda/CMakeLists.txt
+++ b/cuda/CMakeLists.txt
@@ -17,7 +17,7 @@ add_instantiation_files(
     BATCH_BICGSTAB_INSTANTIATE1
 )
 add_instantiation_files(
-    .
+    ${PROJECT_SOURCE_DIR}/cuda
     solver/batch_bicgstab_launch.instantiate.cu
     BATCH_BICGSTAB_INSTANTIATE2
 )
@@ -27,7 +27,7 @@ add_instantiation_files(
     BATCH_CG_INSTANTIATE1
 )
 add_instantiation_files(
-    .
+    ${PROJECT_SOURCE_DIR}/cuda
     solver/batch_cg_launch.instantiate.cu
     BATCH_CG_INSTANTIATE2
 )


### PR DESCRIPTION
CMake always recompile the instantiation file even when the file is not changed.

NVCC adds the <file> as dependency from `#line 1 <file>`
When we only put the relative path there, it will not be able to properly located during checking the dependencies.
We make absolute path for that to ensure the dependency can be found during checking.
It should fix the recompilation issue when no file changes.
