### PR TITLE
Add triangular solver support for dpcpp

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -483,57 +483,6 @@ build/nogpu/mpi/gcc13/noomp/release/shared:
     BUILD_MPI: "ON"
     MODULE_LOAD: "cmake/3.18.6 gcc/13.3.0 openmpi/5.0.7"
 
-# spack oneapi 2023.1
-build/icpx20231/gpu/release/shared:
-  extends:
-    - .build_and_test_template
-    - .default_variables
-    - .quick_test_condition
-    - .use_gko-oneapi20231-gpu
-  variables:
-    CXX_COMPILER: "icpx"
-    CXX_FLAGS: "-Wpedantic -ffp-model=precise"
-    BUILD_SYCL: "ON"
-    BUILD_TYPE: "Release"
-    BUILD_SHARED_LIBS: "ON"
-    DPCPP_SINGLE_MODE: "ON"
-    ONEAPI_DEVICE_SELECTOR: "opencl:gpu"
-    BUILD_HWLOC: "OFF"
-
-build/dpcpp20231/gpu/release/shared:
-  extends:
-    - .build_and_test_tum_template
-    - .default_variables
-    - .full_test_condition
-    - .use_tum-intel-fp32
-  variables:
-    CXX_COMPILER: "dpcpp"
-    CXX_FLAGS: "-Wpedantic -ffp-model=precise"
-    BUILD_SYCL: "ON"
-    BUILD_TYPE: "Release"
-    BUILD_SHARED_LIBS: "ON"
-    DPCPP_SINGLE_MODE: "ON"
-    MODULE_LOAD: "cmake/3.21.7 intel-oneapi-compilers/2023.1.0 intel-oneapi-dpl/2022.1.0 intel-oneapi-tbb/2021.9.0 intel-oneapi-mkl/2023.1.0"
-    ONEAPI_DEVICE_SELECTOR: "opencl:gpu"
-    BUILD_HWLOC: "OFF"
-
-build/icpx202402/gpu/release/shared:
-  extends:
-    - .build_and_test_tum_template
-    - .default_variables
-    - .full_test_condition
-    - .use_tum-intel
-  variables:
-    CXX_COMPILER: "icpx"
-    CXX_FLAGS: "-Wpedantic -ffp-model=precise -Wno-deprecated-declarations"
-    BUILD_SYCL: "ON"
-    BUILD_HWLOC: "OFF"
-    BUILD_TYPE: "Release"
-    ENABLE_HALF: "OFF"
-    ENABLE_BFLOAT16: "OFF"
-    ONEAPI_DEVICE_SELECTOR: "opencl:gpu"
-    MODULE_LOAD: "cmake/3.21.7 intel-oneapi-compilers/2024.0.2 intel-oneapi-dpl/2022.3.0 intel-oneapi-tbb/2021.11.0 intel-oneapi-mkl/2024.0.0"
-
 build/icpx202421/gpu/release/shared:
   extends:
     - .build_and_test_tum_template

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The Ginkgo HIP module has the following __additional__ requirements:
 
 The Ginkgo DPC++(SYCL) module has the following __additional__ requirements:
 
-* _oneAPI 2023.1+_
+* _oneAPI 2024.1+_
 * Set `dpcpp` or `icpx` as the `CMAKE_CXX_COMPILER`
 * The following oneAPI packages should be available:
     * oneMKL

--- a/benchmark/utils/dpcpp_linops.dp.cpp
+++ b/benchmark/utils/dpcpp_linops.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -52,11 +52,8 @@ protected:
         mat_handle_ = handle_manager<oneapi::mkl::sparse::matrix_handle>(
             create_mat_handle(),
             [exec](oneapi::mkl::sparse::matrix_handle_t mat_handle) {
-                oneapi::mkl::sparse::release_matrix_handle(
-#if INTEL_MKL_VERSION >= 20240000
-                    *exec->get_queue(),
-#endif
-                    &mat_handle);
+                oneapi::mkl::sparse::release_matrix_handle(*exec->get_queue(),
+                                                           &mat_handle);
             });
     }
 
@@ -110,10 +107,8 @@ public:
         this->set_size(csr_->get_size());
 
         oneapi::mkl::sparse::set_csr_data(
-#if INTEL_MKL_VERSION >= 20240000
-            *(this->get_device_exec()->get_queue()),
-#endif
-            this->get_mat_handle(), static_cast<int>(this->get_size()[0]),
+            *(this->get_device_exec()->get_queue()), this->get_mat_handle(),
+            static_cast<int>(this->get_size()[0]),
             static_cast<int>(this->get_size()[1]),
             oneapi::mkl::index_base::zero, csr_->get_row_ptrs(),
             csr_->get_col_idxs(), csr_->get_values());

--- a/core/solver/lower_trs.cpp
+++ b/core/solver/lower_trs.cpp
@@ -156,8 +156,8 @@ void LowerTrs<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
             // This kernel checks if a transpose is needed for the multiple rhs
             // case. Currently only the algorithm for HIP needs this
             // transposition due to the limitation in the hipsparse algorithm.
-            // The other executors (omp and reference, CUDA) do not use the
-            // transpose (trans_x and trans_b) and hence are passed in empty
+            // The other executors (omp and reference, CUDA, dpcpp) do not use
+            // the transpose (trans_x and trans_b) and hence are passed in empty
             // pointers.
             Vector* trans_b{};
             Vector* trans_x{};

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1452,10 +1452,7 @@ bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
         oneapi::mkl::sparse::matrix_handle_t mat_handle;
         oneapi::mkl::sparse::init_matrix_handle(&mat_handle);
         oneapi::mkl::sparse::set_csr_data(
-#if INTEL_MKL_VERSION >= 20240000
-            *exec->get_queue(),
-#endif
-            mat_handle, IndexType(a->get_size()[0]),
+            *exec->get_queue(), mat_handle, IndexType(a->get_size()[0]),
             IndexType(a->get_size()[1]), oneapi::mkl::index_base::zero,
             const_cast<IndexType*>(a->get_const_row_ptrs()),
             const_cast<IndexType*>(a->get_const_col_idxs()),
@@ -1473,11 +1470,8 @@ bool try_general_sparselib_spmv(std::shared_ptr<const DpcppExecutor> exec,
                 const_cast<ValueType*>(b.values), b.size[1], b.stride,
                 host_beta, c.values, c.stride);
         }
-        oneapi::mkl::sparse::release_matrix_handle(
-#if INTEL_MKL_VERSION >= 20240000
-            *exec->get_queue(),
-#endif
-            &mat_handle);
+        oneapi::mkl::sparse::release_matrix_handle(*exec->get_queue(),
+                                                   &mat_handle);
     }
     return try_sparselib;
 }

--- a/dpcpp/solver/common_trs_kernels.hpp
+++ b/dpcpp/solver/common_trs_kernels.hpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_DPCPP_SOLVER_COMMON_TRS_KERNELS_HPP_
+#define GKO_DPCPP_SOLVER_COMMON_TRS_KERNELS_HPP_
+
+
+#include <sycl/sycl.hpp>
+
+#include <ginkgo/core/base/math.hpp>
+
+#include "dpcpp/base/onemkl_bindings.hpp"
+#include "dpcpp/base/types.hpp"
+
+
+namespace gko {
+namespace solver {
+
+
+struct SolveStruct {
+    virtual ~SolveStruct() = default;
+};
+
+
+}  // namespace solver
+
+
+namespace kernels {
+namespace dpcpp {
+namespace {
+
+
+template <typename ValueType, typename IndexType>
+struct OneMklSolveStruct : gko::solver::SolveStruct {
+    std::shared_ptr<const gko::DpcppExecutor> exec;
+    oneapi::mkl::sparse::matrix_handle_t mat_handle;
+    size_type num_rhs;
+    oneapi::mkl::uplo uplo;
+    oneapi::mkl::diag diag;
+
+    OneMklSolveStruct(std::shared_ptr<const gko::DpcppExecutor> exec,
+                      const matrix::Csr<ValueType, IndexType>* matrix,
+                      size_type num_rhs, bool is_upper, bool unit_diag)
+        : exec{exec}, num_rhs{num_rhs}
+    {
+        if (num_rhs == 0) {
+            return;
+        }
+        uplo = is_upper ? oneapi::mkl::uplo::upper : oneapi::mkl::uplo::lower;
+        diag = unit_diag ? oneapi::mkl::diag::unit : oneapi::mkl::diag::nonunit;
+        oneapi::mkl::sparse::init_matrix_handle(&mat_handle);
+        oneapi::mkl::sparse::set_csr_data(
+            *exec->get_queue(), mat_handle, IndexType(matrix->get_size()[0]),
+            IndexType(matrix->get_size()[1]), oneapi::mkl::index_base::zero,
+            const_cast<IndexType*>(matrix->get_const_row_ptrs()),
+            const_cast<IndexType*>(matrix->get_const_col_idxs()),
+            const_cast<ValueType*>(matrix->get_const_values()));
+
+        oneapi::mkl::sparse::optimize_trsm(
+            *exec->get_queue(), oneapi::mkl::layout::row_major, uplo,
+            oneapi::mkl::transpose::nontrans, diag, mat_handle,
+            static_cast<int64>(num_rhs));
+    }
+
+    void solve(const matrix::Csr<ValueType, IndexType>* matrix,
+               matrix::view::dense<const ValueType> input,
+               matrix::view::dense<ValueType> output) const
+    {
+        if (input.size[1] != num_rhs) {
+            throw gko::ValueMismatch{
+                __FILE__,
+                __LINE__,
+                __FUNCTION__,
+                input.size[1],
+                num_rhs,
+                "the dimensions of the multivector do not match the value "
+                "provided at generation time. Check the value specified in "
+                ".with_num_rhs(...)."};
+        }
+        oneapi::mkl::sparse::trsm(
+            *exec->get_queue(), oneapi::mkl::layout::row_major,
+            oneapi::mkl::transpose::nontrans, oneapi::mkl::transpose::nontrans,
+            uplo, diag, one<ValueType>(), mat_handle, input.values,
+            static_cast<int64>(num_rhs), input.stride, output.values,
+            output.stride);
+    }
+
+    ~OneMklSolveStruct()
+    {
+        if (mat_handle) {
+            oneapi::mkl::sparse::release_matrix_handle(*exec->get_queue(),
+                                                       &mat_handle);
+        }
+    }
+
+    OneMklSolveStruct(const OneMklSolveStruct&) = delete;
+
+    OneMklSolveStruct(OneMklSolveStruct&&) = delete;
+
+    OneMklSolveStruct& operator=(const OneMklSolveStruct&) = delete;
+
+    OneMklSolveStruct& operator=(OneMklSolveStruct&&) = delete;
+};
+
+
+template <typename ValueType, typename IndexType>
+void generate_kernel(std::shared_ptr<const DpcppExecutor> exec,
+                     const matrix::Csr<ValueType, IndexType>* matrix,
+                     std::shared_ptr<solver::SolveStruct>& solve_struct,
+                     const gko::size_type num_rhs, bool is_upper,
+                     bool unit_diag)
+{
+    if (matrix->get_size()[0] == 0) {
+        return;
+    }
+    if constexpr (onemkl::is_supported<ValueType>::value) {
+        solve_struct =
+            std::make_shared<OneMklSolveStruct<ValueType, IndexType>>(
+                exec, matrix, num_rhs, is_upper, unit_diag);
+    } else {
+        GKO_NOT_IMPLEMENTED;
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+void solve_kernel(std::shared_ptr<const DpcppExecutor> exec,
+                  const matrix::Csr<ValueType, IndexType>* matrix,
+                  const solver::SolveStruct* solve_struct,
+                  matrix::view::dense<const ValueType> b,
+                  matrix::view::dense<ValueType> x)
+{
+    if (matrix->get_size()[0] == 0 || b.size[1] == 0) {
+        return;
+    }
+    using vec = matrix::Dense<ValueType>;
+
+    if constexpr (onemkl::is_supported<ValueType>::value) {
+        if (auto onemkl_solve_struct =
+                dynamic_cast<const OneMklSolveStruct<ValueType, IndexType>*>(
+                    solve_struct)) {
+            onemkl_solve_struct->solve(matrix, b, x);
+        } else {
+            GKO_NOT_SUPPORTED(solve_struct);
+        }
+    } else {
+        GKO_NOT_IMPLEMENTED;
+    }
+}
+
+
+}  // namespace
+}  // namespace dpcpp
+}  // namespace kernels
+}  // namespace gko
+
+
+#endif  // GKO_DPCPP_SOLVER_COMMON_TRS_KERNELS_HPP_

--- a/dpcpp/solver/common_trs_kernels.hpp
+++ b/dpcpp/solver/common_trs_kernels.hpp
@@ -42,7 +42,7 @@ struct OneMklSolveStruct : gko::solver::SolveStruct {
     OneMklSolveStruct(std::shared_ptr<const gko::DpcppExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* matrix,
                       size_type num_rhs, bool is_upper, bool unit_diag)
-        : exec{exec}, num_rhs{num_rhs}
+        : exec{exec}, mat_handle{nullptr}, num_rhs{num_rhs}
     {
         if (num_rhs == 0) {
             return;

--- a/dpcpp/solver/lower_trs_kernels.dp.cpp
+++ b/dpcpp/solver/lower_trs_kernels.dp.cpp
@@ -9,13 +9,13 @@
 
 #include <sycl/sycl.hpp>
 
-#include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>
-#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/solver/triangular.hpp>
+
+#include "dpcpp/solver/common_trs_kernels.hpp"
 
 
 namespace gko {
@@ -41,16 +41,16 @@ void generate(std::shared_ptr<const DpcppExecutor> exec,
               const matrix::Csr<ValueType, IndexType>* matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
-              const size_type num_rhs) GKO_NOT_IMPLEMENTED;
+              const size_type num_rhs)
+{
+    generate_kernel<ValueType, IndexType>(exec, matrix, solve_struct, num_rhs,
+                                          false, unit_diag);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_LOWER_TRS_GENERATE_KERNEL);
 
 
-/**
- * The parameters trans_x and trans_b are used only in the CUDA executor for
- * versions <=9.1 due to a limitation in the cssrsm_solve algorithm
- */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const DpcppExecutor> exec,
            const matrix::Csr<ValueType, IndexType>* matrix,
@@ -59,7 +59,10 @@ void solve(std::shared_ptr<const DpcppExecutor> exec,
            std::optional<matrix::view::dense<ValueType>> trans_b,
            std::optional<matrix::view::dense<ValueType>> trans_x,
            matrix::view::dense<const ValueType> b,
-           matrix::view::dense<ValueType> x) GKO_NOT_IMPLEMENTED;
+           matrix::view::dense<ValueType> x)
+{
+    solve_kernel<ValueType, IndexType>(exec, matrix, solve_struct, b, x);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_LOWER_TRS_SOLVE_KERNEL);

--- a/dpcpp/solver/upper_trs_kernels.dp.cpp
+++ b/dpcpp/solver/upper_trs_kernels.dp.cpp
@@ -9,13 +9,13 @@
 
 #include <sycl/sycl.hpp>
 
-#include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>
-#include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/base/types.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/solver/triangular.hpp>
+
+#include "dpcpp/solver/common_trs_kernels.hpp"
 
 
 namespace gko {
@@ -41,16 +41,16 @@ void generate(std::shared_ptr<const DpcppExecutor> exec,
               const matrix::Csr<ValueType, IndexType>* matrix,
               std::shared_ptr<solver::SolveStruct>& solve_struct,
               bool unit_diag, const solver::trisolve_algorithm algorithm,
-              const size_type num_rhs) GKO_NOT_IMPLEMENTED;
+              const size_type num_rhs)
+{
+    generate_kernel<ValueType, IndexType>(exec, matrix, solve_struct, num_rhs,
+                                          true, unit_diag);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_UPPER_TRS_GENERATE_KERNEL);
 
 
-/**
- * The parameters trans_x and trans_b are used only in the CUDA executor for
- * versions <=9.1 due to a limitation in the cssrsm_solve algorithm
- */
 template <typename ValueType, typename IndexType>
 void solve(std::shared_ptr<const DpcppExecutor> exec,
            const matrix::Csr<ValueType, IndexType>* matrix,
@@ -59,7 +59,10 @@ void solve(std::shared_ptr<const DpcppExecutor> exec,
            std::optional<matrix::view::dense<ValueType>> trans_b,
            std::optional<matrix::view::dense<ValueType>> trans_x,
            matrix::view::dense<const ValueType> b,
-           matrix::view::dense<ValueType> x) GKO_NOT_IMPLEMENTED;
+           matrix::view::dense<ValueType> x)
+{
+    solve_kernel<ValueType, IndexType>(exec, matrix, solve_struct, b, x);
+}
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
     GKO_DECLARE_UPPER_TRS_SOLVE_KERNEL);

--- a/test/solver/CMakeLists.txt
+++ b/test/solver/CMakeLists.txt
@@ -13,11 +13,11 @@ ginkgo_create_common_test(gcr_kernels)
 ginkgo_create_common_test(gmres_kernels)
 ginkgo_create_common_test(idr_kernels)
 ginkgo_create_common_test(ir_kernels)
-ginkgo_create_common_test(lower_trs_kernels DISABLE_EXECUTORS dpcpp)
+ginkgo_create_common_test(lower_trs_kernels)
 ginkgo_create_common_test(minres_kernels)
 ginkgo_create_common_test(multigrid_kernels DISABLE_EXECUTORS dpcpp)
 ginkgo_create_common_test(solver DISABLE_EXECUTORS dpcpp)
-ginkgo_create_common_test(upper_trs_kernels DISABLE_EXECUTORS dpcpp)
+ginkgo_create_common_test(upper_trs_kernels)
 if(GINKGO_BUILD_SYCL)
     gko_add_sycl_to_target(
         TARGET test_solver_idr_kernels_dpcpp

--- a/test/solver/lower_trs_kernels.cpp
+++ b/test/solver/lower_trs_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,7 +21,7 @@
 class LowerTrs : public CommonTestFixture {
 protected:
     using mtx_type = gko::matrix::Csr<value_type, index_type>;
-    using vec_type = gko::matrix::Dense<>;
+    using vec_type = gko::matrix::Dense<value_type>;
     using solver_type = gko::solver::LowerTrs<value_type, index_type>;
 
     LowerTrs() : rand_engine(30) {}
@@ -87,8 +87,7 @@ TEST_F(LowerTrs, ApplyFullDenseMtxIsEquivalentToRef)
 
     solver->apply(b, x);
     d_solver->apply(db, dx);
-
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -105,7 +104,7 @@ TEST_F(LowerTrs, ApplyFullDenseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -120,7 +119,7 @@ TEST_F(LowerTrs, ApplyFullSparseMtxIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -137,7 +136,7 @@ TEST_F(LowerTrs, ApplyFullSparseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -152,7 +151,7 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-13);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e3);
 }
 
 
@@ -169,7 +168,7 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -184,7 +183,7 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -201,7 +200,7 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -216,7 +215,7 @@ TEST_F(LowerTrs, ApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -233,7 +232,7 @@ TEST_F(LowerTrs, ApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -248,7 +247,7 @@ TEST_F(LowerTrs, ApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -265,7 +264,7 @@ TEST_F(LowerTrs, ApplyFullSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -280,7 +279,7 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -297,7 +296,7 @@ TEST_F(LowerTrs, ApplyTriangularDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -312,7 +311,7 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -330,7 +329,7 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 

--- a/test/solver/upper_trs_kernels.cpp
+++ b/test/solver/upper_trs_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,7 +21,7 @@
 class UpperTrs : public CommonTestFixture {
 protected:
     using mtx_type = gko::matrix::Csr<value_type, index_type>;
-    using vec_type = gko::matrix::Dense<>;
+    using vec_type = gko::matrix::Dense<value_type>;
     using solver_type = gko::solver::UpperTrs<value_type, index_type>;
 
     UpperTrs() : rand_engine(30) {}
@@ -88,7 +88,7 @@ TEST_F(UpperTrs, ApplyFullDenseMtxIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -105,7 +105,7 @@ TEST_F(UpperTrs, ApplyFullDenseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -120,7 +120,7 @@ TEST_F(UpperTrs, ApplyFullSparseMtxIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -137,7 +137,7 @@ TEST_F(UpperTrs, ApplyFullSparseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -152,7 +152,7 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-13);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e3);
 }
 
 
@@ -169,7 +169,7 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -184,7 +184,7 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -201,7 +201,7 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -216,7 +216,7 @@ TEST_F(UpperTrs, ApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -233,7 +233,7 @@ TEST_F(UpperTrs, ApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -248,7 +248,7 @@ TEST_F(UpperTrs, ApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -265,7 +265,7 @@ TEST_F(UpperTrs, ApplyFullSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -280,7 +280,7 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -297,7 +297,7 @@ TEST_F(UpperTrs, ApplyTriangularDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -312,7 +312,7 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 
@@ -330,7 +330,7 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
     solver->apply(b, x);
     d_solver->apply(db, dx);
 
-    GKO_ASSERT_MTX_NEAR(dx, x, 1e-14);
+    GKO_ASSERT_MTX_NEAR(dx, x, r<value_type>::value * 1e2);
 }
 
 


### PR DESCRIPTION
Add lower/upper triangular solve for the `DpcppExecutor` via oneMKL. A related issue is #2015, where it was noted that the triangular solvers were missing for dpcpp (though this PR doesn't close that issue because there are other discussion points there).

After a discussion with @yhmtsai, this also bumps minimum oneAPI requirement to 2024.1, when `trsm` was added to oneMKL. This can of course be reverted, in which case we will just have to guard the triangular solve for 2024.1 and newer.