### PR TITLE
use enum for csr_strategy

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -47,5 +47,6 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -DGINKGO_BUILD_TESTS=OFF -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DGINKGO_BUILD_OMP=OFF -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release
+        ctest . -C Release

--- a/INTERFACE_CHANGE.2.md
+++ b/INTERFACE_CHANGE.2.md
@@ -58,8 +58,9 @@ If the object is the concrete type like Dense and Csr, `pointer->clone()` and `p
 If Users have their own class inherit from something like `EnableLinOp`, users only need to inherit from `LinOp` for `apply` function and optionally inherit from `EnableCloneable<ConcreteType>` for `clone` function.
 
 ## Csr create function with the strategy
-No csr strategy with the class inheritence.
-`std::make_shared<Csr::<strategy_type>>(...)` -> `gko::matrix::csr::spmv_strategy::<strategy_name>`
-(currently still allow basic usage on the strategy shared pointer with deprecation warning).  
-`csr->get_strategy()` return enum class not shared_ptr.  
-No manual setup for load_balance strategy. (If you need it, please let us know)
+The `Csr::strategy` classes are deprecated.
+To create a Csr matrix with a specific strategy, use the enum `gko::matrix::csr::spmv_strategy` instead.
+For example, `std::make_shared<Csr<>>(exec, std::make_shared<Csr<>::classical>())` is equivalent to
+`std::make_shared<Csr<>>(exec, csr::spmv_strategy::classical)`. 
+`csr->get_strategy` will now return the enum value instead of a shared_ptr.
+**Note:** It is not possible to have a custom load_balance strategy with the new interface. (Please let us know if you need it)

--- a/INTERFACE_CHANGE.2.md
+++ b/INTERFACE_CHANGE.2.md
@@ -56,3 +56,10 @@ Users can use `as<ConcreteType>(as<Cloneable>(pointer)->clone())` or `as<Concret
 If the object is the concrete type like Dense and Csr, `pointer->clone()` and `pointer->clone(exec)` works the same as previous version.
 
 If Users have their own class inherit from something like `EnableLinOp`, users only need to inherit from `LinOp` for `apply` function and optionally inherit from `EnableCloneable<ConcreteType>` for `clone` function.
+
+## Csr create function with the strategy
+No csr strategy with the class inheritence.
+`std::make_shared<Csr::<strategy_type>>(...)` -> `gko::matrix::csr::spmv_strategy::<strategy_name>`
+(currently still allow basic usage on the strategy shared pointer with deprecation warning).  
+`csr->get_strategy()` return enum class not shared_ptr.  
+No manual setup for load_balance strategy. (If you need it, please let us know)

--- a/INTERFACE_CHANGE.2.md
+++ b/INTERFACE_CHANGE.2.md
@@ -63,4 +63,5 @@ To create a Csr matrix with a specific strategy, use the enum `gko::matrix::csr:
 For example, `std::make_shared<Csr<>>(exec, std::make_shared<Csr<>::classical>())` is equivalent to
 `std::make_shared<Csr<>>(exec, csr::spmv_strategy::classical)`. 
 `csr->get_strategy` will now return the enum value instead of a shared_ptr.
+We use `automatic` in enum not `automatical` like old shared_ptr usage.
 **Note:** It is not possible to have a custom load_balance strategy with the new interface. (Please let us know if you need it)

--- a/benchmark/utils/cuda_linops.cpp
+++ b/benchmark/utils/cuda_linops.cpp
@@ -170,7 +170,7 @@ protected:
                   const gko::dim<2>& size = gko::dim<2>{})
         : CusparseBase(exec, size),
           csr_(std::move(
-              csr::create(exec, std::make_shared<typename csr::classical>()))),
+              csr::create(exec, gko::matrix::csr::spmv_strategy::classical))),
           trans_(SPARSELIB_OPERATION_NON_TRANSPOSE),
           buffer_(exec)
     {
@@ -309,7 +309,7 @@ protected:
                        const gko::dim<2>& size = gko::dim<2>{})
         : CusparseBase(exec, size),
           csr_(std::move(
-              csr::create(exec, std::make_shared<typename csr::classical>()))),
+              csr::create(exec, gko::matrix::csr::spmv_strategy::classical))),
           trans_(SPARSELIB_OPERATION_NON_TRANSPOSE)
     {}
 

--- a/benchmark/utils/dpcpp_linops.dp.cpp
+++ b/benchmark/utils/dpcpp_linops.dp.cpp
@@ -140,7 +140,7 @@ protected:
               const gko::dim<2>& size = gko::dim<2>{})
         : OnemklBase(exec, size),
           csr_(std::move(
-              Csr::create(exec, std::make_shared<typename Csr::classical>()))),
+              Csr::create(exec, gko::matrix::csr::spmv_strategy::classical))),
           trans_(oneapi::mkl::transpose::nontrans)
     {}
 

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -170,7 +170,7 @@ auto create_matrix_type(Args&&... args)
 const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
                                 std::shared_ptr<const gko::Executor>)>>
     matrix_type_factory{
-        {"csr", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::automatical)},
+        {"csr", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::automatic)},
         {"csri", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::load_balance)},
         {"csrm", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::merge_path)},
         {"csrc", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::classical)},

--- a/benchmark/utils/formats.hpp
+++ b/benchmark/utils/formats.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -133,29 +133,6 @@ using ell_mixed = gko::matrix::Ell<gko::next_precision_base<etype>, itype>;
 
 
 /**
- * Creates a CSR strategy of the given type for the given executor if possible,
- * falls back to csr::classical for executors without support for this strategy.
- *
- * @tparam Strategy  one of csr::automatical or csr::load_balance
- */
-template <typename Strategy>
-std::shared_ptr<csr::strategy_type> create_gpu_strategy(
-    std::shared_ptr<const gko::Executor> exec)
-{
-    if (auto cuda = dynamic_cast<const gko::CudaExecutor*>(exec.get())) {
-        return std::make_shared<Strategy>(cuda->shared_from_this());
-    } else if (auto hip = dynamic_cast<const gko::HipExecutor*>(exec.get())) {
-        return std::make_shared<Strategy>(hip->shared_from_this());
-    } else if (auto dpcpp =
-                   dynamic_cast<const gko::DpcppExecutor*>(exec.get())) {
-        return std::make_shared<Strategy>(dpcpp->shared_from_this());
-    } else {
-        return std::make_shared<csr::classical>();
-    }
-}
-
-
-/**
  * Checks whether the given matrix data exceeds the ELL imbalance limit set by
  * the --ell_imbalance_limit flag
  *
@@ -189,25 +166,15 @@ auto create_matrix_type(Args&&... args)
 }
 
 
-template <typename MatrixType, typename Strategy>
-auto create_matrix_type_with_gpu_strategy()
-{
-    return [&](std::shared_ptr<const gko::Executor> exec)
-               -> std::unique_ptr<MatrixType> {
-        return MatrixType::create(exec, create_gpu_strategy<Strategy>(exec));
-    };
-}
-
-
 // clang-format off
 const std::map<std::string, std::function<std::unique_ptr<gko::LinOp>(
                                 std::shared_ptr<const gko::Executor>)>>
     matrix_type_factory{
-        {"csr", create_matrix_type_with_gpu_strategy<csr, csr::automatical>()},
-        {"csri", create_matrix_type_with_gpu_strategy<csr, csr::load_balance>()},
-        {"csrm", create_matrix_type<csr>(std::make_shared<csr::merge_path>())},
-        {"csrc", create_matrix_type<csr>(std::make_shared<csr::classical>())},
-        {"csrs", create_matrix_type<csr>(std::make_shared<csr::sparselib>())},
+        {"csr", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::automatical)},
+        {"csri", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::load_balance)},
+        {"csrm", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::merge_path)},
+        {"csrc", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::classical)},
+        {"csrs", create_matrix_type<csr>(gko::matrix::csr::spmv_strategy::sparselib)},
         {"coo", create_matrix_type<coo>()},
         {"ell", create_matrix_type<ell>()},
         {"ell_mixed", create_matrix_type<ell_mixed>()},

--- a/benchmark/utils/hip_linops.hip.cpp
+++ b/benchmark/utils/hip_linops.hip.cpp
@@ -138,7 +138,7 @@ protected:
                  const gko::dim<2>& size = gko::dim<2>{})
         : HipsparseBase(exec, size),
           csr_(std::move(
-              csr::create(exec, std::make_shared<typename csr::classical>()))),
+              csr::create(exec, gko::matrix::csr::spmv_strategy::classical))),
           trans_(SPARSELIB_OPERATION_NON_TRANSPOSE)
     {}
 
@@ -212,7 +212,7 @@ protected:
                    const gko::dim<2>& size = gko::dim<2>{})
         : HipsparseBase(exec, size),
           csr_(std::move(
-              csr::create(exec, std::make_shared<typename csr::classical>()))),
+              csr::create(exec, gko::matrix::csr::spmv_strategy::classical))),
           trans_(SPARSELIB_OPERATION_NON_TRANSPOSE)
     {}
 
@@ -254,7 +254,7 @@ public:
     void read(const mat_data& data) override
     {
         auto t_csr = csr::create(this->get_executor(),
-                                 std::make_shared<typename csr::classical>());
+                                 gko::matrix::csr::spmv_strategy::classical);
         t_csr->read(data);
         this->set_size(t_csr->get_size());
 

--- a/common/cuda_hip/factorization/factorization_kernels.cpp
+++ b/common/cuda_hip/factorization/factorization_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -353,13 +353,14 @@ __global__ __launch_bounds__(default_block_size) void symbolic_validate(
 
 
 template <typename ValueType, typename IndexType>
-void add_diagonal_elements(std::shared_ptr<const DefaultExecutor> exec,
-                           matrix::Csr<ValueType, IndexType>* mtx,
-                           bool is_sorted)
+void add_diagonal_elements(
+    std::shared_ptr<const DefaultExecutor> exec,
+    matrix::CsrBuilder<ValueType, IndexType>* mtx_builder, bool is_sorted)
 {
     // TODO: Runtime can be optimized by choosing a appropriate size for the
     //       subwarp dependent on the matrix properties
     constexpr int subwarp_size = config::warp_size;
+    auto mtx = mtx_builder->get_matrix();
     auto mtx_size = mtx->get_size();
     auto num_rows = static_cast<IndexType>(mtx_size[0]);
     auto num_cols = static_cast<IndexType>(mtx_size[1]);
@@ -422,9 +423,8 @@ void add_diagonal_elements(std::shared_ptr<const DefaultExecutor> exec,
                               exec->get_stream()>>>(num_rows + 1, old_row_ptrs,
                                                     row_ptrs_add);
 
-    matrix::CsrBuilder<ValueType, IndexType> mtx_builder{mtx};
-    mtx_builder.get_value_array() = std::move(new_value_array);
-    mtx_builder.get_col_idx_array() = std::move(new_col_idx_array);
+    mtx_builder->get_value_array() = std::move(new_value_array);
+    mtx_builder->get_col_idx_array() = std::move(new_col_idx_array);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/cuda_hip/factorization/par_ict_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ict_kernels.cpp
@@ -331,12 +331,12 @@ void add_candidates(syn::value_list<int, subwarp_size>,
                     const matrix::Csr<ValueType, IndexType>* llh,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
-                    matrix::Csr<ValueType, IndexType>* l_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
     auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
-    matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
+    auto l_new = l_new_builder->get_matrix();
     auto llh_row_ptrs = llh->get_const_row_ptrs();
     auto llh_col_idxs = llh->get_const_col_idxs();
     auto llh_vals = llh->get_const_values();
@@ -360,8 +360,8 @@ void add_candidates(syn::value_list<int, subwarp_size>,
 
     // resize output arrays
     auto l_new_nnz = exec->copy_val_to_host(l_new_row_ptrs + num_rows);
-    l_new_builder.get_col_idx_array().resize_and_reset(l_new_nnz);
-    l_new_builder.get_value_array().resize_and_reset(l_new_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_new_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_new_nnz);
 
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = l_new->get_values();
@@ -422,7 +422,7 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* llh,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
-                    matrix::Csr<ValueType, IndexType>* l_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz =
@@ -434,7 +434,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
             return total_nnz_per_row <= compiled_subwarp_size ||
                    compiled_subwarp_size == config::warp_size;
         },
-        syn::value_list<int>(), syn::type_list<>(), exec, llh, a, l, l_new);
+        syn::value_list<int>(), syn::type_list<>(), exec, llh, a, l,
+        l_new_builder);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_approx_filter_kernels.cpp
@@ -48,13 +48,13 @@ using compiled_kernels =
 
 
 template <int subwarp_size, typename ValueType, typename IndexType>
-void threshold_filter_approx(syn::value_list<int, subwarp_size>,
-                             std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>* tmp,
-                             remove_complex<ValueType>* threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    syn::value_list<int, subwarp_size>,
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    array<ValueType>* tmp, remove_complex<ValueType>* threshold,
+    matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto values = m->get_const_values();
     IndexType size = m->get_num_stored_elements();
@@ -105,6 +105,7 @@ void threshold_filter_approx(syn::value_list<int, subwarp_size>,
     auto num_rows = static_cast<IndexType>(m->get_size()[0]);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, block_size);
+    auto m_out = m_out_builder->get_matrix();
     auto new_row_ptrs = m_out->get_row_ptrs();
     if (num_blocks > 0) {
         kernel::bucket_filter_nnz<subwarp_size>
@@ -118,9 +119,8 @@ void threshold_filter_approx(syn::value_list<int, subwarp_size>,
     // build matrix
     auto new_nnz = exec->copy_val_to_host(new_row_ptrs + num_rows);
     // resize arrays and update aliases
-    matrix::CsrBuilder<ValueType, IndexType> builder{m_out};
-    builder.get_col_idx_array().resize_and_reset(new_nnz);
-    builder.get_value_array().resize_and_reset(new_nnz);
+    m_out_builder->get_col_idx_array().resize_and_reset(new_nnz);
+    m_out_builder->get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
     IndexType* new_row_idxs{};
@@ -148,12 +148,12 @@ GKO_ENABLE_IMPLEMENTATION_SELECTION(select_threshold_filter_approx,
 
 
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto num_rows = m->get_size()[0];
     auto total_nnz = m->get_num_stored_elements();
@@ -165,7 +165,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                    compiled_subwarp_size == config::warp_size;
         },
         syn::value_list<int>(), syn::type_list<>(), exec, m, rank, &tmp,
-        &threshold, m_out, m_out_coo);
+        &threshold, m_out_builder, m_out_coo);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_filter_kernels.cpp
@@ -49,7 +49,7 @@ void threshold_filter(syn::value_list<int, subwarp_size>,
                       std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto old_row_ptrs = a->get_const_row_ptrs();
@@ -59,6 +59,7 @@ void threshold_filter(syn::value_list<int, subwarp_size>,
     auto num_rows = static_cast<IndexType>(a->get_size()[0]);
     auto block_size = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, block_size);
+    auto m_out = m_out_builder->get_matrix();
     auto new_row_ptrs = m_out->get_row_ptrs();
     if (num_blocks > 0) {
         kernel::threshold_filter_nnz<subwarp_size>
@@ -73,9 +74,8 @@ void threshold_filter(syn::value_list<int, subwarp_size>,
     // build matrix
     auto new_nnz = exec->copy_val_to_host(new_row_ptrs + num_rows);
     // resize arrays and update aliases
-    matrix::CsrBuilder<ValueType, IndexType> builder{m_out};
-    builder.get_col_idx_array().resize_and_reset(new_nnz);
-    builder.get_value_array().resize_and_reset(new_nnz);
+    m_out_builder->get_col_idx_array().resize_and_reset(new_nnz);
+    m_out_builder->get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
     IndexType* new_row_idxs{};
@@ -107,7 +107,7 @@ template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto num_rows = a->get_size()[0];
@@ -119,8 +119,8 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
             return total_nnz_per_row <= compiled_subwarp_size ||
                    compiled_subwarp_size == config::warp_size;
         },
-        syn::value_list<int>(), syn::type_list<>(), exec, a, threshold, m_out,
-        m_out_coo, lower);
+        syn::value_list<int>(), syn::type_list<>(), exec, a, threshold,
+        m_out_builder, m_out_coo, lower);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
+++ b/common/cuda_hip/factorization/par_ilut_spgeam_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -300,14 +300,14 @@ void add_candidates(syn::value_list<int, subwarp_size>,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
                     const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
+                    matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
     auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
     auto subwarps_per_block = default_block_size / subwarp_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
-    matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
-    matrix::CsrBuilder<ValueType, IndexType> u_new_builder(u_new);
+    auto l_new = l_new_builder->get_matrix();
+    auto u_new = u_new_builder->get_matrix();
     auto lu_row_ptrs = lu->get_const_row_ptrs();
     auto lu_col_idxs = lu->get_const_col_idxs();
     auto lu_vals = lu->get_const_values();
@@ -337,10 +337,10 @@ void add_candidates(syn::value_list<int, subwarp_size>,
     // resize output arrays
     auto l_new_nnz = exec->copy_val_to_host(l_new_row_ptrs + num_rows);
     auto u_new_nnz = exec->copy_val_to_host(u_new_row_ptrs + num_rows);
-    l_new_builder.get_col_idx_array().resize_and_reset(l_new_nnz);
-    l_new_builder.get_value_array().resize_and_reset(l_new_nnz);
-    u_new_builder.get_col_idx_array().resize_and_reset(u_new_nnz);
-    u_new_builder.get_value_array().resize_and_reset(u_new_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_new_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_new_nnz);
+    u_new_builder->get_col_idx_array().resize_and_reset(u_new_nnz);
+    u_new_builder->get_value_array().resize_and_reset(u_new_nnz);
 
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = l_new->get_values();
@@ -373,8 +373,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
                     const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
+                    matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz =
@@ -386,8 +386,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
             return total_nnz_per_row <= compiled_subwarp_size ||
                    compiled_subwarp_size == config::warp_size;
         },
-        syn::value_list<int>(), syn::type_list<>(), exec, lu, a, l, u, l_new,
-        u_new);
+        syn::value_list<int>(), syn::type_list<>(), exec, lu, a, l, u,
+        l_new_builder, u_new_builder);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -2369,13 +2369,22 @@ bool try_sparselib_spmv(
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const DefaultExecutor> exec,
+          const matrix::csr::spmv_strategy strategy,
+          const IndexType max_nnz_per_row,
           const matrix::Csr<MatrixValueType, IndexType>* a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
 {
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
+        return;
+    }
+    if (b.size[0] == 0 || a->get_num_stored_elements() == 0) {
+        // empty input: zero output
+        dense::fill(exec, c, zero<OutputValueType>());
+        return;
+    }
+    if (strategy == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -2389,33 +2398,16 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
             syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
     } else {
         bool use_classical = true;
-        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
+        if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
-        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
+        } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
-            IndexType max_length_per_row = 0;
-            using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else if (a->get_strategy() ==
-                       matrix::csr::spmv_strategy::automatical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else {
-                // as a fall-back: use average row length, at least 1
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            }
-            max_length_per_row = std::max<size_type>(max_length_per_row, 1);
             host_kernel::select_classical_spmv(
                 classical_kernels(),
-                [&max_length_per_row](int compiled_info) {
-                    return max_length_per_row >= compiled_info;
+                [&max_nnz_per_row](int compiled_info) {
+                    return max_nnz_per_row >= compiled_info;
                 },
                 syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
         }
@@ -2426,6 +2418,8 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
+                   const matrix::csr::spmv_strategy strategy,
+                   const IndexType max_nnz_per_row,
                    matrix::view::dense<const MatrixValueType> alpha,
                    const matrix::Csr<MatrixValueType, IndexType>* a,
                    matrix::view::dense<const InputValueType> b,
@@ -2434,7 +2428,14 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
 {
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
+        return;
+    }
+    if (b.size[0] == 0 || a->get_num_stored_elements() == 0) {
+        // empty input: scale output
+        dense::scale(exec, beta, c);
+        return;
+    }
+    if (strategy == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -2449,35 +2450,18 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
             beta);
     } else {
         bool use_classical = true;
-        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
+        if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
-        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
+        } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical =
                 !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
-            IndexType max_length_per_row = 0;
-            using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else if (a->get_strategy() ==
-                       matrix::csr::spmv_strategy::automatical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else {
-                // as a fall-back: use average row length, at least 1
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            }
-            max_length_per_row = std::max<size_type>(max_length_per_row, 1);
             host_kernel::select_classical_spmv(
                 classical_kernels(),
-                [&max_length_per_row](int compiled_info) {
-                    return max_length_per_row >= compiled_info;
+                [&max_nnz_per_row](int compiled_info) {
+                    return max_nnz_per_row >= compiled_info;
                 },
                 syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
                 alpha, beta);

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -1357,8 +1357,10 @@ void spgeam(syn::value_list<int, subwarp_size>,
             const IndexType* a_row_ptrs, const IndexType* a_col_idxs,
             const ValueType* a_vals, const ValueType* beta,
             const IndexType* b_row_ptrs, const IndexType* b_col_idxs,
-            const ValueType* b_vals, matrix::Csr<ValueType, IndexType>* c)
+            const ValueType* b_vals,
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
+    auto c = c_builder->get_matrix();
     auto m = static_cast<IndexType>(c->get_size()[0]);
     auto c_row_ptrs = c->get_row_ptrs();
     // count nnz for alpha * A + beta * B
@@ -1374,10 +1376,9 @@ void spgeam(syn::value_list<int, subwarp_size>,
     components::prefix_sum_nonnegative(exec, c_row_ptrs, m + 1);
 
     // accumulate non-zeros for alpha * A + beta * B
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
     auto c_nnz = exec->copy_val_to_host(c_row_ptrs + m);
-    c_builder.get_col_idx_array().resize_and_reset(c_nnz);
-    c_builder.get_value_array().resize_and_reset(c_nnz);
+    c_builder->get_col_idx_array().resize_and_reset(c_nnz);
+    c_builder->get_value_array().resize_and_reset(c_nnz);
     auto c_col_idxs = c->get_col_idxs();
     auto c_vals = c->get_values();
     if (num_blocks > 0) {
@@ -1402,7 +1403,7 @@ void spgeam(std::shared_ptr<const DefaultExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             matrix::view::dense<const ValueType> beta,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto total_nnz =
         a->get_num_stored_elements() + b->get_num_stored_elements();
@@ -1416,7 +1417,7 @@ void spgeam(std::shared_ptr<const DefaultExecutor> exec,
         syn::value_list<int>(), syn::type_list<>(), exec, alpha.values,
         a->get_const_row_ptrs(), a->get_const_col_idxs(), a->get_const_values(),
         beta.values, b->get_const_row_ptrs(), b->get_const_col_idxs(),
-        b->get_const_values(), c);
+        b->get_const_values(), c_builder);
 }
 
 
@@ -2474,8 +2475,9 @@ template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const DefaultExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
+    auto c = c_builder->get_matrix();
 #ifdef GKO_COMPILING_HIP
     if (sparselib::is_supported<ValueType, IndexType>::value) {
         auto handle = exec->get_sparselib_handle();
@@ -2502,9 +2504,8 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
         auto n = static_cast<IndexType>(b->get_size()[1]);
         auto k = static_cast<IndexType>(a->get_size()[1]);
         auto c_row_ptrs = c->get_row_ptrs();
-        matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-        auto& c_col_idxs_array = c_builder.get_col_idx_array();
-        auto& c_vals_array = c_builder.get_value_array();
+        auto& c_col_idxs_array = c_builder->get_col_idx_array();
+        auto& c_vals_array = c_builder->get_value_array();
 
         // allocate buffer
         size_type buffer_size{};
@@ -2562,9 +2563,8 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
     auto m = IndexType(a->get_size()[0]);
     auto n = IndexType(b->get_size()[1]);
     auto k = IndexType(a->get_size()[1]);
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
 
     const auto beta = zero<ValueType>();
     auto spgemm_descr = sparselib::create_spgemm_descr();
@@ -2624,8 +2624,9 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* b,
                      matrix::view::dense<const ValueType> beta,
                      const matrix::Csr<ValueType, IndexType>* d,
-                     matrix::Csr<ValueType, IndexType>* c)
+                     matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
+    auto c = c_builder->get_matrix();
 #ifdef GKO_COMPILING_HIP
     if (sparselib::is_supported<ValueType, IndexType>::value) {
         auto handle = exec->get_sparselib_handle();
@@ -2701,7 +2702,7 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
             },
             syn::value_list<int>(), syn::type_list<>(), exec, alpha.values,
             c_tmp_row_ptrs, c_tmp_col_idxs, c_tmp_vals, beta.values, d_row_ptrs,
-            d_col_idxs, d_vals, c);
+            d_col_idxs, d_vals, c_builder);
     } else {
         GKO_NOT_IMPLEMENTED;
     }
@@ -2793,7 +2794,7 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
         c_tmp_row_ptrs_array.get_const_data(),
         c_tmp_col_idxs_array.get_const_data(),
         c_tmp_vals_array.get_const_data(), beta.values, d_row_ptrs, d_col_idxs,
-        d_vals, c);
+        d_vals, c_builder);
 #endif  // GKO_COMPILING_CUDA
 }
 

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -2375,7 +2375,7 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
 {
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy()->get_name() == "merge_path") {
+    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -2389,23 +2389,23 @@ void spmv(std::shared_ptr<const DefaultExecutor> exec,
             syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
     } else {
         bool use_classical = true;
-        if (a->get_strategy()->get_name() == "load_balance") {
+        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
-        } else if (a->get_strategy()->get_name() == "sparselib" ||
-                   a->get_strategy()->get_name() == "cusparse") {
+        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
             use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
             using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (auto strategy =
-                    std::dynamic_pointer_cast<const typename Tcsr::classical>(
-                        a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
-            } else if (auto strategy = std::dynamic_pointer_cast<
-                           const typename Tcsr::automatical>(
-                           a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
+            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
+            } else if (a->get_strategy() ==
+                       matrix::csr::spmv_strategy::automatical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
             } else {
                 // as a fall-back: use average row length, at least 1
                 max_length_per_row = a->get_num_stored_elements() /
@@ -2434,7 +2434,7 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
 {
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy()->get_name() == "merge_path") {
+    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -2449,25 +2449,25 @@ void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,
             beta);
     } else {
         bool use_classical = true;
-        if (a->get_strategy()->get_name() == "load_balance") {
+        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
-        } else if (a->get_strategy()->get_name() == "sparselib" ||
-                   a->get_strategy()->get_name() == "cusparse") {
+        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
             use_classical =
                 !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
             using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (auto strategy =
-                    std::dynamic_pointer_cast<const typename Tcsr::classical>(
-                        a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
-            } else if (auto strategy = std::dynamic_pointer_cast<
-                           const typename Tcsr::automatical>(
-                           a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
+            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
+            } else if (a->get_strategy() ==
+                       matrix::csr::spmv_strategy::automatical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
             } else {
                 // as a fall-back: use average row length, at least 1
                 max_length_per_row = a->get_num_stored_elements() /

--- a/core/config/config_helper.hpp
+++ b/core/config/config_helper.hpp
@@ -310,6 +310,8 @@ inline matrix::csr::spmv_strategy get_strategy(const pnode& config)
         return matrix::csr::spmv_strategy::classical;
     } else if (str == "automatical") {
         return matrix::csr::spmv_strategy::automatical;
+    } else if (str == "load_balance") {
+        return matrix::csr::spmv_strategy::load_balance;
     } else {
         GKO_INVALID_CONFIG_VALUE("strategy", str);
     }

--- a/core/config/config_helper.hpp
+++ b/core/config/config_helper.hpp
@@ -15,6 +15,7 @@
 #include <ginkgo/core/base/math.hpp>
 #include <ginkgo/core/config/config.hpp>
 #include <ginkgo/core/config/registry.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/solver/solver_base.hpp>
 #include <ginkgo/core/stop/criterion.hpp>
 
@@ -298,22 +299,20 @@ get_value(const pnode& config)
 
 
 template <typename Csr>
-inline std::shared_ptr<typename Csr::strategy_type> get_strategy(
-    const pnode& config)
+inline matrix::csr::spmv_strategy get_strategy(const pnode& config)
 {
     auto str = config.get_string();
-    std::shared_ptr<typename Csr::strategy_type> strategy_ptr;
-    // automatical and load_balance requires the executor
-    if (str == "sparselib" || str == "cusparse") {
-        strategy_ptr = std::make_shared<typename Csr::sparselib>();
+    if (str == "sparselib") {
+        return matrix::csr::spmv_strategy::sparselib;
     } else if (str == "merge_path") {
-        strategy_ptr = std::make_shared<typename Csr::merge_path>();
+        return matrix::csr::spmv_strategy::merge_path;
     } else if (str == "classical") {
-        strategy_ptr = std::make_shared<typename Csr::classical>();
+        return matrix::csr::spmv_strategy::classical;
+    } else if (str == "automatical") {
+        return matrix::csr::spmv_strategy::automatical;
     } else {
         GKO_INVALID_CONFIG_VALUE("strategy", str);
     }
-    return strategy_ptr;
 }
 
 

--- a/core/config/config_helper.hpp
+++ b/core/config/config_helper.hpp
@@ -308,8 +308,8 @@ inline matrix::csr::spmv_strategy get_strategy(const pnode& config)
         return matrix::csr::spmv_strategy::merge_path;
     } else if (str == "classical") {
         return matrix::csr::spmv_strategy::classical;
-    } else if (str == "automatical") {
-        return matrix::csr::spmv_strategy::automatical;
+    } else if (str == "automatic") {
+        return matrix::csr::spmv_strategy::automatic;
     } else if (str == "load_balance") {
         return matrix::csr::spmv_strategy::load_balance;
     } else {

--- a/core/factorization/factorization_kernels.hpp
+++ b/core/factorization/factorization_kernels.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -13,6 +13,7 @@
 #include <ginkgo/core/matrix/csr.hpp>
 
 #include "core/base/kernel_declaration.hpp"
+#include "core/matrix/csr_builder.hpp"
 #include "core/matrix/csr_lookup.hpp"
 
 
@@ -20,11 +21,11 @@ namespace gko {
 namespace kernels {
 
 
-#define GKO_DECLARE_FACTORIZATION_ADD_DIAGONAL_ELEMENTS_KERNEL(ValueType,   \
-                                                               IndexType)   \
-    void add_diagonal_elements(std::shared_ptr<const DefaultExecutor> exec, \
-                               matrix::Csr<ValueType, IndexType>* mtx,      \
-                               bool is_sorted)
+#define GKO_DECLARE_FACTORIZATION_ADD_DIAGONAL_ELEMENTS_KERNEL(ValueType, \
+                                                               IndexType) \
+    void add_diagonal_elements(                                           \
+        std::shared_ptr<const DefaultExecutor> exec,                      \
+        matrix::CsrBuilder<ValueType, IndexType>* mtx_builder, bool is_sorted)
 
 #define GKO_DECLARE_FACTORIZATION_INITIALIZE_ROW_PTRS_L_U_KERNEL(ValueType, \
                                                                  IndexType) \

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -102,10 +102,7 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
 
     // TODO: it always run make_srow even if the matrix is not changed
     exec->run(ic_factorization::make_add_diagonal_elements(
-        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
-            local_system_matrix)
-            .get(),
-        false));
+        matrix::make_builder_unique_ptr(local_system_matrix).get(), false));
     std::shared_ptr<const matrix_type> ic;
     // Compute IC factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -101,7 +101,7 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
     // Add explicit diagonal zero elements if they are missing
     exec->run(ic_factorization::make_add_diagonal_elements(
         local_system_matrix.get(), false));
-
+    local_system_matrix->set_strategy(local_system_matrix->get_strategy());
     std::shared_ptr<const matrix_type> ic;
     // Compute IC factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -99,9 +99,13 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
     }
 
     // Add explicit diagonal zero elements if they are missing
-    exec->run(ic_factorization::make_add_diagonal_elements(
-        local_system_matrix.get(), false));
-    local_system_matrix->set_strategy(local_system_matrix->get_strategy());
+    {
+        // TODO: it always run make_srow even if the matrix is not changed
+        auto mtx_builder =
+            matrix::CsrBuilder<ValueType, IndexType>(local_system_matrix);
+        exec->run(
+            ic_factorization::make_add_diagonal_elements(&mtx_builder, false));
+    }
     std::shared_ptr<const matrix_type> ic;
     // Compute IC factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/ic.cpp
+++ b/core/factorization/ic.cpp
@@ -99,13 +99,13 @@ std::unique_ptr<Composition<ValueType>> Ic<ValueType, IndexType>::generate(
     }
 
     // Add explicit diagonal zero elements if they are missing
-    {
-        // TODO: it always run make_srow even if the matrix is not changed
-        auto mtx_builder =
-            matrix::CsrBuilder<ValueType, IndexType>(local_system_matrix);
-        exec->run(
-            ic_factorization::make_add_diagonal_elements(&mtx_builder, false));
-    }
+
+    // TODO: it always run make_srow even if the matrix is not changed
+    exec->run(ic_factorization::make_add_diagonal_elements(
+        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
+            local_system_matrix)
+            .get(),
+        false));
     std::shared_ptr<const matrix_type> ic;
     // Compute IC factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -97,10 +97,7 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
     // TODO: it always run make_srow even if the matrix is not changed
     // Add explicit diagonal zero elements if they are missing
     exec->run(ilu_factorization::make_add_diagonal_elements(
-        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
-            local_system_matrix)
-            .get(),
-        false));
+        matrix::make_builder_unique_ptr(local_system_matrix).get(), false));
     std::shared_ptr<const matrix_type> ilu;
     // Compute ILU factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -94,14 +94,13 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
         local_system_matrix->sort_by_column_index();
     }
 
-    {
-        // TODO: it always run make_srow even if the matrix is not changed
-        auto mtx_builder =
-            matrix::CsrBuilder<ValueType, IndexType>(local_system_matrix);
-        // Add explicit diagonal zero elements if they are missing
-        exec->run(
-            ilu_factorization::make_add_diagonal_elements(&mtx_builder, false));
-    }
+    // TODO: it always run make_srow even if the matrix is not changed
+    // Add explicit diagonal zero elements if they are missing
+    exec->run(ilu_factorization::make_add_diagonal_elements(
+        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
+            local_system_matrix)
+            .get(),
+        false));
     std::shared_ptr<const matrix_type> ilu;
     // Compute ILU factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -97,7 +97,7 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
     // Add explicit diagonal zero elements if they are missing
     exec->run(ilu_factorization::make_add_diagonal_elements(
         local_system_matrix.get(), false));
-
+    local_system_matrix->set_strategy(local_system_matrix->get_strategy());
     std::shared_ptr<const matrix_type> ilu;
     // Compute ILU factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/ilu.cpp
+++ b/core/factorization/ilu.cpp
@@ -94,10 +94,14 @@ std::unique_ptr<Composition<ValueType>> Ilu<ValueType, IndexType>::generate_l_u(
         local_system_matrix->sort_by_column_index();
     }
 
-    // Add explicit diagonal zero elements if they are missing
-    exec->run(ilu_factorization::make_add_diagonal_elements(
-        local_system_matrix.get(), false));
-    local_system_matrix->set_strategy(local_system_matrix->get_strategy());
+    {
+        // TODO: it always run make_srow even if the matrix is not changed
+        auto mtx_builder =
+            matrix::CsrBuilder<ValueType, IndexType>(local_system_matrix);
+        // Add explicit diagonal zero elements if they are missing
+        exec->run(
+            ilu_factorization::make_add_diagonal_elements(&mtx_builder, false));
+    }
     std::shared_ptr<const matrix_type> ilu;
     // Compute ILU factorization
     if (parameters_.algorithm == incomplete_algorithm::syncfree ||

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -91,14 +91,14 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
         csr_system_matrix->sort_by_column_index();
     }
 
-    {
-        // TODO: it always run make_srow even if the matrix is not changed
-        auto mtx_builder =
-            matrix::CsrBuilder<ValueType, IndexType>(csr_system_matrix);
-        // Add explicit diagonal zero elements if they are missing
-        exec->run(par_ic_factorization::make_add_diagonal_elements(&mtx_builder,
-                                                                   true));
-    }
+    // TODO: it always run make_srow even if the matrix is not changed
+    // Add explicit diagonal zero elements if they are missing
+    exec->run(par_ic_factorization::make_add_diagonal_elements(
+        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
+            csr_system_matrix)
+            .get(),
+        true));
+
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -91,10 +91,14 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
         csr_system_matrix->sort_by_column_index();
     }
 
-    // Add explicit diagonal zero elements if they are missing
-    exec->run(par_ic_factorization::make_add_diagonal_elements(
-        csr_system_matrix.get(), true));
-    csr_system_matrix->set_strategy(csr_system_matrix->get_strategy());
+    {
+        // TODO: it always run make_srow even if the matrix is not changed
+        auto mtx_builder =
+            matrix::CsrBuilder<ValueType, IndexType>(csr_system_matrix);
+        // Add explicit diagonal zero elements if they are missing
+        exec->run(par_ic_factorization::make_add_diagonal_elements(&mtx_builder,
+                                                                   true));
+    }
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
     // Add explicit diagonal zero elements if they are missing
     exec->run(par_ic_factorization::make_add_diagonal_elements(
         csr_system_matrix.get(), true));
-
+    csr_system_matrix->set_strategy(csr_system_matrix->get_strategy());
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ic.cpp
+++ b/core/factorization/par_ic.cpp
@@ -94,10 +94,7 @@ std::unique_ptr<Composition<ValueType>> ParIc<ValueType, IndexType>::generate(
     // TODO: it always run make_srow even if the matrix is not changed
     // Add explicit diagonal zero elements if they are missing
     exec->run(par_ic_factorization::make_add_diagonal_elements(
-        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
-            csr_system_matrix)
-            .get(),
-        true));
+        matrix::make_builder_unique_ptr(csr_system_matrix).get(), true));
 
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -233,12 +233,18 @@ ParIct<ValueType, IndexType>::generate_l_lt(
 template <typename ValueType, typename IndexType>
 void ParIctState<ValueType, IndexType>::iterate()
 {
-    // compute L * L^H
-    exec->run(make_spgemm(l.get(), lh.get(), llh.get()));
+    {
+        auto builder = CsrBuilder(llh);
+        // compute L * L^H
+        exec->run(make_spgemm(l.get(), lh.get(), &builder));
+    }
 
-    // add new candidates to L' factor
-    exec->run(
-        make_add_candidates(llh.get(), system_matrix, l.get(), l_new.get()));
+    {
+        auto builder = CsrBuilder(l_new);
+        // add new candidates to L' factor
+        exec->run(
+            make_add_candidates(llh.get(), system_matrix, l.get(), &builder));
+    }
 
     // update L(COO), L'^H sizes and pointers
     {
@@ -268,9 +274,10 @@ void ParIctState<ValueType, IndexType>::iterate()
     auto l_filter_rank = std::max<IndexType>(0, l_nnz - l_nnz_limit - 1);
     if (use_approx_select) {
         remove_complex<ValueType> tmp{};
+        auto builder = CsrBuilder(l);
         // remove approximately smallest candidates
         exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
-                                               selection_tmp, tmp, l.get(),
+                                               selection_tmp, tmp, &builder,
                                                l_coo.get()));
     } else {
         // select threshold to remove smallest candidates
@@ -278,9 +285,9 @@ void ParIctState<ValueType, IndexType>::iterate()
         exec->run(make_threshold_select(l_new.get(), l_filter_rank,
                                         selection_tmp, selection_tmp2,
                                         l_threshold));
-
+        auto builder = CsrBuilder(l);
         // remove smallest candidates
-        exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
+        exec->run(make_threshold_filter(l_new.get(), l_threshold, &builder,
                                         l_coo.get(), true));
     }
 

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -236,6 +236,7 @@ void ParIctState<ValueType, IndexType>::iterate()
     // compute L * L^H
     exec->run(
         make_spgemm(l.get(), lh.get(), make_builder_unique_ptr(llh).get()));
+
     // add new candidates to L' factor
     exec->run(make_add_candidates(llh.get(), system_matrix, l.get(),
                                   make_builder_unique_ptr(l_new).get()));

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -233,18 +233,12 @@ ParIct<ValueType, IndexType>::generate_l_lt(
 template <typename ValueType, typename IndexType>
 void ParIctState<ValueType, IndexType>::iterate()
 {
-    {
-        auto builder = CsrBuilder(llh);
-        // compute L * L^H
-        exec->run(make_spgemm(l.get(), lh.get(), &builder));
-    }
-
-    {
-        auto builder = CsrBuilder(l_new);
-        // add new candidates to L' factor
-        exec->run(
-            make_add_candidates(llh.get(), system_matrix, l.get(), &builder));
-    }
+    // compute L * L^H
+    exec->run(make_spgemm(l.get(), lh.get(),
+                          std::make_unique<CsrBuilder>(llh).get()));
+    // add new candidates to L' factor
+    exec->run(make_add_candidates(llh.get(), system_matrix, l.get(),
+                                  std::make_unique<CsrBuilder>(l_new).get()));
 
     // update L(COO), L'^H sizes and pointers
     {
@@ -274,20 +268,19 @@ void ParIctState<ValueType, IndexType>::iterate()
     auto l_filter_rank = std::max<IndexType>(0, l_nnz - l_nnz_limit - 1);
     if (use_approx_select) {
         remove_complex<ValueType> tmp{};
-        auto builder = CsrBuilder(l);
         // remove approximately smallest candidates
-        exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
-                                               selection_tmp, tmp, &builder,
-                                               l_coo.get()));
+        exec->run(make_threshold_filter_approx(
+            l_new.get(), l_filter_rank, selection_tmp, tmp,
+            std::make_unique<CsrBuilder>(l).get(), l_coo.get()));
     } else {
         // select threshold to remove smallest candidates
         remove_complex<ValueType> l_threshold{};
         exec->run(make_threshold_select(l_new.get(), l_filter_rank,
                                         selection_tmp, selection_tmp2,
                                         l_threshold));
-        auto builder = CsrBuilder(l);
         // remove smallest candidates
-        exec->run(make_threshold_filter(l_new.get(), l_threshold, &builder,
+        exec->run(make_threshold_filter(l_new.get(), l_threshold,
+                                        std::make_unique<CsrBuilder>(l).get(),
                                         l_coo.get(), true));
     }
 
@@ -298,11 +291,11 @@ void ParIctState<ValueType, IndexType>::iterate()
     // convert L to L^H
     {
         auto l_nnz = l->get_num_stored_elements();
-        CsrBuilder lt_builder{lh};
-        lt_builder.get_col_idx_array().resize_and_reset(l_nnz);
-        lt_builder.get_value_array().resize_and_reset(l_nnz);
+        CsrBuilder lh_builder{lh};
+        lh_builder.get_col_idx_array().resize_and_reset(l_nnz);
+        lh_builder.get_value_array().resize_and_reset(l_nnz);
+        exec->run(make_csr_conj_transpose(l.get(), lh.get()));
     }
-    exec->run(make_csr_conj_transpose(l.get(), lh.get()));
 }
 
 

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -234,11 +234,11 @@ template <typename ValueType, typename IndexType>
 void ParIctState<ValueType, IndexType>::iterate()
 {
     // compute L * L^H
-    exec->run(make_spgemm(l.get(), lh.get(),
-                          std::make_unique<CsrBuilder>(llh).get()));
+    exec->run(
+        make_spgemm(l.get(), lh.get(), make_builder_unique_ptr(llh).get()));
     // add new candidates to L' factor
     exec->run(make_add_candidates(llh.get(), system_matrix, l.get(),
-                                  std::make_unique<CsrBuilder>(l_new).get()));
+                                  make_builder_unique_ptr(l_new).get()));
 
     // update L(COO), L'^H sizes and pointers
     {
@@ -271,7 +271,7 @@ void ParIctState<ValueType, IndexType>::iterate()
         // remove approximately smallest candidates
         exec->run(make_threshold_filter_approx(
             l_new.get(), l_filter_rank, selection_tmp, tmp,
-            std::make_unique<CsrBuilder>(l).get(), l_coo.get()));
+            make_builder_unique_ptr(l).get(), l_coo.get()));
     } else {
         // select threshold to remove smallest candidates
         remove_complex<ValueType> l_threshold{};
@@ -280,7 +280,7 @@ void ParIctState<ValueType, IndexType>::iterate()
                                         l_threshold));
         // remove smallest candidates
         exec->run(make_threshold_filter(l_new.get(), l_threshold,
-                                        std::make_unique<CsrBuilder>(l).get(),
+                                        make_builder_unique_ptr(l).get(),
                                         l_coo.get(), true));
     }
 

--- a/core/factorization/par_ict.cpp
+++ b/core/factorization/par_ict.cpp
@@ -101,16 +101,15 @@ struct ParIctState {
     // temporary array for threshold selection
     array<remove_complex<ValueType>> selection_tmp2;
     // strategy to be used by the lower factor
-    std::shared_ptr<typename CsrMatrix::strategy_type> l_strategy;
+    matrix::csr::spmv_strategy l_strategy;
     // strategy to be used by the upper factor
-    std::shared_ptr<typename CsrMatrix::strategy_type> lh_strategy;
+    matrix::csr::spmv_strategy lh_strategy;
 
     ParIctState(std::shared_ptr<const Executor> exec_in,
                 const CsrMatrix* system_matrix_in,
                 std::unique_ptr<CsrMatrix> l_in, IndexType l_nnz_limit,
-                bool use_approx_select,
-                std::shared_ptr<typename CsrMatrix::strategy_type> l_strategy_,
-                std::shared_ptr<typename CsrMatrix::strategy_type> lh_strategy_)
+                bool use_approx_select, matrix::csr::spmv_strategy l_strategy_,
+                matrix::csr::spmv_strategy lh_strategy_)
         : exec{std::move(exec_in)},
           l_nnz_limit{l_nnz_limit},
           use_approx_select{use_approx_select},
@@ -118,8 +117,8 @@ struct ParIctState {
           l{std::move(l_in)},
           selection_tmp{exec},
           selection_tmp2{exec},
-          l_strategy{std::move(l_strategy_)},
-          lh_strategy{std::move(lh_strategy_)}
+          l_strategy{l_strategy_},
+          lh_strategy{lh_strategy_}
     {
         auto mtx_size = system_matrix->get_size();
         auto l_nnz = l->get_num_stored_elements();

--- a/core/factorization/par_ict_kernels.hpp
+++ b/core/factorization/par_ict_kernels.hpp
@@ -23,11 +23,12 @@ namespace kernels {
 
 
 #define GKO_DECLARE_PAR_ICT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
-    void add_candidates(std::shared_ptr<const DefaultExecutor> exec,    \
-                        const matrix::Csr<ValueType, IndexType>* llh,   \
-                        const matrix::Csr<ValueType, IndexType>* a,     \
-                        const matrix::Csr<ValueType, IndexType>* l,     \
-                        matrix::Csr<ValueType, IndexType>* l_new)
+    void add_candidates(                                                \
+        std::shared_ptr<const DefaultExecutor> exec,                    \
+        const matrix::Csr<ValueType, IndexType>* llh,                   \
+        const matrix::Csr<ValueType, IndexType>* a,                     \
+        const matrix::Csr<ValueType, IndexType>* l,                     \
+        matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 
 #define GKO_DECLARE_PAR_ICT_COMPUTE_FACTOR_KERNEL(ValueType, IndexType) \
     void compute_factor(                                                \

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -95,6 +95,7 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     // Add explicit diagonal zero elements if they are missing
     exec->run(par_ilu_factorization::make_add_diagonal_elements(
         matrix::make_builder_unique_ptr(csr_system_matrix).get(), true));
+
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -94,7 +94,7 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     // Add explicit diagonal zero elements if they are missing
     exec->run(par_ilu_factorization::make_add_diagonal_elements(
         csr_system_matrix.get(), true));
-
+    csr_system_matrix->set_strategy(csr_system_matrix->get_strategy());
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -91,14 +91,13 @@ ParIlu<ValueType, IndexType>::generate_l_u(
         csr_system_matrix->sort_by_column_index();
     }
 
-    {
-        // TODO: it always run make_srow even if the matrix is not changed
-        auto mtx_builder =
-            matrix::CsrBuilder<ValueType, IndexType>(csr_system_matrix);
-        // Add explicit diagonal zero elements if they are missing
-        exec->run(par_ilu_factorization::make_add_diagonal_elements(
-            &mtx_builder, true));
-    }
+    // TODO: it always run make_srow even if the matrix is not changed
+    // Add explicit diagonal zero elements if they are missing
+    exec->run(par_ilu_factorization::make_add_diagonal_elements(
+        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
+            csr_system_matrix)
+            .get(),
+        true));
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -91,10 +91,14 @@ ParIlu<ValueType, IndexType>::generate_l_u(
         csr_system_matrix->sort_by_column_index();
     }
 
-    // Add explicit diagonal zero elements if they are missing
-    exec->run(par_ilu_factorization::make_add_diagonal_elements(
-        csr_system_matrix.get(), true));
-    csr_system_matrix->set_strategy(csr_system_matrix->get_strategy());
+    {
+        // TODO: it always run make_srow even if the matrix is not changed
+        auto mtx_builder =
+            matrix::CsrBuilder<ValueType, IndexType>(csr_system_matrix);
+        // Add explicit diagonal zero elements if they are missing
+        exec->run(par_ilu_factorization::make_add_diagonal_elements(
+            &mtx_builder, true));
+    }
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -71,8 +71,8 @@ template <typename ValueType, typename IndexType>
 std::unique_ptr<Composition<ValueType>>
 ParIlu<ValueType, IndexType>::generate_l_u(
     const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting,
-    std::shared_ptr<typename l_matrix_type::strategy_type> l_strategy,
-    std::shared_ptr<typename u_matrix_type::strategy_type> u_strategy) const
+    matrix::csr::spmv_strategy l_strategy,
+    matrix::csr::spmv_strategy u_strategy) const
 {
     using CsrMatrix = matrix::Csr<ValueType, IndexType>;
     using CooMatrix = matrix::Coo<ValueType, IndexType>;

--- a/core/factorization/par_ilu.cpp
+++ b/core/factorization/par_ilu.cpp
@@ -94,10 +94,7 @@ ParIlu<ValueType, IndexType>::generate_l_u(
     // TODO: it always run make_srow even if the matrix is not changed
     // Add explicit diagonal zero elements if they are missing
     exec->run(par_ilu_factorization::make_add_diagonal_elements(
-        std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
-            csr_system_matrix)
-            .get(),
-        true));
+        matrix::make_builder_unique_ptr(csr_system_matrix).get(), true));
     const auto matrix_size = csr_system_matrix->get_size();
     const auto number_rows = matrix_size[0];
     array<IndexType> l_row_ptrs{exec, number_rows + 1};

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -262,19 +262,13 @@ ParIlut<ValueType, IndexType>::generate_l_u(
 template <typename ValueType, typename IndexType>
 void ParIlutState<ValueType, IndexType>::iterate()
 {
-    {
-        auto builder = CsrBuilder(lu);
-        // compute L * U
-        exec->run(make_spgemm(l.get(), u.get(), &builder));
-    }
-
-    {
-        auto l_new_builder = CsrBuilder(l_new);
-        auto u_new_builder = CsrBuilder(u_new);
-        // add new candidates to L' and U' factors
-        exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
-                                      &l_new_builder, &u_new_builder));
-    }
+    // compute L * U
+    exec->run(
+        make_spgemm(l.get(), u.get(), std::make_unique<CsrBuilder>(lu).get()));
+    // add new candidates to L' and U' factors
+    exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
+                                  std::make_unique<CsrBuilder>(l_new).get(),
+                                  std::make_unique<CsrBuilder>(u_new).get()));
 
     // update U'(CSC), L'(COO), U'(COO) sizes and pointers
     {
@@ -325,15 +319,13 @@ void ParIlutState<ValueType, IndexType>::iterate()
     remove_complex<ValueType> u_threshold{};
     CooMatrix* null_coo = nullptr;
     if (use_approx_select) {
-        auto l_builder = CsrBuilder(l);
-        auto u_csc_builder = CsrBuilder(u_csc);
         // remove approximately smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
-                                               selection_tmp, l_threshold,
-                                               &l_builder, l_coo.get()));
-        exec->run(make_threshold_filter_approx(u_new_csc.get(), u_filter_rank,
-                                               selection_tmp, u_threshold,
-                                               &u_csc_builder, null_coo));
+        exec->run(make_threshold_filter_approx(
+            l_new.get(), l_filter_rank, selection_tmp, l_threshold,
+            std::make_unique<CsrBuilder>(l).get(), l_coo.get()));
+        exec->run(make_threshold_filter_approx(
+            u_new_csc.get(), u_filter_rank, selection_tmp, u_threshold,
+            std::make_unique<CsrBuilder>(u_csc).get(), null_coo));
     } else {
         // select threshold to remove smallest candidates
         exec->run(make_threshold_select(l_new.get(), l_filter_rank,
@@ -343,20 +335,18 @@ void ParIlutState<ValueType, IndexType>::iterate()
                                         selection_tmp, selection_tmp2,
                                         u_threshold));
 
-        auto l_builder = CsrBuilder(l);
-        auto u_csc_builder = CsrBuilder(u_csc);
         // remove smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter(l_new.get(), l_threshold, &l_builder,
+        exec->run(make_threshold_filter(l_new.get(), l_threshold,
+                                        std::make_unique<CsrBuilder>(l).get(),
                                         l_coo.get(), true));
-        exec->run(make_threshold_filter(u_new_csc.get(), u_threshold,
-                                        &u_csc_builder, null_coo, true));
+        exec->run(make_threshold_filter(
+            u_new_csc.get(), u_threshold,
+            std::make_unique<CsrBuilder>(u_csc).get(), null_coo, true));
     }
-    {
-        auto builder = CsrBuilder(u);
-        // remove smallest candidates from U'
-        exec->run(make_threshold_filter(u_new.get(), u_threshold, &builder,
-                                        u_coo.get(), false));
-    }
+    // remove smallest candidates from U'
+    exec->run(make_threshold_filter(u_new.get(), u_threshold,
+                                    std::make_unique<CsrBuilder>(u).get(),
+                                    u_coo.get(), false));
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(
         system_matrix, l.get(), l_coo->get_const_device_view(), u.get(),

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -263,12 +263,11 @@ template <typename ValueType, typename IndexType>
 void ParIlutState<ValueType, IndexType>::iterate()
 {
     // compute L * U
-    exec->run(
-        make_spgemm(l.get(), u.get(), std::make_unique<CsrBuilder>(lu).get()));
+    exec->run(make_spgemm(l.get(), u.get(), make_builder_unique_ptr(lu).get()));
     // add new candidates to L' and U' factors
     exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
-                                  std::make_unique<CsrBuilder>(l_new).get(),
-                                  std::make_unique<CsrBuilder>(u_new).get()));
+                                  make_builder_unique_ptr(l_new).get(),
+                                  make_builder_unique_ptr(u_new).get()));
 
     // update U'(CSC), L'(COO), U'(COO) sizes and pointers
     {
@@ -322,10 +321,10 @@ void ParIlutState<ValueType, IndexType>::iterate()
         // remove approximately smallest candidates from L' and U'^T
         exec->run(make_threshold_filter_approx(
             l_new.get(), l_filter_rank, selection_tmp, l_threshold,
-            std::make_unique<CsrBuilder>(l).get(), l_coo.get()));
+            make_builder_unique_ptr(l).get(), l_coo.get()));
         exec->run(make_threshold_filter_approx(
             u_new_csc.get(), u_filter_rank, selection_tmp, u_threshold,
-            std::make_unique<CsrBuilder>(u_csc).get(), null_coo));
+            make_builder_unique_ptr(u_csc).get(), null_coo));
     } else {
         // select threshold to remove smallest candidates
         exec->run(make_threshold_select(l_new.get(), l_filter_rank,
@@ -337,15 +336,15 @@ void ParIlutState<ValueType, IndexType>::iterate()
 
         // remove smallest candidates from L' and U'^T
         exec->run(make_threshold_filter(l_new.get(), l_threshold,
-                                        std::make_unique<CsrBuilder>(l).get(),
+                                        make_builder_unique_ptr(l).get(),
                                         l_coo.get(), true));
-        exec->run(make_threshold_filter(
-            u_new_csc.get(), u_threshold,
-            std::make_unique<CsrBuilder>(u_csc).get(), null_coo, true));
+        exec->run(make_threshold_filter(u_new_csc.get(), u_threshold,
+                                        make_builder_unique_ptr(u_csc).get(),
+                                        null_coo, true));
     }
     // remove smallest candidates from U'
     exec->run(make_threshold_filter(u_new.get(), u_threshold,
-                                    std::make_unique<CsrBuilder>(u).get(),
+                                    make_builder_unique_ptr(u).get(),
                                     u_coo.get(), false));
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -110,17 +110,17 @@ struct ParIlutState {
     // temporary array for threshold selection
     array<remove_complex<ValueType>> selection_tmp2;
     // strategy to be used by the lower factor
-    std::shared_ptr<typename CsrMatrix::strategy_type> l_strategy;
+    matrix::csr::spmv_strategy l_strategy;
     // strategy to be used by the upper factor
-    std::shared_ptr<typename CsrMatrix::strategy_type> u_strategy;
+    matrix::csr::spmv_strategy u_strategy;
 
     ParIlutState(std::shared_ptr<const Executor> exec_in,
                  const CsrMatrix* system_matrix_in,
                  std::unique_ptr<CsrMatrix> l_in,
                  std::unique_ptr<CsrMatrix> u_in, IndexType l_nnz_limit,
                  IndexType u_nnz_limit, bool use_approx_select,
-                 std::shared_ptr<typename CsrMatrix::strategy_type> l_strategy_,
-                 std::shared_ptr<typename CsrMatrix::strategy_type> u_strategy_)
+                 matrix::csr::spmv_strategy l_strategy_,
+                 matrix::csr::spmv_strategy u_strategy_)
         : exec{std::move(exec_in)},
           l_nnz_limit{l_nnz_limit},
           u_nnz_limit{u_nnz_limit},
@@ -130,8 +130,8 @@ struct ParIlutState {
           u{std::move(u_in)},
           selection_tmp{exec},
           selection_tmp2{exec},
-          l_strategy{std::move(l_strategy_)},
-          u_strategy{std::move(u_strategy_)}
+          l_strategy{l_strategy_},
+          u_strategy{u_strategy_}
     {
         auto mtx_size = system_matrix->get_size();
         auto u_nnz = u->get_num_stored_elements();

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -262,12 +262,19 @@ ParIlut<ValueType, IndexType>::generate_l_u(
 template <typename ValueType, typename IndexType>
 void ParIlutState<ValueType, IndexType>::iterate()
 {
-    // compute L * U
-    exec->run(make_spgemm(l.get(), u.get(), lu.get()));
+    {
+        auto builder = CsrBuilder(lu);
+        // compute L * U
+        exec->run(make_spgemm(l.get(), u.get(), &builder));
+    }
 
-    // add new candidates to L' and U' factors
-    exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
-                                  l_new.get(), u_new.get()));
+    {
+        auto l_new_builder = CsrBuilder(l_new);
+        auto u_new_builder = CsrBuilder(u_new);
+        // add new candidates to L' and U' factors
+        exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
+                                      &l_new_builder, &u_new_builder));
+    }
 
     // update U'(CSC), L'(COO), U'(COO) sizes and pointers
     {
@@ -318,13 +325,15 @@ void ParIlutState<ValueType, IndexType>::iterate()
     remove_complex<ValueType> u_threshold{};
     CooMatrix* null_coo = nullptr;
     if (use_approx_select) {
+        auto l_builder = CsrBuilder(l);
+        auto u_csc_builder = CsrBuilder(u_csc);
         // remove approximately smallest candidates from L' and U'^T
         exec->run(make_threshold_filter_approx(l_new.get(), l_filter_rank,
                                                selection_tmp, l_threshold,
-                                               l.get(), l_coo.get()));
+                                               &l_builder, l_coo.get()));
         exec->run(make_threshold_filter_approx(u_new_csc.get(), u_filter_rank,
                                                selection_tmp, u_threshold,
-                                               u_csc.get(), null_coo));
+                                               &u_csc_builder, null_coo));
     } else {
         // select threshold to remove smallest candidates
         exec->run(make_threshold_select(l_new.get(), l_filter_rank,
@@ -334,16 +343,20 @@ void ParIlutState<ValueType, IndexType>::iterate()
                                         selection_tmp, selection_tmp2,
                                         u_threshold));
 
+        auto l_builder = CsrBuilder(l);
+        auto u_csc_builder = CsrBuilder(u_csc);
         // remove smallest candidates from L' and U'^T
-        exec->run(make_threshold_filter(l_new.get(), l_threshold, l.get(),
+        exec->run(make_threshold_filter(l_new.get(), l_threshold, &l_builder,
                                         l_coo.get(), true));
         exec->run(make_threshold_filter(u_new_csc.get(), u_threshold,
-                                        u_csc.get(), null_coo, true));
+                                        &u_csc_builder, null_coo, true));
     }
-    // remove smallest candidates from U'
-    exec->run(make_threshold_filter(u_new.get(), u_threshold, u.get(),
-                                    u_coo.get(), false));
-
+    {
+        auto builder = CsrBuilder(u);
+        // remove smallest candidates from U'
+        exec->run(make_threshold_filter(u_new.get(), u_threshold, &builder,
+                                        u_coo.get(), false));
+    }
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(
         system_matrix, l.get(), l_coo->get_const_device_view(), u.get(),

--- a/core/factorization/par_ilut.cpp
+++ b/core/factorization/par_ilut.cpp
@@ -264,6 +264,7 @@ void ParIlutState<ValueType, IndexType>::iterate()
 {
     // compute L * U
     exec->run(make_spgemm(l.get(), u.get(), make_builder_unique_ptr(lu).get()));
+
     // add new candidates to L' and U' factors
     exec->run(make_add_candidates(lu.get(), system_matrix, l.get(), u.get(),
                                   make_builder_unique_ptr(l_new).get(),
@@ -346,6 +347,7 @@ void ParIlutState<ValueType, IndexType>::iterate()
     exec->run(make_threshold_filter(u_new.get(), u_threshold,
                                     make_builder_unique_ptr(u).get(),
                                     u_coo.get(), false));
+
     // execute asynchronous iteration
     exec->run(make_compute_l_u_factors(
         system_matrix, l.get(), l_coo->get_const_device_view(), u.get(),

--- a/core/factorization/par_ilut_kernels.hpp
+++ b/core/factorization/par_ilut_kernels.hpp
@@ -16,6 +16,7 @@
 #include <ginkgo/core/matrix/device_views.hpp>
 
 #include "core/base/kernel_declaration.hpp"
+#include "core/matrix/csr_builder.hpp"
 
 
 namespace gko {
@@ -23,13 +24,14 @@ namespace kernels {
 
 
 #define GKO_DECLARE_PAR_ILUT_ADD_CANDIDATES_KERNEL(ValueType, IndexType) \
-    void add_candidates(std::shared_ptr<const DefaultExecutor> exec,     \
-                        const matrix::Csr<ValueType, IndexType>* lu,     \
-                        const matrix::Csr<ValueType, IndexType>* a,      \
-                        const matrix::Csr<ValueType, IndexType>* l,      \
-                        const matrix::Csr<ValueType, IndexType>* u,      \
-                        matrix::Csr<ValueType, IndexType>* l_new,        \
-                        matrix::Csr<ValueType, IndexType>* u_new)
+    void add_candidates(                                                 \
+        std::shared_ptr<const DefaultExecutor> exec,                     \
+        const matrix::Csr<ValueType, IndexType>* lu,                     \
+        const matrix::Csr<ValueType, IndexType>* a,                      \
+        const matrix::Csr<ValueType, IndexType>* l,                      \
+        const matrix::Csr<ValueType, IndexType>* u,                      \
+        matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,         \
+        matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 
 #define GKO_DECLARE_PAR_ILUT_COMPUTE_LU_FACTORS_KERNEL(ValueType, IndexType) \
     void compute_l_u_factors(                                                \
@@ -49,21 +51,21 @@ namespace kernels {
                           remove_complex<ValueType>& threshold)
 
 #define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_KERNEL(ValueType, IndexType) \
-    void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,     \
-                          const matrix::Csr<ValueType, IndexType>* m,      \
-                          remove_complex<ValueType> threshold,             \
-                          matrix::Csr<ValueType, IndexType>* m_out,        \
-                          matrix::Coo<ValueType, IndexType>* m_out_coo,    \
-                          bool lower)
+    void threshold_filter(                                                 \
+        std::shared_ptr<const DefaultExecutor> exec,                       \
+        const matrix::Csr<ValueType, IndexType>* m,                        \
+        remove_complex<ValueType> threshold,                               \
+        matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,           \
+        matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 
-#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType,        \
-                                                            IndexType)        \
-    void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec, \
-                                 const matrix::Csr<ValueType, IndexType>* m,  \
-                                 IndexType rank, array<ValueType>& tmp,       \
-                                 remove_complex<ValueType>& threshold,        \
-                                 matrix::Csr<ValueType, IndexType>* m_out,    \
-                                 matrix::Coo<ValueType, IndexType>* m_out_coo)
+#define GKO_DECLARE_PAR_ILUT_THRESHOLD_FILTER_APPROX_KERNEL(ValueType, \
+                                                            IndexType) \
+    void threshold_filter_approx(                                      \
+        std::shared_ptr<const DefaultExecutor> exec,                   \
+        const matrix::Csr<ValueType, IndexType>* m, IndexType rank,    \
+        array<ValueType>& tmp, remove_complex<ValueType>& threshold,   \
+        matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,       \
+        matrix::Coo<ValueType, IndexType>* m_out_coo)
 
 #define GKO_DECLARE_ALL_AS_TEMPLATES                                      \
     constexpr auto sampleselect_searchtree_height = 8;                    \

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -117,7 +117,7 @@ Csr<ValueType, IndexType>::create_const(
     gko::detail::const_array_view<ValueType>&& values,
     gko::detail::const_array_view<IndexType>&& col_idxs,
     gko::detail::const_array_view<IndexType>&& row_ptrs,
-    std::shared_ptr<strategy_type> strategy)
+    csr::spmv_strategy strategy)
 {
     // cast const-ness away, but return a const object afterwards,
     // so we can ensure that no modifications take place.
@@ -129,8 +129,7 @@ Csr<ValueType, IndexType>::create_const(
 
 template <typename ValueType, typename IndexType>
 std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
-    std::shared_ptr<const Executor> exec,
-    std::shared_ptr<strategy_type> strategy)
+    std::shared_ptr<const Executor> exec, csr::spmv_strategy strategy)
 {
     return create(exec, dim<2>{}, size_type{}, std::move(strategy));
 }
@@ -139,7 +138,7 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
 template <typename ValueType, typename IndexType>
 std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
     std::shared_ptr<const Executor> exec, const dim<2>& size,
-    size_type num_nonzeros, std::shared_ptr<strategy_type> strategy)
+    size_type num_nonzeros, csr::spmv_strategy strategy)
 {
     return std::unique_ptr<Csr>{
         new Csr{exec, size, num_nonzeros, std::move(strategy)}};
@@ -150,7 +149,7 @@ template <typename ValueType, typename IndexType>
 std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
     std::shared_ptr<const Executor> exec, const dim<2>& size,
     array<value_type> values, array<index_type> col_idxs,
-    array<index_type> row_ptrs, std::shared_ptr<strategy_type> strategy)
+    array<index_type> row_ptrs, csr::spmv_strategy strategy)
 {
     return std::unique_ptr<Csr>{
         new Csr{exec, size, std::move(values), std::move(col_idxs),
@@ -161,16 +160,16 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
 template <typename ValueType, typename IndexType>
 Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
                                const dim<2>& size, size_type num_nonzeros,
-                               std::shared_ptr<strategy_type> strategy)
+                               csr::spmv_strategy strategy)
     : LinOp(exec, size),
-      strategy_(strategy ? strategy->copy() : Csr::make_default_strategy(exec)),
+      strategy_(strategy),
       values_(exec, num_nonzeros),
       col_idxs_(exec, num_nonzeros),
       row_ptrs_(exec, size[0] + 1),
-      srow_(exec, strategy_->clac_size(num_nonzeros))
+      srow_(exec)
 {
     row_ptrs_.fill(0);
-    this->make_srow();
+    // this->make_srow();
 }
 
 
@@ -179,9 +178,9 @@ Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
                                const dim<2>& size, array<value_type> values,
                                array<index_type> col_idxs,
                                array<index_type> row_ptrs,
-                               std::shared_ptr<strategy_type> strategy)
+                               csr::spmv_strategy strategy)
     : LinOp(exec, size),
-      strategy_(strategy ? strategy->copy() : Csr::make_default_strategy(exec)),
+      strategy_(strategy),
       values_{exec, std::move(values)},
       col_idxs_{exec, std::move(col_idxs)},
       row_ptrs_{exec, std::move(row_ptrs)},
@@ -204,11 +203,7 @@ Csr<ValueType, IndexType>& Csr<ValueType, IndexType>::operator=(
         col_idxs_ = other.col_idxs_;
         row_ptrs_ = other.row_ptrs_;
         srow_ = other.srow_;
-        if (this->get_executor() != other.get_executor()) {
-            other.convert_strategy_helper(this);
-        } else {
-            this->set_strategy(other.get_strategy()->copy());
-        }
+        this->set_strategy(other.get_strategy());
         // END NOTE
     }
     return *this;
@@ -227,7 +222,8 @@ Csr<ValueType, IndexType>& Csr<ValueType, IndexType>::operator=(
         srow_ = std::move(other.srow_);
         strategy_ = other.strategy_;
         if (this->get_executor() != other.get_executor()) {
-            detail::strategy_rebuild_helper(this);
+            this->make_srow();
+            // detail::strategy_rebuild_helper(this);
         }
         // restore other invariant
         other.row_ptrs_.resize_and_reset(1);
@@ -272,6 +268,101 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
             },
             b, x);
     }
+}
+
+
+template <typename ValueType, typename IndexType>
+void Csr<ValueType, IndexType>::make_srow()
+{
+    size_type srow_size = 0;
+    int warp_size = 0;
+    int64_t nwarps = 0;
+    max_nnz_per_row_ = 0;
+    auto exec = this->get_executor();
+    row_ptrs_.set_executor(exec->get_master());
+    // calculate the max_nnz_per_row in host
+    for (int i = 0; i < this->get_size()[0]; i++) {
+        max_nnz_per_row_ =
+            std::max(max_nnz_per_row_, row_ptrs_.get_const_data()[i + 1] -
+                                           row_ptrs_.get_const_data()[i]);
+    }
+
+    if (auto dexec = std::dynamic_pointer_cast<const CudaExecutor>(exec)) {
+        nwarps = dexec->get_num_warps();
+        warp_size = dexec->get_warp_size();
+    } else if (auto dexec =
+                   std::dynamic_pointer_cast<const HipExecutor>(exec)) {
+        nwarps = dexec->get_num_warps();
+        warp_size = dexec->get_warp_size();
+    } else if (auto dexec =
+                   std::dynamic_pointer_cast<const DpcppExecutor>(exec)) {
+        nwarps = dexec->get_num_subgroups();
+        warp_size = 32;
+    }
+    auto load_balance_size = [&](const int64_t nnz) -> int64_t {
+        int multiple = 8;
+        if (std::dynamic_pointer_cast<const CudaExecutor>(exec)) {
+            if (nnz >= static_cast<int64_t>(2e8)) {
+                multiple = 2048;
+            } else if (nnz >= static_cast<int64_t>(2e7)) {
+                multiple = 512;
+            } else if (nnz >= static_cast<int64_t>(2e6)) {
+                multiple = 128;
+            } else if (nnz >= static_cast<int64_t>(2e5)) {
+                multiple = 32;
+            }
+        } else if (std::dynamic_pointer_cast<const HipExecutor>(exec)) {
+            // only for AMD GPU
+            if (nnz >= static_cast<int64_t>(1e7)) {
+                multiple = 64;
+            } else if (nnz >= static_cast<int64_t>(1e6)) {
+                multiple = 16;
+            }
+        } else if (std::dynamic_pointer_cast<const DpcppExecutor>(exec)) {
+            if (nnz >= static_cast<int64_t>(2e8)) {
+                multiple = 256;
+            } else if (nnz >= static_cast<int64_t>(2e7)) {
+                multiple = 32;
+            }
+        } else {
+            return 0;
+        }
+        return static_cast<int64_t>(std::min(
+            ceildiv(nnz, warp_size), static_cast<int64_t>(nwarps * multiple)));
+    };
+
+    if (strategy_ == csr::spmv_strategy::load_balance ||
+        strategy_ == csr::spmv_strategy::automatical) {
+        srow_size = load_balance_size(this->get_num_stored_elements());
+    }
+    // just to make load_balance(2) works
+    // srow_size = std::max(srow_size, size_type{1});
+    srow_.resize_and_reset(srow_size);
+    if (srow_size != 0) {
+        srow_.set_executor(exec->get_master());
+        const auto num_rows = this->get_size()[0];
+        for (size_type i = 0; i < srow_size; i++) {
+            srow_.get_data()[i] = 0;
+        }
+        const auto num_elems = this->get_num_stored_elements();
+        const auto bucket_divider =
+            num_elems > 0 ? ceildiv(num_elems, warp_size) : 1;
+        for (size_type i = 0; i < num_rows; i++) {
+            auto bucket =
+                ceildiv((ceildiv(row_ptrs_.get_const_data()[i + 1], warp_size) *
+                         srow_size),
+                        bucket_divider);
+            if (bucket < srow_size) {
+                srow_.get_data()[bucket]++;
+            }
+        }
+        // find starting row for thread i
+        for (size_type i = 1; i < srow_size; i++) {
+            srow_.get_data()[i] += srow_.get_data()[i - 1];
+        }
+        srow_.set_executor(exec);
+    }
+    row_ptrs_.set_executor(exec);
 }
 
 
@@ -324,7 +415,7 @@ void Csr<ValueType, IndexType>::convert_to(
     result->col_idxs_ = this->col_idxs_;
     result->row_ptrs_ = this->row_ptrs_;
     result->set_size(this->get_size());
-    convert_strategy_helper(result);
+    result->set_strategy(this->get_strategy());
 }
 
 
@@ -344,7 +435,7 @@ void Csr<ValueType, IndexType>::convert_to(
     result->col_idxs_ = this->col_idxs_;
     result->row_ptrs_ = this->row_ptrs_;
     result->set_size(this->get_size());
-    convert_strategy_helper(result);
+    result->set_strategy(this->get_strategy());
 }
 
 
@@ -366,7 +457,7 @@ void Csr<ValueType, IndexType>::convert_to(
     result->col_idxs_ = this->col_idxs_;
     result->row_ptrs_ = this->row_ptrs_;
     result->set_size(this->get_size());
-    convert_strategy_helper(result);
+    result->set_strategy(this->get_strategy());
 }
 
 
@@ -1041,7 +1132,7 @@ transform_reusable(const Csr<ValueType, IndexType>* input, gko::dim<2> out_size,
         make_const_array_view(exec, nnz, input->get_const_col_idxs()),
         make_const_array_view(exec, in_size[0] + 1,
                               input->get_const_row_ptrs()),
-        std::make_shared<typename Csr<FloatIndexType, IndexType>::sparselib>());
+        csr::spmv_strategy::sparselib);
     auto transformed_iota = closure(iota_mtx.get());
     exec->copy(out_size[0] + 1, transformed_iota->get_const_row_ptrs(),
                transformed->get_row_ptrs());
@@ -1143,7 +1234,7 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::permute(
     if ((mode & permute_mode::symmetric) == permute_mode::none) {
         return this->clone();
     }
-    auto result = Csr::create(exec, size, nnz, this->get_strategy()->copy());
+    auto result = Csr::create(exec, size, nnz, this->get_strategy());
     auto local_permutation = make_temporary_clone(exec, permutation);
     std::unique_ptr<const Permutation<IndexType>> inv_permutation;
     const auto perm_idxs = local_permutation->get_const_permutation();
@@ -1197,7 +1288,7 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::permute(
     const auto nnz = this->get_num_stored_elements();
     GKO_ASSERT_EQUAL_ROWS(this, row_permutation);
     GKO_ASSERT_EQUAL_COLS(this, col_permutation);
-    auto result = Csr::create(exec, size, nnz, this->get_strategy()->copy());
+    auto result = Csr::create(exec, size, nnz, this->get_strategy());
     auto local_row_permutation = make_temporary_clone(exec, row_permutation);
     auto local_col_permutation = make_temporary_clone(exec, col_permutation);
     if (invert) {
@@ -1256,7 +1347,7 @@ Csr<ValueType, IndexType>::scale_permute(
     if ((mode & permute_mode::symmetric) == permute_mode::none) {
         return this->clone();
     }
-    auto result = Csr::create(exec, size, nnz, this->get_strategy()->copy());
+    auto result = Csr::create(exec, size, nnz, this->get_strategy());
     auto local_permutation = make_temporary_clone(exec, permutation);
     std::unique_ptr<const ScaledPermutation<ValueType, IndexType>>
         inv_permutation;
@@ -1320,7 +1411,7 @@ Csr<ValueType, IndexType>::scale_permute(
     const auto nnz = this->get_num_stored_elements();
     GKO_ASSERT_EQUAL_ROWS(this, row_permutation);
     GKO_ASSERT_EQUAL_COLS(this, col_permutation);
-    auto result = Csr::create(exec, size, nnz, this->get_strategy()->copy());
+    auto result = Csr::create(exec, size, nnz, this->get_strategy());
     auto local_row_permutation = make_temporary_clone(exec, row_permutation);
     auto local_col_permutation = make_temporary_clone(exec, col_permutation);
     if (invert) {
@@ -1559,7 +1650,7 @@ Csr<ValueType, IndexType>::compute_absolute() const
                                                 this->get_num_stored_elements(),
                                                 abs_csr->get_values()));
 
-    convert_strategy_helper(abs_csr.get());
+    abs_csr->make_srow();
     return abs_csr;
 }
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -32,6 +32,7 @@
 #include "core/components/precision_conversion_kernels.hpp"
 #include "core/components/prefix_sum_kernels.hpp"
 #include "core/matrix/csr_kernels.hpp"
+#include "core/matrix/csr_strategy.hpp"
 #include "core/matrix/ell_kernels.hpp"
 #include "core/matrix/hybrid_kernels.hpp"
 #include "core/matrix/permutation.hpp"
@@ -117,7 +118,7 @@ spmv_strategy get_actual_strategy(std::shared_ptr<const Executor> exec,
                                   size_type num_stored_elements,
                                   size_type max_nnz_per_row)
 {
-    if (strategy != csr::spmv_strategy::automatical) {
+    if (strategy != spmv_strategy::automatical) {
         return strategy;
     }
     // If the number of stored elements is larger than <nnz_limit> or the
@@ -152,12 +153,12 @@ spmv_strategy get_actual_strategy(std::shared_ptr<const Executor> exec,
         row_len_limit = amd_row_len_limit;
     } else if (!std::dynamic_pointer_cast<const CudaExecutor>(exec)) {
         // we do not have load balance on reference and omp executor.
-        return csr::spmv_strategy::classical;
+        return spmv_strategy::classical;
     }
     if (num_stored_elements > nnz_limit || max_nnz_per_row > row_len_limit) {
-        return csr::spmv_strategy::load_balance;
+        return spmv_strategy::load_balance;
     } else {
-        return csr::spmv_strategy::classical;
+        return spmv_strategy::classical;
     }
 }
 
@@ -295,7 +296,7 @@ Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
       srow_(exec)
 {
     row_ptrs_.fill(0);
-    // this->make_srow();
+    this->make_srow();
 }
 
 
@@ -349,7 +350,6 @@ Csr<ValueType, IndexType>& Csr<ValueType, IndexType>::operator=(
         strategy_ = other.strategy_;
         if (this->get_executor() != other.get_executor()) {
             this->make_srow();
-            // detail::strategy_rebuild_helper(this);
         }
         // restore other invariant
         other.row_ptrs_.resize_and_reset(1);

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -280,12 +280,18 @@ void Csr<ValueType, IndexType>::make_srow()
     int64_t nwarps = 0;
     max_nnz_per_row_ = 0;
     auto exec = this->get_executor();
-    row_ptrs_.set_executor(exec->get_master());
+    array<IndexType> row_ptrs_host(exec->get_master());
+    const IndexType* row_ptrs{nullptr};
+    if (exec == exec->get_master()) {
+        row_ptrs = row_ptrs_.get_const_data();
+    } else {
+        row_ptrs_host = row_ptrs_;
+        row_ptrs = row_ptrs_host.get_const_data();
+    }
     // calculate the max_nnz_per_row in host
     for (int i = 0; i < this->get_size()[0]; i++) {
         max_nnz_per_row_ =
-            std::max(max_nnz_per_row_, row_ptrs_.get_const_data()[i + 1] -
-                                           row_ptrs_.get_const_data()[i]);
+            std::max(max_nnz_per_row_, row_ptrs[i + 1] - row_ptrs[i]);
     }
 
     if (auto dexec = std::dynamic_pointer_cast<const CudaExecutor>(exec)) {
@@ -350,8 +356,7 @@ void Csr<ValueType, IndexType>::make_srow()
             num_elems > 0 ? ceildiv(num_elems, warp_size) : 1;
         for (size_type i = 0; i < num_rows; i++) {
             auto bucket =
-                ceildiv((ceildiv(row_ptrs_.get_const_data()[i + 1], warp_size) *
-                         srow_size),
+                ceildiv((ceildiv(row_ptrs[i + 1], warp_size) * srow_size),
                         bucket_divider);
             if (bucket < srow_size) {
                 srow_.get_data()[bucket]++;

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -413,8 +413,6 @@ void Csr<ValueType, IndexType>::make_srow()
         strategy_ == csr::spmv_strategy::automatical) {
         srow_size = load_balance_size(this->get_num_stored_elements());
     }
-    // just to make load_balance(2) works
-    // srow_size = std::max(srow_size, size_type{1});
     srow_.resize_and_reset(srow_size);
     if (srow_size != 0) {
         srow_.set_executor(exec->get_master());

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -157,6 +157,72 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
 }
 
 
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
+
+// C++ can not deduce template parameters from a nested dependent type.
+// Thus, we put Csr not ValueType, IndexType as template because we need to call
+// with explicit type anyway.
+template <typename Csr>
+csr::spmv_strategy get_strategy_enum(
+    std::shared_ptr<typename Csr::strategy_type> strategy)
+{
+    if (strategy == nullptr ||
+        std::dynamic_pointer_cast<typename Csr::automatical>(strategy)) {
+        return csr::spmv_strategy::automatical;
+    } else if (std::dynamic_pointer_cast<typename Csr::classical>(strategy)) {
+        return csr::spmv_strategy::classical;
+    } else if (std::dynamic_pointer_cast<typename Csr::merge_path>(strategy)) {
+        return csr::spmv_strategy::merge_path;
+    } else if (std::dynamic_pointer_cast<typename Csr::sparselib>(strategy) ||
+               std::dynamic_pointer_cast<typename Csr::cusparse>(strategy)) {
+        return csr::spmv_strategy::sparselib;
+    } else {
+        GKO_NOT_SUPPORTED(strategy);
+    }
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<const Csr<ValueType, IndexType>>
+Csr<ValueType, IndexType>::create_const(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    gko::detail::const_array_view<ValueType>&& values,
+    gko::detail::const_array_view<IndexType>&& col_idxs,
+    gko::detail::const_array_view<IndexType>&& row_ptrs,
+    std::shared_ptr<strategy_type> strategy)
+{
+    return create_const(
+        std::move(exec), size,
+        std::forward<gko::detail::const_array_view<ValueType>>(values),
+        std::forward<gko::detail::const_array_view<IndexType>>(col_idxs),
+        std::forward<gko::detail::const_array_view<IndexType>>(row_ptrs),
+        get_strategy_enum<Csr>(strategy));
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec,
+    std::shared_ptr<strategy_type> strategy)
+{
+    return create(std::move(exec), get_strategy_enum<Csr>(strategy));
+}
+
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
+    std::shared_ptr<const Executor> exec, const dim<2>& size,
+    array<value_type> values, array<index_type> col_idxs,
+    array<index_type> row_ptrs, std::shared_ptr<strategy_type> strategy)
+{
+    return create(std::move(exec), size, std::move(values), std::move(col_idxs),
+                  std::move(row_ptrs), get_strategy_enum<Csr>(strategy));
+}
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS
+
+
 template <typename ValueType, typename IndexType>
 Csr<ValueType, IndexType>::Csr(std::shared_ptr<const Executor> exec,
                                const dim<2>& size, size_type num_nonzeros,

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -465,8 +465,7 @@ void Csr<ValueType, IndexType>::make_srow()
             ceildiv(nnz, warp_size), static_cast<int64_t>(nwarps * multiple)));
     };
 
-    if (strategy_ == csr::spmv_strategy::load_balance ||
-        strategy_ == csr::spmv_strategy::automatic) {
+    if (this->get_actual_strategy() == csr::spmv_strategy::load_balance) {
         srow_size = load_balance_size(this->get_num_stored_elements());
     }
     srow_.resize_and_reset(srow_size);

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -385,8 +385,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
         // if b is a CSR matrix, we compute a SpGeMM
         auto x_csr = as<TCsr>(x);
         this->get_executor()->run(csr::make_spgemm(
-            this, b_csr,
-            std::make_unique<CsrBuilder<ValueType, IndexType>>(x_csr).get()));
+            this, b_csr, make_builder_unique_ptr(x_csr).get()));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this](auto dense_b, auto dense_x) {
@@ -511,7 +510,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
         this->get_executor()->run(csr::make_advanced_spgemm(
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this, b_csr,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
-            std::make_unique<CsrBuilder<ValueType, IndexType>>(x_csr).get()));
+            make_builder_unique_ptr(x_csr).get()));
     } else if (dynamic_cast<const Identity<ValueType>*>(b)) {
         // if b is an identity matrix, we compute an SpGEAM
         auto x_csr = as<TCsr>(x);
@@ -519,7 +518,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
         this->get_executor()->run(csr::make_spgeam(
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
-            std::make_unique<CsrBuilder<ValueType, IndexType>>(x_csr).get()));
+            make_builder_unique_ptr(x_csr).get()));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this, alpha, beta](auto dense_b, auto dense_x) {
@@ -886,9 +885,8 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::multiply(
     auto exec = this->get_executor();
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
-    exec->run(csr::make_spgemm(
-        this, local_other.get(),
-        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
+    exec->run(csr::make_spgemm(this, local_other.get(),
+                               make_builder_unique_ptr(result).get()));
     return result;
 }
 
@@ -968,9 +966,8 @@ Csr<ValueType, IndexType>::multiply_reuse(ptr_param<const Csr> other) const
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
     {
-        exec->run(csr::make_spgemm(
-            this, local_other.get(),
-            std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
+        exec->run(csr::make_spgemm(this, local_other.get(),
+                                   make_builder_unique_ptr(result).get()));
     }
     auto lookup = csr::build_lookup(result.get());
     auto reuse_info = multiply_reuse_info{
@@ -1006,7 +1003,7 @@ Csr<ValueType, IndexType>::multiply_add(
     exec->run(csr::make_advanced_spgemm(
         local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
         local_scale_add->get_const_device_view(), local_mtx_add.get(),
-        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
+        make_builder_unique_ptr(result).get()));
     return result;
 }
 
@@ -1110,7 +1107,7 @@ Csr<ValueType, IndexType>::multiply_add_reuse(
     exec->run(csr::make_advanced_spgemm(
         local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
         local_scale_add->get_const_device_view(), local_mtx_add.get(),
-        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
+        make_builder_unique_ptr(result).get()));
     auto lookup = csr::build_lookup(result.get());
     auto reuse_info = multiply_add_reuse_info{
         std::make_unique<typename multiply_add_reuse_info::lookup_data>(
@@ -1138,10 +1135,10 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::scale_add(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    exec->run(csr::make_spgeam(
-        local_scale_this->get_const_device_view(), this,
-        local_scale_other->get_const_device_view(), local_mtx_other.get(),
-        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
+    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(), this,
+                               local_scale_other->get_const_device_view(),
+                               local_mtx_other.get(),
+                               make_builder_unique_ptr(result).get()));
     return result;
 }
 
@@ -1233,10 +1230,10 @@ Csr<ValueType, IndexType>::add_scale_reuse(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    exec->run(csr::make_spgeam(
-        local_scale_this->get_const_device_view(), this,
-        local_scale_other->get_const_device_view(), local_mtx_other.get(),
-        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
+    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(), this,
+                               local_scale_other->get_const_device_view(),
+                               local_mtx_other.get(),
+                               make_builder_unique_ptr(result).get()));
     return std::make_pair(
         std::move(result),
         scale_add_reuse_info{

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -263,9 +263,10 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this](auto dense_b, auto dense_x) {
-                this->get_executor()->run(
-                    csr::make_spmv(this, dense_b->get_const_device_view(),
-                                   dense_x->get_device_view()));
+                this->get_executor()->run(csr::make_spmv(
+                    this->get_actual_strategy(), max_nnz_per_row_, this,
+                    dense_b->get_const_device_view(),
+                    dense_x->get_device_view()));
             },
             b, x);
     }
@@ -405,6 +406,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
                     typename std::decay_t<decltype(*dense_x)>::value_type>(
                     beta);
                 this->get_executor()->run(csr::make_advanced_spmv(
+                    this->get_actual_strategy(), max_nnz_per_row_,
                     dense_alpha->get_const_device_view(), this,
                     dense_b->get_const_device_view(),
                     dense_beta->get_const_device_view(),
@@ -1698,6 +1700,63 @@ void Csr<ValueType, IndexType>::add_scaled_identity_impl(const LinOp* a,
         make_temporary_conversion<ValueType>(a)->get_const_device_view(),
         make_temporary_conversion<ValueType>(b)->get_const_device_view(),
         this));
+}
+
+template <typename ValueType, typename IndexType>
+csr::spmv_strategy Csr<ValueType, IndexType>::get_strategy() const noexcept
+{
+    return strategy_;
+}
+
+template <typename ValueType, typename IndexType>
+csr::spmv_strategy Csr<ValueType, IndexType>::get_actual_strategy()
+    const noexcept
+{
+    auto strategy = this->get_strategy();
+    if (strategy != csr::spmv_strategy::automatical) {
+        return strategy;
+    }
+    auto exec = this->get_executor();
+    // If the number of stored elements is larger than <nnz_limit> or the
+    // maximum
+    // number of stored elements per row is larger than <row_len_limit>, use
+    // load_balance otherwise use classical
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 1024 on NVIDIA hardware */
+    const int64_t nvidia_row_len_limit = 1024;
+    /* Use imbalance strategy when the matrix has more more than 1e6 on
+     * NVIDIA hardware */
+    const int64_t nvidia_nnz_limit{static_cast<int64_t>(1e6)};
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 768 on AMD hardware */
+    const int64_t amd_row_len_limit = 768;
+    /* Use imbalance strategy when the matrix has more more than 1e8 on
+     * AMD hardware */
+    const int64_t amd_nnz_limit{static_cast<int64_t>(1e8)};
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 25600 on Intel hardware */
+    const int64_t intel_row_len_limit = 25600;
+    /* Use imbalance strategy when the matrix has more more than 3e8 on
+     * Intel hardware */
+    const int64_t intel_nnz_limit{static_cast<int64_t>(3e8)};
+    auto nnz_limit = nvidia_nnz_limit;
+    auto row_len_limit = nvidia_row_len_limit;
+    if (std::dynamic_pointer_cast<const DpcppExecutor>(exec)) {
+        nnz_limit = intel_nnz_limit;
+        row_len_limit = intel_row_len_limit;
+    } else if (std::dynamic_pointer_cast<const HipExecutor>(exec)) {
+        nnz_limit = amd_nnz_limit;
+        row_len_limit = amd_row_len_limit;
+    } else if (!std::dynamic_pointer_cast<const CudaExecutor>(exec)) {
+        // we do not have load balance on reference and omp executor.
+        return csr::spmv_strategy::classical;
+    }
+    if (this->get_num_stored_elements() > nnz_limit ||
+        max_nnz_per_row_ > row_len_limit) {
+        return csr::spmv_strategy::load_balance;
+    } else {
+        return csr::spmv_strategy::classical;
+    }
 }
 
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -318,6 +318,7 @@ Csr<ValueType, IndexType>& Csr<ValueType, IndexType>::operator=(
         col_idxs_ = other.col_idxs_;
         row_ptrs_ = other.row_ptrs_;
         srow_ = other.srow_;
+        max_nnz_per_row_ = other.max_nnz_per_row_;
         strategy_ = other.strategy_;
         if (this->get_executor() != other.get_executor()) {
             // strategy can give different srow on different executor
@@ -338,6 +339,7 @@ Csr<ValueType, IndexType>& Csr<ValueType, IndexType>::operator=(
         col_idxs_ = std::move(other.col_idxs_);
         row_ptrs_ = std::move(other.row_ptrs_);
         srow_ = std::move(other.srow_);
+        max_nnz_per_row_ = std::exchange(other.max_nnz_per_row_, 0);
         strategy_ = other.strategy_;
         if (this->get_executor() != other.get_executor()) {
             // strategy can give different srow on different executor

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -224,21 +224,10 @@ template <typename Csr>
 csr::spmv_strategy get_strategy_enum(
     std::shared_ptr<typename Csr::strategy_type> strategy)
 {
-    if (strategy == nullptr ||
-        std::dynamic_pointer_cast<typename Csr::automatical>(strategy)) {
-        return csr::spmv_strategy::automatic;
-    } else if (std::dynamic_pointer_cast<typename Csr::classical>(strategy)) {
-        return csr::spmv_strategy::classical;
-    } else if (std::dynamic_pointer_cast<typename Csr::merge_path>(strategy)) {
-        return csr::spmv_strategy::merge_path;
-    } else if (std::dynamic_pointer_cast<typename Csr::load_balance>(
-                   strategy)) {
-        return csr::spmv_strategy::load_balance;
-    } else if (std::dynamic_pointer_cast<typename Csr::sparselib>(strategy) ||
-               std::dynamic_pointer_cast<typename Csr::cusparse>(strategy)) {
-        return csr::spmv_strategy::sparselib;
+    if (strategy) {
+        return strategy->get_enum();
     } else {
-        GKO_NOT_SUPPORTED(strategy);
+        return csr::spmv_strategy::automatic;
     }
 }
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -107,6 +107,62 @@ GKO_REGISTER_OPERATION(aos_to_soa, components::aos_to_soa);
 
 
 }  // anonymous namespace
+
+
+namespace detail {
+
+
+spmv_strategy get_actual_strategy(std::shared_ptr<const Executor> exec,
+                                  spmv_strategy strategy,
+                                  size_type num_stored_elements,
+                                  size_type max_nnz_per_row)
+{
+    if (strategy != csr::spmv_strategy::automatical) {
+        return strategy;
+    }
+    // If the number of stored elements is larger than <nnz_limit> or the
+    // maximum
+    // number of stored elements per row is larger than <row_len_limit>, use
+    // load_balance otherwise use classical
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 1024 on NVIDIA hardware */
+    const int64_t nvidia_row_len_limit = 1024;
+    /* Use imbalance strategy when the matrix has more more than 1e6 on
+     * NVIDIA hardware */
+    const int64_t nvidia_nnz_limit{static_cast<int64_t>(1e6)};
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 768 on AMD hardware */
+    const int64_t amd_row_len_limit = 768;
+    /* Use imbalance strategy when the matrix has more more than 1e8 on
+     * AMD hardware */
+    const int64_t amd_nnz_limit{static_cast<int64_t>(1e8)};
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 25600 on Intel hardware */
+    const int64_t intel_row_len_limit = 25600;
+    /* Use imbalance strategy when the matrix has more more than 3e8 on
+     * Intel hardware */
+    const int64_t intel_nnz_limit{static_cast<int64_t>(3e8)};
+    auto nnz_limit = nvidia_nnz_limit;
+    auto row_len_limit = nvidia_row_len_limit;
+    if (std::dynamic_pointer_cast<const DpcppExecutor>(exec)) {
+        nnz_limit = intel_nnz_limit;
+        row_len_limit = intel_row_len_limit;
+    } else if (std::dynamic_pointer_cast<const HipExecutor>(exec)) {
+        nnz_limit = amd_nnz_limit;
+        row_len_limit = amd_row_len_limit;
+    } else if (!std::dynamic_pointer_cast<const CudaExecutor>(exec)) {
+        // we do not have load balance on reference and omp executor.
+        return csr::spmv_strategy::classical;
+    }
+    if (num_stored_elements > nnz_limit || max_nnz_per_row > row_len_limit) {
+        return csr::spmv_strategy::load_balance;
+    } else {
+        return csr::spmv_strategy::classical;
+    }
+}
+
+
+}  // namespace detail
 }  // namespace csr
 
 
@@ -1796,55 +1852,15 @@ csr::spmv_strategy Csr<ValueType, IndexType>::get_strategy() const noexcept
     return strategy_;
 }
 
+
 template <typename ValueType, typename IndexType>
 csr::spmv_strategy Csr<ValueType, IndexType>::get_actual_strategy()
     const noexcept
 {
-    auto strategy = this->get_strategy();
-    if (strategy != csr::spmv_strategy::automatical) {
-        return strategy;
-    }
-    auto exec = this->get_executor();
-    // If the number of stored elements is larger than <nnz_limit> or the
-    // maximum
-    // number of stored elements per row is larger than <row_len_limit>, use
-    // load_balance otherwise use classical
-    /* Use imbalance strategy when the maximum number of nonzero per row
-     * is more than 1024 on NVIDIA hardware */
-    const int64_t nvidia_row_len_limit = 1024;
-    /* Use imbalance strategy when the matrix has more more than 1e6 on
-     * NVIDIA hardware */
-    const int64_t nvidia_nnz_limit{static_cast<int64_t>(1e6)};
-    /* Use imbalance strategy when the maximum number of nonzero per row
-     * is more than 768 on AMD hardware */
-    const int64_t amd_row_len_limit = 768;
-    /* Use imbalance strategy when the matrix has more more than 1e8 on
-     * AMD hardware */
-    const int64_t amd_nnz_limit{static_cast<int64_t>(1e8)};
-    /* Use imbalance strategy when the maximum number of nonzero per row
-     * is more than 25600 on Intel hardware */
-    const int64_t intel_row_len_limit = 25600;
-    /* Use imbalance strategy when the matrix has more more than 3e8 on
-     * Intel hardware */
-    const int64_t intel_nnz_limit{static_cast<int64_t>(3e8)};
-    auto nnz_limit = nvidia_nnz_limit;
-    auto row_len_limit = nvidia_row_len_limit;
-    if (std::dynamic_pointer_cast<const DpcppExecutor>(exec)) {
-        nnz_limit = intel_nnz_limit;
-        row_len_limit = intel_row_len_limit;
-    } else if (std::dynamic_pointer_cast<const HipExecutor>(exec)) {
-        nnz_limit = amd_nnz_limit;
-        row_len_limit = amd_row_len_limit;
-    } else if (!std::dynamic_pointer_cast<const CudaExecutor>(exec)) {
-        // we do not have load balance on reference and omp executor.
-        return csr::spmv_strategy::classical;
-    }
-    if (this->get_num_stored_elements() > nnz_limit ||
-        max_nnz_per_row_ > row_len_limit) {
-        return csr::spmv_strategy::load_balance;
-    } else {
-        return csr::spmv_strategy::classical;
-    }
+    return csr::detail::get_actual_strategy(
+        this->get_executor(), this->get_strategy(),
+        this->get_num_stored_elements(),
+        static_cast<size_type>(max_nnz_per_row_));
 }
 
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -314,13 +314,15 @@ Csr<ValueType, IndexType>& Csr<ValueType, IndexType>::operator=(
 {
     if (&other != this) {
         LinOp::operator=(other);
-        // NOTE: as soon as strategies are improved, this can be reverted
         values_ = other.values_;
         col_idxs_ = other.col_idxs_;
         row_ptrs_ = other.row_ptrs_;
         srow_ = other.srow_;
-        this->set_strategy(other.get_strategy());
-        // END NOTE
+        strategy_ = other.strategy_;
+        if (this->get_executor() != other.get_executor()) {
+            // strategy can give different srow on different executor
+            this->make_srow();
+        }
     }
     return *this;
 }
@@ -338,6 +340,7 @@ Csr<ValueType, IndexType>& Csr<ValueType, IndexType>::operator=(
         srow_ = std::move(other.srow_);
         strategy_ = other.strategy_;
         if (this->get_executor() != other.get_executor()) {
+            // strategy can give different srow on different executor
             this->make_srow();
         }
         // restore other invariant

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -118,7 +118,7 @@ spmv_strategy get_actual_strategy(std::shared_ptr<const Executor> exec,
                                   size_type num_stored_elements,
                                   size_type max_nnz_per_row)
 {
-    if (strategy != spmv_strategy::automatical) {
+    if (strategy != spmv_strategy::automatic) {
         return strategy;
     }
     // If the number of stored elements is larger than <nnz_limit> or the
@@ -226,7 +226,7 @@ csr::spmv_strategy get_strategy_enum(
 {
     if (strategy == nullptr ||
         std::dynamic_pointer_cast<typename Csr::automatical>(strategy)) {
-        return csr::spmv_strategy::automatical;
+        return csr::spmv_strategy::automatic;
     } else if (std::dynamic_pointer_cast<typename Csr::classical>(strategy)) {
         return csr::spmv_strategy::classical;
     } else if (std::dynamic_pointer_cast<typename Csr::merge_path>(strategy)) {
@@ -466,7 +466,7 @@ void Csr<ValueType, IndexType>::make_srow()
     };
 
     if (strategy_ == csr::spmv_strategy::load_balance ||
-        strategy_ == csr::spmv_strategy::automatical) {
+        strategy_ == csr::spmv_strategy::automatic) {
         srow_size = load_balance_size(this->get_num_stored_elements());
     }
     srow_.resize_and_reset(srow_size);

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -174,6 +174,9 @@ csr::spmv_strategy get_strategy_enum(
         return csr::spmv_strategy::classical;
     } else if (std::dynamic_pointer_cast<typename Csr::merge_path>(strategy)) {
         return csr::spmv_strategy::merge_path;
+    } else if (std::dynamic_pointer_cast<typename Csr::load_balance>(
+                   strategy)) {
+        return csr::spmv_strategy::load_balance;
     } else if (std::dynamic_pointer_cast<typename Csr::sparselib>(strategy) ||
                std::dynamic_pointer_cast<typename Csr::cusparse>(strategy)) {
         return csr::spmv_strategy::sparselib;
@@ -219,6 +222,7 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::create(
     return create(std::move(exec), size, std::move(values), std::move(col_idxs),
                   std::move(row_ptrs), get_strategy_enum<Csr>(strategy));
 }
+
 
 GKO_END_DISABLE_DEPRECATION_WARNINGS
 

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -259,6 +259,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
         // if b is a CSR matrix, we compute a SpGeMM
         auto x_csr = as<TCsr>(x);
         this->get_executor()->run(csr::make_spgemm(this, b_csr, x_csr));
+        x_csr->set_strategy(x_csr->get_strategy());
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this](auto dense_b, auto dense_x) {
@@ -381,6 +382,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this, b_csr,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
             x_csr));
+        x_csr->set_strategy(x_csr->get_strategy());
     } else if (dynamic_cast<const Identity<ValueType>*>(b)) {
         // if b is an identity matrix, we compute an SpGEAM
         auto x_csr = as<TCsr>(x);
@@ -389,6 +391,7 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
             x_csr));
+        x_csr->set_strategy(x_csr->get_strategy());
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this, alpha, beta](auto dense_b, auto dense_x) {

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -384,8 +384,9 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
     if (auto b_csr = dynamic_cast<const TCsr*>(b)) {
         // if b is a CSR matrix, we compute a SpGeMM
         auto x_csr = as<TCsr>(x);
-        auto builder = CsrBuilder<ValueType, IndexType>(x_csr);
-        this->get_executor()->run(csr::make_spgemm(this, b_csr, &builder));
+        this->get_executor()->run(csr::make_spgemm(
+            this, b_csr,
+            std::make_unique<CsrBuilder<ValueType, IndexType>>(x_csr).get()));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this](auto dense_b, auto dense_x) {
@@ -507,20 +508,18 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
         // if b is a CSR matrix, we compute a SpGeMM
         auto x_csr = as<TCsr>(x);
         auto x_copy = x_csr->clone();
-        auto builder = CsrBuilder<ValueType, IndexType>(x_csr);
         this->get_executor()->run(csr::make_advanced_spgemm(
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this, b_csr,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
-            &builder));
+            std::make_unique<CsrBuilder<ValueType, IndexType>>(x_csr).get()));
     } else if (dynamic_cast<const Identity<ValueType>*>(b)) {
         // if b is an identity matrix, we compute an SpGEAM
         auto x_csr = as<TCsr>(x);
         auto x_copy = x_csr->clone();
-        auto builder = CsrBuilder<ValueType, IndexType>(x_csr);
         this->get_executor()->run(csr::make_spgeam(
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
-            &builder));
+            std::make_unique<CsrBuilder<ValueType, IndexType>>(x_csr).get()));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this, alpha, beta](auto dense_b, auto dense_x) {
@@ -887,10 +886,9 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::multiply(
     auto exec = this->get_executor();
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
-    {
-        auto builder = CsrBuilder<ValueType, IndexType>(result);
-        exec->run(csr::make_spgemm(this, local_other.get(), &builder));
-    }
+    exec->run(csr::make_spgemm(
+        this, local_other.get(),
+        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
     return result;
 }
 
@@ -970,8 +968,9 @@ Csr<ValueType, IndexType>::multiply_reuse(ptr_param<const Csr> other) const
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
     {
-        auto builder = CsrBuilder<ValueType, IndexType>(result);
-        exec->run(csr::make_spgemm(this, local_other.get(), &builder));
+        exec->run(csr::make_spgemm(
+            this, local_other.get(),
+            std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
     }
     auto lookup = csr::build_lookup(result.get());
     auto reuse_info = multiply_reuse_info{
@@ -1004,13 +1003,10 @@ Csr<ValueType, IndexType>::multiply_add(
     auto local_scale_add = make_temporary_clone(exec, scale_add);
     auto local_mtx_add = make_temporary_clone(exec, mtx_add);
     auto result = Csr::create(exec, result_size);
-    {
-        auto builder = CsrBuilder<ValueType, IndexType>(result);
-        exec->run(csr::make_advanced_spgemm(
-            local_scale_mult->get_const_device_view(), this,
-            local_mtx_mult.get(), local_scale_add->get_const_device_view(),
-            local_mtx_add.get(), &builder));
-    }
+    exec->run(csr::make_advanced_spgemm(
+        local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
+        local_scale_add->get_const_device_view(), local_mtx_add.get(),
+        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
     return result;
 }
 
@@ -1111,13 +1107,10 @@ Csr<ValueType, IndexType>::multiply_add_reuse(
     auto local_scale_add = make_temporary_clone(exec, scale_add);
     auto local_mtx_add = make_temporary_clone(exec, mtx_add);
     auto result = Csr::create(exec, result_size);
-    {
-        auto builder = CsrBuilder<ValueType, IndexType>(result);
-        exec->run(csr::make_advanced_spgemm(
-            local_scale_mult->get_const_device_view(), this,
-            local_mtx_mult.get(), local_scale_add->get_const_device_view(),
-            local_mtx_add.get(), &builder));
-    }
+    exec->run(csr::make_advanced_spgemm(
+        local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
+        local_scale_add->get_const_device_view(), local_mtx_add.get(),
+        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
     auto lookup = csr::build_lookup(result.get());
     auto reuse_info = multiply_add_reuse_info{
         std::make_unique<typename multiply_add_reuse_info::lookup_data>(
@@ -1145,13 +1138,10 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::scale_add(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    {
-        auto builder = CsrBuilder<ValueType, IndexType>(result);
-        exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(),
-                                   this,
-                                   local_scale_other->get_const_device_view(),
-                                   local_mtx_other.get(), &builder));
-    }
+    exec->run(csr::make_spgeam(
+        local_scale_this->get_const_device_view(), this,
+        local_scale_other->get_const_device_view(), local_mtx_other.get(),
+        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
     return result;
 }
 
@@ -1243,13 +1233,10 @@ Csr<ValueType, IndexType>::add_scale_reuse(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    {
-        auto builder = CsrBuilder<ValueType, IndexType>(result);
-        exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(),
-                                   this,
-                                   local_scale_other->get_const_device_view(),
-                                   local_mtx_other.get(), &builder));
-    }
+    exec->run(csr::make_spgeam(
+        local_scale_this->get_const_device_view(), this,
+        local_scale_other->get_const_device_view(), local_mtx_other.get(),
+        std::make_unique<CsrBuilder<ValueType, IndexType>>(result).get()));
     return std::make_pair(
         std::move(result),
         scale_add_reuse_info{

--- a/core/matrix/csr.cpp
+++ b/core/matrix/csr.cpp
@@ -258,8 +258,8 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* b, LinOp* x) const
     if (auto b_csr = dynamic_cast<const TCsr*>(b)) {
         // if b is a CSR matrix, we compute a SpGeMM
         auto x_csr = as<TCsr>(x);
-        this->get_executor()->run(csr::make_spgemm(this, b_csr, x_csr));
-        x_csr->set_strategy(x_csr->get_strategy());
+        auto builder = CsrBuilder<ValueType, IndexType>(x_csr);
+        this->get_executor()->run(csr::make_spgemm(this, b_csr, &builder));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this](auto dense_b, auto dense_x) {
@@ -384,20 +384,20 @@ void Csr<ValueType, IndexType>::apply_impl(const LinOp* alpha, const LinOp* b,
         // if b is a CSR matrix, we compute a SpGeMM
         auto x_csr = as<TCsr>(x);
         auto x_copy = x_csr->clone();
+        auto builder = CsrBuilder<ValueType, IndexType>(x_csr);
         this->get_executor()->run(csr::make_advanced_spgemm(
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this, b_csr,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
-            x_csr));
-        x_csr->set_strategy(x_csr->get_strategy());
+            &builder));
     } else if (dynamic_cast<const Identity<ValueType>*>(b)) {
         // if b is an identity matrix, we compute an SpGEAM
         auto x_csr = as<TCsr>(x);
         auto x_copy = x_csr->clone();
+        auto builder = CsrBuilder<ValueType, IndexType>(x_csr);
         this->get_executor()->run(csr::make_spgeam(
             as<Dense<ValueType>>(alpha)->get_const_device_view(), this,
             as<Dense<ValueType>>(beta)->get_const_device_view(), x_copy.get(),
-            x_csr));
-        x_csr->set_strategy(x_csr->get_strategy());
+            &builder));
     } else {
         mixed_precision_dispatch_real_complex<ValueType>(
             [this, alpha, beta](auto dense_b, auto dense_x) {
@@ -764,7 +764,10 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::multiply(
     auto exec = this->get_executor();
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
-    exec->run(csr::make_spgemm(this, local_other.get(), result.get()));
+    {
+        auto builder = CsrBuilder<ValueType, IndexType>(result);
+        exec->run(csr::make_spgemm(this, local_other.get(), &builder));
+    }
     return result;
 }
 
@@ -843,7 +846,10 @@ Csr<ValueType, IndexType>::multiply_reuse(ptr_param<const Csr> other) const
     auto exec = this->get_executor();
     auto local_other = make_temporary_clone(exec, other);
     auto result = Csr::create(exec, result_size);
-    exec->run(csr::make_spgemm(this, local_other.get(), result.get()));
+    {
+        auto builder = CsrBuilder<ValueType, IndexType>(result);
+        exec->run(csr::make_spgemm(this, local_other.get(), &builder));
+    }
     auto lookup = csr::build_lookup(result.get());
     auto reuse_info = multiply_reuse_info{
         std::make_unique<typename multiply_reuse_info::lookup_data>(
@@ -875,10 +881,13 @@ Csr<ValueType, IndexType>::multiply_add(
     auto local_scale_add = make_temporary_clone(exec, scale_add);
     auto local_mtx_add = make_temporary_clone(exec, mtx_add);
     auto result = Csr::create(exec, result_size);
-    exec->run(csr::make_advanced_spgemm(
-        local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
-        local_scale_add->get_const_device_view(), local_mtx_add.get(),
-        result.get()));
+    {
+        auto builder = CsrBuilder<ValueType, IndexType>(result);
+        exec->run(csr::make_advanced_spgemm(
+            local_scale_mult->get_const_device_view(), this,
+            local_mtx_mult.get(), local_scale_add->get_const_device_view(),
+            local_mtx_add.get(), &builder));
+    }
     return result;
 }
 
@@ -979,10 +988,13 @@ Csr<ValueType, IndexType>::multiply_add_reuse(
     auto local_scale_add = make_temporary_clone(exec, scale_add);
     auto local_mtx_add = make_temporary_clone(exec, mtx_add);
     auto result = Csr::create(exec, result_size);
-    exec->run(csr::make_advanced_spgemm(
-        local_scale_mult->get_const_device_view(), this, local_mtx_mult.get(),
-        local_scale_add->get_const_device_view(), local_mtx_add.get(),
-        result.get()));
+    {
+        auto builder = CsrBuilder<ValueType, IndexType>(result);
+        exec->run(csr::make_advanced_spgemm(
+            local_scale_mult->get_const_device_view(), this,
+            local_mtx_mult.get(), local_scale_add->get_const_device_view(),
+            local_mtx_add.get(), &builder));
+    }
     auto lookup = csr::build_lookup(result.get());
     auto reuse_info = multiply_add_reuse_info{
         std::make_unique<typename multiply_add_reuse_info::lookup_data>(
@@ -1010,9 +1022,13 @@ std::unique_ptr<Csr<ValueType, IndexType>> Csr<ValueType, IndexType>::scale_add(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(), this,
-                               local_scale_other->get_const_device_view(),
-                               local_mtx_other.get(), result.get()));
+    {
+        auto builder = CsrBuilder<ValueType, IndexType>(result);
+        exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(),
+                                   this,
+                                   local_scale_other->get_const_device_view(),
+                                   local_mtx_other.get(), &builder));
+    }
     return result;
 }
 
@@ -1104,9 +1120,13 @@ Csr<ValueType, IndexType>::add_scale_reuse(
     auto local_scale_other = make_temporary_clone(exec, scale_other);
     auto local_mtx_other = make_temporary_clone(exec, mtx_other);
     auto result = Csr::create(exec, this->get_size());
-    exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(), this,
-                               local_scale_other->get_const_device_view(),
-                               local_mtx_other.get(), result.get()));
+    {
+        auto builder = CsrBuilder<ValueType, IndexType>(result);
+        exec->run(csr::make_spgeam(local_scale_this->get_const_device_view(),
+                                   this,
+                                   local_scale_other->get_const_device_view(),
+                                   local_mtx_other.get(), &builder));
+    }
     return std::make_pair(
         std::move(result),
         scale_add_reuse_info{

--- a/core/matrix/csr_builder.hpp
+++ b/core/matrix/csr_builder.hpp
@@ -35,6 +35,11 @@ public:
     array<ValueType>& get_value_array() { return matrix_->values_; }
 
     /**
+     * Returns the matrix pointer
+     */
+    Csr<ValueType, IndexType>* get_matrix() { return matrix_; }
+
+    /**
      * Initializes a CsrBuilder from an existing CSR matrix.
      */
     explicit CsrBuilder(ptr_param<Csr<ValueType, IndexType>> matrix)
@@ -44,9 +49,7 @@ public:
     /**
      * Updates the internal matrix data structures at destruction.
      */
-    ~CsrBuilder()
-    { /*matrix_->make_srow();*/
-    }
+    ~CsrBuilder() { matrix_->make_srow(); }
 
     // make this type non-movable
     CsrBuilder(const CsrBuilder&) = delete;

--- a/core/matrix/csr_builder.hpp
+++ b/core/matrix/csr_builder.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -44,7 +44,9 @@ public:
     /**
      * Updates the internal matrix data structures at destruction.
      */
-    ~CsrBuilder() { matrix_->make_srow(); }
+    ~CsrBuilder()
+    { /*matrix_->make_srow();*/
+    }
 
     // make this type non-movable
     CsrBuilder(const CsrBuilder&) = delete;

--- a/core/matrix/csr_builder.hpp
+++ b/core/matrix/csr_builder.hpp
@@ -6,6 +6,9 @@
 #define GKO_CORE_MATRIX_CSR_BUILDER_HPP_
 
 
+#include <memory>
+
+#include <ginkgo/core/base/utils_helper.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
 
@@ -60,6 +63,29 @@ public:
 private:
     Csr<ValueType, IndexType>* matrix_;
 };
+
+
+// helper function to make CsrBuilder unique_ptr from Csr
+template <typename ValueType, typename IndexType>
+std::unique_ptr<CsrBuilder<ValueType, IndexType>> make_builder_unique_ptr(
+    Csr<ValueType, IndexType>* ptr)
+{
+    return std::make_unique<CsrBuilder<ValueType, IndexType>>(ptr);
+}
+
+template <typename ValueType, typename IndexType>
+std::unique_ptr<CsrBuilder<ValueType, IndexType>> make_builder_unique_ptr(
+    const std::shared_ptr<Csr<ValueType, IndexType>>& ptr)
+{
+    return make_builder_unique_ptr(ptr.get());
+}
+
+template <typename ValueType, typename IndexType, typename Deleter>
+std::unique_ptr<CsrBuilder<ValueType, IndexType>> make_builder_unique_ptr(
+    const std::unique_ptr<Csr<ValueType, IndexType>, Deleter>& ptr)
+{
+    return make_builder_unique_ptr(ptr.get());
+}
 
 
 }  // namespace matrix

--- a/core/matrix/csr_builder.hpp
+++ b/core/matrix/csr_builder.hpp
@@ -43,6 +43,13 @@ public:
     Csr<ValueType, IndexType>* get_matrix() { return matrix_; }
 
     /**
+     * Returns the max nnz per row
+     *
+     * @note it currently only for testing to access the private member
+     */
+    IndexType get_max_nnz_per_row() { return matrix_->max_nnz_per_row_; }
+
+    /**
      * Initializes a CsrBuilder from an existing CSR matrix.
      */
     explicit CsrBuilder(ptr_param<Csr<ValueType, IndexType>> matrix)

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -26,6 +26,8 @@ namespace kernels {
 #define GKO_DECLARE_CSR_SPMV_KERNEL(MatrixValueType, InputValueType, \
                                     OutputValueType, IndexType)      \
     void spmv(std::shared_ptr<const DefaultExecutor> exec,           \
+              const matrix::csr::spmv_strategy strategy,             \
+              const IndexType max_nnz_per_row,                       \
               const matrix::Csr<MatrixValueType, IndexType>* a,      \
               matrix::view::dense<const InputValueType> b,           \
               matrix::view::dense<OutputValueType> c)
@@ -33,6 +35,8 @@ namespace kernels {
 #define GKO_DECLARE_CSR_ADVANCED_SPMV_KERNEL(MatrixValueType, InputValueType, \
                                              OutputValueType, IndexType)      \
     void advanced_spmv(std::shared_ptr<const DefaultExecutor> exec,           \
+                       const matrix::csr::spmv_strategy strategy,             \
+                       const IndexType max_nnz_per_row,                       \
                        matrix::view::dense<const MatrixValueType> alpha,      \
                        const matrix::Csr<MatrixValueType, IndexType>* a,      \
                        matrix::view::dense<const InputValueType> b,           \

--- a/core/matrix/csr_kernels.hpp
+++ b/core/matrix/csr_kernels.hpp
@@ -16,6 +16,7 @@
 #include <ginkgo/core/matrix/sparsity_csr.hpp>
 
 #include "core/base/kernel_declaration.hpp"
+#include "core/matrix/csr_builder.hpp"
 #include "core/matrix/csr_lookup.hpp"
 
 
@@ -47,7 +48,7 @@ namespace kernels {
     void spgemm(std::shared_ptr<const DefaultExecutor> exec, \
                 const matrix::Csr<ValueType, IndexType>* a,  \
                 const matrix::Csr<ValueType, IndexType>* b,  \
-                matrix::Csr<ValueType, IndexType>* c)
+                matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
 #define GKO_DECLARE_CSR_ADVANCED_SPGEMM_KERNEL(ValueType, IndexType)  \
     void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec, \
@@ -56,7 +57,7 @@ namespace kernels {
                          const matrix::Csr<ValueType, IndexType>* b,  \
                          matrix::view::dense<const ValueType> beta,   \
                          const matrix::Csr<ValueType, IndexType>* d,  \
-                         matrix::Csr<ValueType, IndexType>* c)
+                         matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
 #define GKO_DECLARE_CSR_SPGEMM_REUSE_KERNEL(ValueType, IndexType)          \
     void spgemm_reuse(std::shared_ptr<const DefaultExecutor> exec,         \
@@ -82,7 +83,7 @@ namespace kernels {
                 const matrix::Csr<ValueType, IndexType>* a,  \
                 matrix::view::dense<const ValueType> beta,   \
                 const matrix::Csr<ValueType, IndexType>* b,  \
-                matrix::Csr<ValueType, IndexType>* c)
+                matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 
 #define GKO_DECLARE_CSR_SPGEAM_NUMERIC_KERNEL(ValueType, IndexType)  \
     void spgeam_numeric(std::shared_ptr<const DefaultExecutor> exec, \

--- a/core/matrix/csr_strategy.hpp
+++ b/core/matrix/csr_strategy.hpp
@@ -16,9 +16,9 @@ namespace detail {
 
 
 /**
- * Returns the actual strategy passed. When the strategy is automatical, this
+ * Returns the actual strategy passed. When the strategy is automatic, this
  * returns the actual underlying strategy. This returns the same strategy as
- * the input when the input is not automatical.
+ * the input when the input is not automatic.
  *
  * @param exec  Executor associated to the matrix
  * @param strategy  the strategy of CSR

--- a/core/matrix/csr_strategy.hpp
+++ b/core/matrix/csr_strategy.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_MATRIX_CSR_STRATEGY_HPP_
+#define GKO_CORE_MATRIX_CSR_STRATEGY_HPP_
+
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+
+
+namespace gko {
+namespace matrix {
+namespace csr {
+namespace detail {
+
+
+/**
+ * Returns the actual strategy passed. When the strategy is automatical, this
+ * returns the actual underlying strategy. This returns the same strategy as
+ * the input when the input is not automatical.
+ *
+ * @param exec  Executor associated to the matrix
+ * @param strategy  the strategy of CSR
+ * @param num_stored_elements  the number of stored elements
+ * @param max_nnz_per_row  the maximum number of stored elements per row
+ *
+ * @return the actual strategy
+ */
+spmv_strategy get_actual_strategy(std::shared_ptr<const Executor> exec,
+                                  spmv_strategy strategy,
+                                  size_type num_stored_elements,
+                                  size_type max_nnz_per_row);
+
+
+}  // namespace detail
+}  // namespace csr
+}  // namespace matrix
+}  // namespace gko
+
+#endif  // GKO_CORE_MATRIX_CSR_STRATEGY_HPP_

--- a/core/preconditioner/isai.cpp
+++ b/core/preconditioner/isai.cpp
@@ -213,7 +213,7 @@ void Isai<IsaiType, ValueType, IndexType>::generate_inverse(
             auto excess_system =
                 Csr::create(exec, dim<2>(excess_dim, excess_dim), excess_nnz);
             excess_system->set_strategy(
-                std::make_shared<typename Csr::classical>());
+                gko::matrix::csr::spmv_strategy::classical);
             auto excess_rhs = Dense::create(exec, dim<2>(excess_dim, 1));
             auto excess_solution = Dense::create(exec, dim<2>(excess_dim, 1));
             exec->run(isai::make_generate_excess_system(

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -391,7 +391,6 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             // block_pointers has larger size than actual num_blocks_
             exec->run(jacobi::make_block_l1(
                 num_blocks_, parameters_.block_pointers, changed_mtx.get()));
-            changed_mtx->set_strategy(changed_mtx->get_strategy());
             csr_mtx = changed_mtx;
         }
         const auto all_block_opt =

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -384,10 +384,7 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             // TODO: it always run make_srow even if the matrix is not
             // changed
             exec->run(jacobi::make_add_diagonal_elements(
-                std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
-                    changed_mtx)
-                    .get(),
-                true));
+                matrix::make_builder_unique_ptr(changed_mtx).get(), true));
             // block_pointers has larger size than actual num_blocks_
             exec->run(jacobi::make_block_l1(
                 num_blocks_, parameters_.block_pointers, changed_mtx.get()));

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -381,14 +381,13 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             // Because we change the matrix value, we clone it to avoid
             // overwriting to the original matrix.
             auto changed_mtx = share(csr_mtx->clone());
-            {
-                // TODO: it always run make_srow even if the matrix is not
-                // changed
-                auto mtx_builder =
-                    matrix::CsrBuilder<ValueType, IndexType>(changed_mtx);
-                exec->run(
-                    jacobi::make_add_diagonal_elements(&mtx_builder, true));
-            }
+            // TODO: it always run make_srow even if the matrix is not
+            // changed
+            exec->run(jacobi::make_add_diagonal_elements(
+                std::make_unique<matrix::CsrBuilder<ValueType, IndexType>>(
+                    changed_mtx)
+                    .get(),
+                true));
             // block_pointers has larger size than actual num_blocks_
             exec->run(jacobi::make_block_l1(
                 num_blocks_, parameters_.block_pointers, changed_mtx.get()));

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -381,8 +381,14 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             // Because we change the matrix value, we clone it to avoid
             // overwriting to the original matrix.
             auto changed_mtx = share(csr_mtx->clone());
-            exec->run(
-                jacobi::make_add_diagonal_elements(changed_mtx.get(), true));
+            {
+                // TODO: it always run make_srow even if the matrix is not
+                // changed
+                auto mtx_builder =
+                    matrix::CsrBuilder<ValueType, IndexType>(changed_mtx);
+                exec->run(
+                    jacobi::make_add_diagonal_elements(&mtx_builder, true));
+            }
             // block_pointers has larger size than actual num_blocks_
             exec->run(jacobi::make_block_l1(
                 num_blocks_, parameters_.block_pointers, changed_mtx.get()));

--- a/core/preconditioner/jacobi.cpp
+++ b/core/preconditioner/jacobi.cpp
@@ -386,6 +386,7 @@ void Jacobi<ValueType, IndexType>::generate(const LinOp* system_matrix,
             // block_pointers has larger size than actual num_blocks_
             exec->run(jacobi::make_block_l1(
                 num_blocks_, parameters_.block_pointers, changed_mtx.get()));
+            changed_mtx->set_strategy(changed_mtx->get_strategy());
             csr_mtx = changed_mtx;
         }
         const auto all_block_opt =

--- a/core/solver/bicg.cpp
+++ b/core/solver/bicg.cpp
@@ -88,7 +88,7 @@ std::unique_ptr<LinOp> conj_transpose_with_csr(const LinOp* mtx)
         mtx->get_executor(), const_cast<LinOp*>(mtx));
 
     csr_matrix_unique_ptr->set_strategy(
-        std::make_shared<typename CsrType::classical>());
+        gko::matrix::csr::spmv_strategy::classical);
 
     return csr_matrix_unique_ptr->conj_transpose();
 }

--- a/core/test/config/factorization.cpp
+++ b/core/test/config/factorization.cpp
@@ -31,13 +31,6 @@ using namespace gko::config;
 using Sparsity = gko::matrix::SparsityCsr<float, int>;
 
 
-inline void check_strategy(gko::matrix::csr::spmv_strategy res,
-                           gko::matrix::csr::spmv_strategy ans)
-{
-    ASSERT_EQ(res, ans);
-}
-
-
 template <typename ChangedType, typename DefaultType>
 struct FactorizationConfigTest {
     using changed_type = ChangedType;
@@ -79,7 +72,7 @@ struct Ic : FactorizationConfigTest<gko::factorization::Ic<float, int>,
         auto res_param = gko::as<AnswerType>(result)->get_parameters();
         auto ans_param = answer->get_parameters();
 
-        check_strategy(res_param.l_strategy, ans_param.l_strategy);
+        ASSERT_EQ(res_param.l_strategy, ans_param.l_strategy);
         ASSERT_EQ(res_param.skip_sorting, ans_param.skip_sorting);
         ASSERT_EQ(res_param.both_factors, ans_param.both_factors);
         ASSERT_EQ(res_param.algorithm, ans_param.algorithm);
@@ -115,8 +108,8 @@ struct Ilu : FactorizationConfigTest<gko::factorization::Ilu<float, int>,
         auto res_param = gko::as<AnswerType>(result)->get_parameters();
         auto ans_param = answer->get_parameters();
 
-        check_strategy(res_param.l_strategy, ans_param.l_strategy);
-        check_strategy(res_param.u_strategy, ans_param.u_strategy);
+        ASSERT_EQ(res_param.l_strategy, ans_param.l_strategy);
+        ASSERT_EQ(res_param.u_strategy, ans_param.u_strategy);
         ASSERT_EQ(res_param.skip_sorting, ans_param.skip_sorting);
         ASSERT_EQ(res_param.algorithm, ans_param.algorithm);
     }
@@ -220,7 +213,7 @@ struct ParIc : FactorizationConfigTest<gko::factorization::ParIc<float, int>,
 
         ASSERT_EQ(res_param.iterations, ans_param.iterations);
         ASSERT_EQ(res_param.skip_sorting, ans_param.skip_sorting);
-        check_strategy(res_param.l_strategy, ans_param.l_strategy);
+        ASSERT_EQ(res_param.l_strategy, ans_param.l_strategy);
         ASSERT_EQ(res_param.both_factors, ans_param.both_factors);
     }
 };
@@ -256,8 +249,8 @@ struct ParIlu
 
         ASSERT_EQ(res_param.iterations, ans_param.iterations);
         ASSERT_EQ(res_param.skip_sorting, ans_param.skip_sorting);
-        check_strategy(res_param.l_strategy, ans_param.l_strategy);
-        check_strategy(res_param.u_strategy, ans_param.u_strategy);
+        ASSERT_EQ(res_param.l_strategy, ans_param.l_strategy);
+        ASSERT_EQ(res_param.u_strategy, ans_param.u_strategy);
     }
 };
 
@@ -298,12 +291,12 @@ struct ParIct
 
         ASSERT_EQ(res_param.iterations, ans_param.iterations);
         ASSERT_EQ(res_param.skip_sorting, ans_param.skip_sorting);
-        check_strategy(res_param.l_strategy, ans_param.l_strategy);
+        ASSERT_EQ(res_param.l_strategy, ans_param.l_strategy);
         ASSERT_EQ(res_param.approximate_select, ans_param.approximate_select);
         ASSERT_EQ(res_param.deterministic_sample,
                   ans_param.deterministic_sample);
         ASSERT_EQ(res_param.fill_in_limit, ans_param.fill_in_limit);
-        check_strategy(res_param.lt_strategy, ans_param.lt_strategy);
+        ASSERT_EQ(res_param.lt_strategy, ans_param.lt_strategy);
     }
 };
 
@@ -344,12 +337,12 @@ struct ParIlut
 
         ASSERT_EQ(res_param.iterations, ans_param.iterations);
         ASSERT_EQ(res_param.skip_sorting, ans_param.skip_sorting);
-        check_strategy(res_param.l_strategy, ans_param.l_strategy);
+        ASSERT_EQ(res_param.l_strategy, ans_param.l_strategy);
         ASSERT_EQ(res_param.approximate_select, ans_param.approximate_select);
         ASSERT_EQ(res_param.deterministic_sample,
                   ans_param.deterministic_sample);
         ASSERT_EQ(res_param.fill_in_limit, ans_param.fill_in_limit);
-        check_strategy(res_param.u_strategy, ans_param.u_strategy);
+        ASSERT_EQ(res_param.u_strategy, ans_param.u_strategy);
     }
 };
 

--- a/core/test/config/factorization.cpp
+++ b/core/test/config/factorization.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -31,15 +31,10 @@ using namespace gko::config;
 using Sparsity = gko::matrix::SparsityCsr<float, int>;
 
 
-template <typename StrategyType>
-inline void check_strategy(std::shared_ptr<StrategyType>& res,
-                           std::shared_ptr<StrategyType>& ans)
+inline void check_strategy(gko::matrix::csr::spmv_strategy res,
+                           gko::matrix::csr::spmv_strategy ans)
 {
-    if (ans && res) {
-        ASSERT_EQ(res->get_name(), ans->get_name());
-    } else {
-        ASSERT_EQ(res, ans);
-    }
+    ASSERT_EQ(res, ans);
 }
 
 
@@ -68,9 +63,7 @@ struct Ic : FactorizationConfigTest<gko::factorization::Ic<float, int>,
                     std::shared_ptr<const gko::Executor> exec)
     {
         config_map["l_strategy"] = pnode{"sparselib"};
-        param.with_l_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_l_strategy(gko::matrix::csr::spmv_strategy::sparselib);
         config_map["skip_sorting"] = pnode{true};
         param.with_skip_sorting(true);
         config_map["both_factors"] = pnode{false};
@@ -106,13 +99,9 @@ struct Ilu : FactorizationConfigTest<gko::factorization::Ilu<float, int>,
                     std::shared_ptr<const gko::Executor> exec)
     {
         config_map["l_strategy"] = pnode{"sparselib"};
-        param.with_l_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_l_strategy(gko::matrix::csr::spmv_strategy::sparselib);
         config_map["u_strategy"] = pnode{"sparselib"};
-        param.with_u_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_u_strategy(gko::matrix::csr::spmv_strategy::sparselib);
         config_map["skip_sorting"] = pnode{true};
         param.with_skip_sorting(true);
         config_map["algorithm"] = pnode{"syncfree"};
@@ -218,9 +207,7 @@ struct ParIc : FactorizationConfigTest<gko::factorization::ParIc<float, int>,
         config_map["skip_sorting"] = pnode{true};
         param.with_skip_sorting(true);
         config_map["l_strategy"] = pnode{"sparselib"};
-        param.with_l_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_l_strategy(gko::matrix::csr::spmv_strategy::sparselib);
         config_map["both_factors"] = pnode{false};
         param.with_both_factors(false);
     }
@@ -256,13 +243,9 @@ struct ParIlu
         config_map["skip_sorting"] = pnode{true};
         param.with_skip_sorting(true);
         config_map["l_strategy"] = pnode{"sparselib"};
-        param.with_l_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_l_strategy(gko::matrix::csr::spmv_strategy::sparselib);
         config_map["u_strategy"] = pnode{"sparselib"};
-        param.with_u_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_u_strategy(gko::matrix::csr::spmv_strategy::sparselib);
     }
 
     template <typename AnswerType>
@@ -296,9 +279,7 @@ struct ParIct
         config_map["skip_sorting"] = pnode{true};
         param.with_skip_sorting(true);
         config_map["l_strategy"] = pnode{"sparselib"};
-        param.with_l_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_l_strategy(gko::matrix::csr::spmv_strategy::sparselib);
         config_map["approximate_select"] = pnode{false};
         param.with_approximate_select(false);
         config_map["deterministic_sample"] = pnode{true};
@@ -306,9 +287,7 @@ struct ParIct
         config_map["fill_in_limit"] = pnode{2.5};
         param.with_fill_in_limit(2.5);
         config_map["lt_strategy"] = pnode{"sparselib"};
-        param.with_lt_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_lt_strategy(gko::matrix::csr::spmv_strategy::sparselib);
     }
 
     template <typename AnswerType>
@@ -346,9 +325,7 @@ struct ParIlut
         config_map["skip_sorting"] = pnode{true};
         param.with_skip_sorting(true);
         config_map["l_strategy"] = pnode{"sparselib"};
-        param.with_l_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_l_strategy(gko::matrix::csr::spmv_strategy::sparselib);
         config_map["approximate_select"] = pnode{false};
         param.with_approximate_select(false);
         config_map["deterministic_sample"] = pnode{true};
@@ -356,9 +333,7 @@ struct ParIlut
         config_map["fill_in_limit"] = pnode{2.5};
         param.with_fill_in_limit(2.5);
         config_map["u_strategy"] = pnode{"sparselib"};
-        param.with_u_strategy(
-            std::make_shared<
-                typename gko::matrix::Csr<float, int>::sparselib>());
+        param.with_u_strategy(gko::matrix::csr::spmv_strategy::sparselib);
     }
 
     template <typename AnswerType>

--- a/core/test/factorization/CMakeLists.txt
+++ b/core/test/factorization/CMakeLists.txt
@@ -1,4 +1,6 @@
 ginkgo_create_test(elimination_forest)
+ginkgo_create_test(ic)
+ginkgo_create_test(ilu)
 ginkgo_create_test(par_ic)
 ginkgo_create_test(par_ict)
 ginkgo_create_test(par_ilu)

--- a/core/test/factorization/ic.cpp
+++ b/core/test/factorization/ic.cpp
@@ -5,42 +5,30 @@
 #include <gtest/gtest.h>
 
 #include <ginkgo/core/base/executor.hpp>
-#include <ginkgo/core/factorization/par_ic.hpp>
+#include <ginkgo/core/factorization/ic.hpp>
 
 #include "core/test/utils.hpp"
 
 
-namespace {
-
-
 template <typename ValueIndexType>
-class ParIc : public ::testing::Test {
+class Ic : public ::testing::Test {
 public:
     using value_type =
         typename std::tuple_element<0, decltype(ValueIndexType())>::type;
     using index_type =
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
-    using ic_factory_type = gko::factorization::ParIc<value_type, index_type>;
+    using ic_factory_type = gko::factorization::Ic<value_type, index_type>;
 
 protected:
-    ParIc() : ref(gko::ReferenceExecutor::create()) {}
+    Ic() : ref(gko::ReferenceExecutor::create()) {}
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;
 };
 
-TYPED_TEST_SUITE(ParIc, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
+TYPED_TEST_SUITE(Ic, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
-TYPED_TEST(ParIc, SetIterations)
-{
-    auto factory =
-        TestFixture::ic_factory_type::build().with_iterations(5u).on(this->ref);
-
-    ASSERT_EQ(factory->get_parameters().iterations, 5u);
-}
-
-
-TYPED_TEST(ParIc, SetSkip)
+TYPED_TEST(Ic, SetSkip)
 {
     auto factory =
         TestFixture::ic_factory_type::build().with_skip_sorting(true).on(
@@ -50,7 +38,7 @@ TYPED_TEST(ParIc, SetSkip)
 }
 
 
-TYPED_TEST(ParIc, SetLStrategy)
+TYPED_TEST(Ic, SetLStrategy)
 {
     auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
 
@@ -65,7 +53,7 @@ TYPED_TEST(ParIc, SetLStrategy)
 GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
-TYPED_TEST(ParIc, SetLStrategyDeprecated)
+TYPED_TEST(Ic, SetLStrategyDeprecated)
 {
     auto strategy = std::make_shared<
         typename TestFixture::ic_factory_type::matrix_type::load_balance>(
@@ -83,7 +71,7 @@ TYPED_TEST(ParIc, SetLStrategyDeprecated)
 GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
-TYPED_TEST(ParIc, SetBothFactors)
+TYPED_TEST(Ic, SetBothFactors)
 {
     auto factory =
         TestFixture::ic_factory_type::build().with_both_factors(false).on(
@@ -93,34 +81,46 @@ TYPED_TEST(ParIc, SetBothFactors)
 }
 
 
-TYPED_TEST(ParIc, SetDefaults)
+TYPED_TEST(Ic, SetAlgorithm)
+{
+    auto factory =
+        TestFixture::ic_factory_type::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
+            .on(this->ref);
+
+    ASSERT_EQ(factory->get_parameters().algorithm,
+              gko::factorization::incomplete_algorithm::syncfree);
+}
+
+
+TYPED_TEST(Ic, SetDefaults)
 {
     auto factory = TestFixture::ic_factory_type::build().on(this->ref);
 
-    ASSERT_EQ(factory->get_parameters().iterations, 0u);
     ASSERT_EQ(factory->get_parameters().skip_sorting, false);
     ASSERT_EQ(factory->get_parameters().l_strategy,
               gko::matrix::csr::spmv_strategy::classical);
     ASSERT_TRUE(factory->get_parameters().both_factors);
+    ASSERT_EQ(factory->get_parameters().algorithm,
+              gko::factorization::incomplete_algorithm::sparselib);
 }
 
 
-TYPED_TEST(ParIc, SetEverything)
+TYPED_TEST(Ic, SetEverything)
 {
-    auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
-    auto factory = TestFixture::ic_factory_type::build()
-                       .with_iterations(7u)
-                       .with_skip_sorting(false)
-                       .with_l_strategy(strategy)
-                       .with_both_factors(false)
-                       .on(this->ref);
+    auto factory =
+        TestFixture::ic_factory_type::build()
+            .with_skip_sorting(false)
+            .with_l_strategy(strategy)
+            .with_both_factors(false)
+            .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
+            .on(this->ref);
 
-    ASSERT_EQ(factory->get_parameters().iterations, 7u);
     ASSERT_EQ(factory->get_parameters().skip_sorting, false);
     ASSERT_EQ(factory->get_parameters().l_strategy, strategy);
     ASSERT_FALSE(factory->get_parameters().both_factors);
+    ASSERT_EQ(factory->get_parameters().algorithm,
+              gko::factorization::incomplete_algorithm::syncfree);
 }
-
-
-}  // namespace

--- a/core/test/factorization/ilu.cpp
+++ b/core/test/factorization/ilu.cpp
@@ -5,43 +5,30 @@
 #include <gtest/gtest.h>
 
 #include <ginkgo/core/base/executor.hpp>
-#include <ginkgo/core/factorization/par_ilu.hpp>
+#include <ginkgo/core/factorization/ilu.hpp>
 
 #include "core/test/utils.hpp"
 
 
-namespace {
-
-
 template <typename ValueIndexType>
-class ParIlu : public ::testing::Test {
+class Ilu : public ::testing::Test {
 public:
     using value_type =
         typename std::tuple_element<0, decltype(ValueIndexType())>::type;
     using index_type =
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
-    using ilu_factory_type = gko::factorization::ParIlu<value_type, index_type>;
+    using ilu_factory_type = gko::factorization::Ilu<value_type, index_type>;
 
 protected:
-    ParIlu() : ref(gko::ReferenceExecutor::create()) {}
+    Ilu() : ref(gko::ReferenceExecutor::create()) {}
 
     std::shared_ptr<const gko::ReferenceExecutor> ref;
 };
 
-TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
+TYPED_TEST_SUITE(Ilu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 
 
-TYPED_TEST(ParIlu, SetIterations)
-{
-    auto factory =
-        TestFixture::ilu_factory_type::build().with_iterations(5u).on(
-            this->ref);
-
-    ASSERT_EQ(factory->get_parameters().iterations, 5u);
-}
-
-
-TYPED_TEST(ParIlu, SetSkip)
+TYPED_TEST(Ilu, SetSkip)
 {
     auto factory =
         TestFixture::ilu_factory_type::build().with_skip_sorting(true).on(
@@ -51,7 +38,7 @@ TYPED_TEST(ParIlu, SetSkip)
 }
 
 
-TYPED_TEST(ParIlu, SetLStrategy)
+TYPED_TEST(Ilu, SetLStrategy)
 {
     auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
 
@@ -63,7 +50,7 @@ TYPED_TEST(ParIlu, SetLStrategy)
 }
 
 
-TYPED_TEST(ParIlu, SetUStrategy)
+TYPED_TEST(Ilu, SetUStrategy)
 {
     auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
 
@@ -78,7 +65,7 @@ TYPED_TEST(ParIlu, SetUStrategy)
 GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
 
-TYPED_TEST(ParIlu, SetStrategyDeprecated)
+TYPED_TEST(Ilu, SetStrategyDeprecated)
 {
     using matrix_type = typename TestFixture::ilu_factory_type::matrix_type;
     auto l_strategy =
@@ -100,36 +87,48 @@ TYPED_TEST(ParIlu, SetStrategyDeprecated)
 GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
-TYPED_TEST(ParIlu, SetDefaults)
+TYPED_TEST(Ilu, SetAlgorithm)
+{
+    auto factory =
+        TestFixture::ilu_factory_type::build()
+            .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
+            .on(this->ref);
+
+    ASSERT_EQ(factory->get_parameters().algorithm,
+              gko::factorization::incomplete_algorithm::syncfree);
+}
+
+
+TYPED_TEST(Ilu, SetDefaults)
 {
     auto factory = TestFixture::ilu_factory_type::build().on(this->ref);
 
-    ASSERT_EQ(factory->get_parameters().iterations, 0u);
     ASSERT_EQ(factory->get_parameters().skip_sorting, false);
     ASSERT_EQ(factory->get_parameters().l_strategy,
               gko::matrix::csr::spmv_strategy::classical);
     ASSERT_EQ(factory->get_parameters().u_strategy,
               gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(factory->get_parameters().algorithm,
+              gko::factorization::incomplete_algorithm::sparselib);
 }
 
 
-TYPED_TEST(ParIlu, SetEverything)
+TYPED_TEST(Ilu, SetEverything)
 {
     auto l_strategy = gko::matrix::csr::spmv_strategy::load_balance;
     auto u_strategy = gko::matrix::csr::spmv_strategy::sparselib;
 
-    auto factory = TestFixture::ilu_factory_type::build()
-                       .with_iterations(7u)
-                       .with_skip_sorting(false)
-                       .with_l_strategy(l_strategy)
-                       .with_u_strategy(u_strategy)
-                       .on(this->ref);
+    auto factory =
+        TestFixture::ilu_factory_type::build()
+            .with_skip_sorting(false)
+            .with_l_strategy(l_strategy)
+            .with_u_strategy(u_strategy)
+            .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
+            .on(this->ref);
 
-    ASSERT_EQ(factory->get_parameters().iterations, 7u);
     ASSERT_EQ(factory->get_parameters().skip_sorting, false);
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
     ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
+    ASSERT_EQ(factory->get_parameters().algorithm,
+              gko::factorization::incomplete_algorithm::syncfree);
 }
-
-
-}  // namespace

--- a/core/test/factorization/par_ic.cpp
+++ b/core/test/factorization/par_ic.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,7 +21,6 @@ public:
     using index_type =
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
     using ic_factory_type = gko::factorization::ParIc<value_type, index_type>;
-    using strategy_type = typename ic_factory_type::matrix_type::classical;
 
 protected:
     ParIc() : ref(gko::ReferenceExecutor::create()) {}
@@ -53,7 +52,7 @@ TYPED_TEST(ParIc, SetSkip)
 
 TYPED_TEST(ParIc, SetLStrategy)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         TestFixture::ic_factory_type::build().with_l_strategy(strategy).on(
@@ -79,14 +78,15 @@ TYPED_TEST(ParIc, SetDefaults)
 
     ASSERT_EQ(factory->get_parameters().iterations, 0u);
     ASSERT_EQ(factory->get_parameters().skip_sorting, false);
-    ASSERT_EQ(factory->get_parameters().l_strategy, nullptr);
+    ASSERT_EQ(factory->get_parameters().l_strategy,
+              gko::matrix::csr::spmv_strategy::classical);
     ASSERT_TRUE(factory->get_parameters().both_factors);
 }
 
 
 TYPED_TEST(ParIc, SetEverything)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = TestFixture::ic_factory_type::build()
                        .with_iterations(7u)

--- a/core/test/factorization/par_ict.cpp
+++ b/core/test/factorization/par_ict.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,7 +21,6 @@ public:
     using index_type =
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
     using ict_factory_type = gko::factorization::ParIct<value_type, index_type>;
-    using strategy_type = typename ict_factory_type::matrix_type::classical;
 
 protected:
     ParIct() : ref(gko::ReferenceExecutor::create()) {}
@@ -84,7 +83,7 @@ TYPED_TEST(ParIct, SetFillIn)
 
 TYPED_TEST(ParIct, SetLStrategy)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         TestFixture::ict_factory_type::build().with_l_strategy(strategy).on(
@@ -103,13 +102,14 @@ TYPED_TEST(ParIct, SetDefaults)
     ASSERT_EQ(factory->get_parameters().approximate_select, true);
     ASSERT_EQ(factory->get_parameters().deterministic_sample, false);
     ASSERT_EQ(factory->get_parameters().fill_in_limit, 2.0);
-    ASSERT_EQ(factory->get_parameters().l_strategy, nullptr);
+    ASSERT_EQ(factory->get_parameters().l_strategy,
+              gko::matrix::csr::spmv_strategy::classical);
 }
 
 
 TYPED_TEST(ParIct, SetEverything)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = TestFixture::ict_factory_type::build()
                        .with_iterations(7u)

--- a/core/test/factorization/par_ict.cpp
+++ b/core/test/factorization/par_ict.cpp
@@ -83,7 +83,7 @@ TYPED_TEST(ParIct, SetFillIn)
 
 TYPED_TEST(ParIct, SetLStrategy)
 {
-    auto strategy = gko::matrix::csr::spmv_strategy::classical;
+    auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
 
     auto factory =
         TestFixture::ict_factory_type::build().with_l_strategy(strategy).on(
@@ -91,6 +91,27 @@ TYPED_TEST(ParIct, SetLStrategy)
 
     ASSERT_EQ(factory->get_parameters().l_strategy, strategy);
 }
+
+
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
+
+TYPED_TEST(ParIct, SetLStrategyDeprecated)
+{
+    auto strategy = std::make_shared<
+        typename TestFixture::ict_factory_type::matrix_type::load_balance>(
+        this->ref);
+
+    auto factory =
+        TestFixture::ict_factory_type::build().with_l_strategy(strategy).on(
+            this->ref);
+
+    ASSERT_EQ(factory->get_parameters().l_strategy,
+              gko::matrix::csr::spmv_strategy::load_balance);
+}
+
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
 TYPED_TEST(ParIct, SetDefaults)
@@ -109,7 +130,7 @@ TYPED_TEST(ParIct, SetDefaults)
 
 TYPED_TEST(ParIct, SetEverything)
 {
-    auto strategy = gko::matrix::csr::spmv_strategy::classical;
+    auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
 
     auto factory = TestFixture::ict_factory_type::build()
                        .with_iterations(7u)

--- a/core/test/factorization/par_ilu.cpp
+++ b/core/test/factorization/par_ilu.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -21,7 +21,6 @@ public:
     using index_type =
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
     using ilu_factory_type = gko::factorization::ParIlu<value_type, index_type>;
-    using strategy_type = typename ilu_factory_type::matrix_type::classical;
 
 protected:
     ParIlu() : ref(gko::ReferenceExecutor::create()) {}
@@ -54,7 +53,7 @@ TYPED_TEST(ParIlu, SetSkip)
 
 TYPED_TEST(ParIlu, SetLStrategy)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         TestFixture::ilu_factory_type::build().with_l_strategy(strategy).on(
@@ -66,7 +65,7 @@ TYPED_TEST(ParIlu, SetLStrategy)
 
 TYPED_TEST(ParIlu, SetUStrategy)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         TestFixture::ilu_factory_type::build().with_u_strategy(strategy).on(
@@ -82,15 +81,17 @@ TYPED_TEST(ParIlu, SetDefaults)
 
     ASSERT_EQ(factory->get_parameters().iterations, 0u);
     ASSERT_EQ(factory->get_parameters().skip_sorting, false);
-    ASSERT_EQ(factory->get_parameters().l_strategy, nullptr);
-    ASSERT_EQ(factory->get_parameters().u_strategy, nullptr);
+    ASSERT_EQ(factory->get_parameters().l_strategy,
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(factory->get_parameters().u_strategy,
+              gko::matrix::csr::spmv_strategy::classical);
 }
 
 
 TYPED_TEST(ParIlu, SetEverything)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
-    auto strategy2 = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
+    auto strategy2 = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = TestFixture::ilu_factory_type::build()
                        .with_iterations(7u)

--- a/core/test/factorization/par_ilut.cpp
+++ b/core/test/factorization/par_ilut.cpp
@@ -85,7 +85,7 @@ TYPED_TEST(ParIlut, SetFillIn)
 
 TYPED_TEST(ParIlut, SetLStrategy)
 {
-    auto strategy = gko::matrix::csr::spmv_strategy::classical;
+    auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
 
     auto factory =
         TestFixture::ilut_factory_type::build().with_l_strategy(strategy).on(
@@ -97,7 +97,7 @@ TYPED_TEST(ParIlut, SetLStrategy)
 
 TYPED_TEST(ParIlut, SetUStrategy)
 {
-    auto strategy = gko::matrix::csr::spmv_strategy::classical;
+    auto strategy = gko::matrix::csr::spmv_strategy::load_balance;
 
     auto factory =
         TestFixture::ilut_factory_type::build().with_u_strategy(strategy).on(
@@ -105,6 +105,31 @@ TYPED_TEST(ParIlut, SetUStrategy)
 
     ASSERT_EQ(factory->get_parameters().u_strategy, strategy);
 }
+
+
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
+
+TYPED_TEST(ParIlut, SetStrategyDeprecated)
+{
+    using matrix_type = typename TestFixture::ilut_factory_type::matrix_type;
+    auto l_strategy =
+        std::make_shared<typename matrix_type::load_balance>(this->ref);
+    auto u_strategy = std::make_shared<typename matrix_type::sparselib>();
+
+    auto factory = TestFixture::ilut_factory_type::build()
+                       .with_l_strategy(l_strategy)
+                       .with_u_strategy(u_strategy)
+                       .on(this->ref);
+
+    ASSERT_EQ(factory->get_parameters().l_strategy,
+              gko::matrix::csr::spmv_strategy::load_balance);
+    ASSERT_EQ(factory->get_parameters().u_strategy,
+              gko::matrix::csr::spmv_strategy::sparselib);
+}
+
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS
 
 
 TYPED_TEST(ParIlut, SetDefaults)
@@ -125,8 +150,8 @@ TYPED_TEST(ParIlut, SetDefaults)
 
 TYPED_TEST(ParIlut, SetEverything)
 {
-    auto strategy = gko::matrix::csr::spmv_strategy::classical;
-    auto strategy2 = gko::matrix::csr::spmv_strategy::classical;
+    auto l_strategy = gko::matrix::csr::spmv_strategy::load_balance;
+    auto u_strategy = gko::matrix::csr::spmv_strategy::sparselib;
 
     auto factory = TestFixture::ilut_factory_type::build()
                        .with_iterations(7u)
@@ -134,8 +159,8 @@ TYPED_TEST(ParIlut, SetEverything)
                        .with_approximate_select(false)
                        .with_deterministic_sample(true)
                        .with_fill_in_limit(1.2)
-                       .with_l_strategy(strategy)
-                       .with_u_strategy(strategy2)
+                       .with_l_strategy(l_strategy)
+                       .with_u_strategy(u_strategy)
                        .on(this->ref);
 
     ASSERT_EQ(factory->get_parameters().iterations, 7u);
@@ -143,8 +168,8 @@ TYPED_TEST(ParIlut, SetEverything)
     ASSERT_EQ(factory->get_parameters().approximate_select, false);
     ASSERT_EQ(factory->get_parameters().deterministic_sample, true);
     ASSERT_EQ(factory->get_parameters().fill_in_limit, 1.2);
-    ASSERT_EQ(factory->get_parameters().l_strategy, strategy);
-    ASSERT_EQ(factory->get_parameters().u_strategy, strategy2);
+    ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
+    ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
 }
 
 

--- a/core/test/factorization/par_ilut.cpp
+++ b/core/test/factorization/par_ilut.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -22,7 +22,6 @@ public:
         typename std::tuple_element<1, decltype(ValueIndexType())>::type;
     using ilut_factory_type =
         gko::factorization::ParIlut<value_type, index_type>;
-    using strategy_type = typename ilut_factory_type::matrix_type::classical;
 
 protected:
     ParIlut() : ref(gko::ReferenceExecutor::create()) {}
@@ -86,7 +85,7 @@ TYPED_TEST(ParIlut, SetFillIn)
 
 TYPED_TEST(ParIlut, SetLStrategy)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         TestFixture::ilut_factory_type::build().with_l_strategy(strategy).on(
@@ -98,7 +97,7 @@ TYPED_TEST(ParIlut, SetLStrategy)
 
 TYPED_TEST(ParIlut, SetUStrategy)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         TestFixture::ilut_factory_type::build().with_u_strategy(strategy).on(
@@ -117,15 +116,17 @@ TYPED_TEST(ParIlut, SetDefaults)
     ASSERT_EQ(factory->get_parameters().approximate_select, true);
     ASSERT_EQ(factory->get_parameters().deterministic_sample, false);
     ASSERT_EQ(factory->get_parameters().fill_in_limit, 2.0);
-    ASSERT_EQ(factory->get_parameters().l_strategy, nullptr);
-    ASSERT_EQ(factory->get_parameters().u_strategy, nullptr);
+    ASSERT_EQ(factory->get_parameters().l_strategy,
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(factory->get_parameters().u_strategy,
+              gko::matrix::csr::spmv_strategy::classical);
 }
 
 
 TYPED_TEST(ParIlut, SetEverything)
 {
-    auto strategy = std::make_shared<typename TestFixture::strategy_type>();
-    auto strategy2 = std::make_shared<typename TestFixture::strategy_type>();
+    auto strategy = gko::matrix::csr::spmv_strategy::classical;
+    auto strategy2 = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = TestFixture::ilut_factory_type::build()
                        .with_iterations(7u)

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -122,8 +122,10 @@ TYPED_TEST(Csr, CanBeCreatedFromExistingData)
         gko::make_array_view(this->exec, 4, values),
         gko::make_array_view(this->exec, 4, col_idxs),
         gko::make_array_view(this->exec, 4, row_ptrs),
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+        gko::matrix::csr::spmv_strategy::load_balance);
 
+    ASSERT_EQ(mtx->get_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
     ASSERT_EQ(mtx->get_num_srow_elements(), 0);
     ASSERT_EQ(mtx->get_const_values(), values);
     ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
@@ -146,8 +148,10 @@ TYPED_TEST(Csr, CanBeCreatedFromExistingConstData)
         gko::array<value_type>::const_view(this->exec, 4, values),
         gko::array<index_type>::const_view(this->exec, 4, col_idxs),
         gko::array<index_type>::const_view(this->exec, 4, row_ptrs),
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+        gko::matrix::csr::spmv_strategy::load_balance);
 
+    ASSERT_EQ(mtx->get_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
     ASSERT_EQ(mtx->get_num_srow_elements(), 0);
     ASSERT_EQ(mtx->get_const_values(), values);
     ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
@@ -209,13 +213,13 @@ TYPED_TEST(Csr, CanBeCreatedFromExistingDataAndDeprecatedStrategy)
                     gko::make_array_view(this->exec, 4, row_ptrs),
                     std::make_shared<typename Mtx::load_balance>(this->exec));
 
+    ASSERT_EQ(mtx->get_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
     ASSERT_EQ(mtx->get_num_srow_elements(), 0);
     ASSERT_EQ(mtx->get_const_values(), values);
     ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
     ASSERT_EQ(mtx->get_const_row_ptrs(), row_ptrs);
     ASSERT_EQ(mtx->get_const_srow(), nullptr);
-    ASSERT_EQ(mtx->get_strategy(),
-              gko::matrix::csr::spmv_strategy::load_balance);
 }
 
 
@@ -285,9 +289,8 @@ TYPED_TEST(Csr, CanBeCloned)
 TYPED_TEST(Csr, CanBeReadFromMatrixData)
 {
     using Mtx = typename TestFixture::Mtx;
-    auto m = Mtx::create(
-        this->exec,
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m =
+        Mtx::create(this->exec, gko::matrix::csr::spmv_strategy::load_balance);
 
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
@@ -303,10 +306,9 @@ TYPED_TEST(Csr, CanBeReadFromMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 4);
     auto values = gko::array<value_type>(this->exec, 4);
-    auto m = Mtx::create(
-        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
-        row_ptrs.as_view(),
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         gko::matrix::csr::spmv_strategy::load_balance);
 
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
@@ -325,10 +327,9 @@ TYPED_TEST(Csr, ThrowsOnIncompatibleReadFromMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 1);
     auto values = gko::array<value_type>(this->exec, 1);
-    auto m = Mtx::create(
-        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
-        row_ptrs.as_view(),
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         gko::matrix::csr::spmv_strategy::load_balance);
 
     ASSERT_THROW(m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}}}),
                  gko::NotSupported);
@@ -340,9 +341,8 @@ TYPED_TEST(Csr, CanBeReadFromMatrixAssemblyData)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto m = Mtx::create(
-        this->exec,
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m =
+        Mtx::create(this->exec, gko::matrix::csr::spmv_strategy::load_balance);
     gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -360,9 +360,8 @@ TYPED_TEST(Csr, CanBeReadFromDeviceMatrixData)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto m = Mtx::create(
-        this->exec,
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m =
+        Mtx::create(this->exec, gko::matrix::csr::spmv_strategy::load_balance);
     gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -389,10 +388,9 @@ TYPED_TEST(Csr, CanBeReadFromDeviceMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 4);
     auto values = gko::array<value_type>(this->exec, 4);
-    auto m = Mtx::create(
-        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
-        row_ptrs.as_view(),
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         gko::matrix::csr::spmv_strategy::load_balance);
     gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -419,10 +417,9 @@ TYPED_TEST(Csr, ThrowsOnIncompatibleReadFromDeviceMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 1);
     auto values = gko::array<value_type>(this->exec, 1);
-    auto m = Mtx::create(
-        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
-        row_ptrs.as_view(),
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         gko::matrix::csr::spmv_strategy::load_balance);
     gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -439,9 +436,8 @@ TYPED_TEST(Csr, CanBeReadFromMovedDeviceMatrixData)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto m = Mtx::create(
-        this->exec,
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m =
+        Mtx::create(this->exec, gko::matrix::csr::spmv_strategy::load_balance);
     gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -470,10 +466,9 @@ TYPED_TEST(Csr, CanBeReadFromMovedDeviceMatrixDataIntoViews)
     row_ptrs.fill(0);
     col_idxs.fill(0);
     values.fill(gko::zero<value_type>());
-    auto m = Mtx::create(
-        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
-        row_ptrs.as_view(),
-        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
+    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
+                         col_idxs.as_view(), row_ptrs.as_view(),
+                         gko::matrix::csr::spmv_strategy::load_balance);
     gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -26,13 +26,11 @@ protected:
     Csr()
         : exec(gko::ReferenceExecutor::create()),
           mtx(gko::matrix::Csr<value_type, index_type>::create(
-              exec, gko::dim<2>{2, 3}, 4,
-              std::make_shared<typename Mtx::load_balance>(2)))
+              exec, gko::dim<2>{2, 3}, 4))
     {
         value_type* v = mtx->get_values();
         index_type* c = mtx->get_col_idxs();
         index_type* r = mtx->get_row_ptrs();
-        index_type* s = mtx->get_srow();
         r[0] = 0;
         r[1] = 3;
         r[2] = 4;
@@ -44,7 +42,9 @@ protected:
         v[1] = 3.0;
         v[2] = 2.0;
         v[3] = 5.0;
-        s[0] = 0;
+        // need set strategy after filling the data, but the automatical
+        // strategy has nothing on reference.
+        mtx->set_strategy(mtx->get_strategy());
     }
 
     std::shared_ptr<const gko::Executor> exec;
@@ -69,7 +69,7 @@ protected:
         EXPECT_EQ(v[1], value_type{3.0});
         EXPECT_EQ(v[2], value_type{2.0});
         EXPECT_EQ(v[3], value_type{5.0});
-        EXPECT_EQ(s[0], 0);
+        ASSERT_EQ(s, nullptr);
     }
 
     void assert_empty(gko::ptr_param<const Mtx> m)
@@ -122,13 +122,13 @@ TYPED_TEST(Csr, CanBeCreatedFromExistingData)
         gko::make_array_view(this->exec, 4, values),
         gko::make_array_view(this->exec, 4, col_idxs),
         gko::make_array_view(this->exec, 4, row_ptrs),
-        std::make_shared<typename Mtx::load_balance>(2));
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
 
-    ASSERT_EQ(mtx->get_num_srow_elements(), 1);
+    ASSERT_EQ(mtx->get_num_srow_elements(), 0);
     ASSERT_EQ(mtx->get_const_values(), values);
     ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
     ASSERT_EQ(mtx->get_const_row_ptrs(), row_ptrs);
-    ASSERT_EQ(mtx->get_const_srow()[0], 0);
+    ASSERT_EQ(mtx->get_const_srow(), nullptr);
 }
 
 
@@ -146,13 +146,12 @@ TYPED_TEST(Csr, CanBeCreatedFromExistingConstData)
         gko::array<value_type>::const_view(this->exec, 4, values),
         gko::array<index_type>::const_view(this->exec, 4, col_idxs),
         gko::array<index_type>::const_view(this->exec, 4, row_ptrs),
-        std::make_shared<typename Mtx::load_balance>(2));
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
 
-    ASSERT_EQ(mtx->get_num_srow_elements(), 1);
+    ASSERT_EQ(mtx->get_num_srow_elements(), 0);
     ASSERT_EQ(mtx->get_const_values(), values);
     ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
     ASSERT_EQ(mtx->get_const_row_ptrs(), row_ptrs);
-    ASSERT_EQ(mtx->get_const_srow()[0], 0);
 }
 
 
@@ -194,8 +193,9 @@ TYPED_TEST(Csr, CanBeCloned)
 TYPED_TEST(Csr, CanBeReadFromMatrixData)
 {
     using Mtx = typename TestFixture::Mtx;
-    auto m = Mtx::create(this->exec,
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec,
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
 
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
@@ -211,9 +211,10 @@ TYPED_TEST(Csr, CanBeReadFromMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 4);
     auto values = gko::array<value_type>(this->exec, 4);
-    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
-                         col_idxs.as_view(), row_ptrs.as_view(),
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
+        row_ptrs.as_view(),
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
 
     m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
 
@@ -232,9 +233,10 @@ TYPED_TEST(Csr, ThrowsOnIncompatibleReadFromMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 1);
     auto values = gko::array<value_type>(this->exec, 1);
-    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
-                         col_idxs.as_view(), row_ptrs.as_view(),
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
+        row_ptrs.as_view(),
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
 
     ASSERT_THROW(m->read({{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}}}),
                  gko::NotSupported);
@@ -246,8 +248,9 @@ TYPED_TEST(Csr, CanBeReadFromMatrixAssemblyData)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto m = Mtx::create(this->exec,
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec,
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
     gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -265,8 +268,9 @@ TYPED_TEST(Csr, CanBeReadFromDeviceMatrixData)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto m = Mtx::create(this->exec,
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec,
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
     gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -293,9 +297,10 @@ TYPED_TEST(Csr, CanBeReadFromDeviceMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 4);
     auto values = gko::array<value_type>(this->exec, 4);
-    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
-                         col_idxs.as_view(), row_ptrs.as_view(),
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
+        row_ptrs.as_view(),
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
     gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -322,9 +327,10 @@ TYPED_TEST(Csr, ThrowsOnIncompatibleReadFromDeviceMatrixDataIntoViews)
     auto row_ptrs = gko::array<index_type>(this->exec, 3);
     auto col_idxs = gko::array<index_type>(this->exec, 1);
     auto values = gko::array<value_type>(this->exec, 1);
-    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
-                         col_idxs.as_view(), row_ptrs.as_view(),
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
+        row_ptrs.as_view(),
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
     gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -341,8 +347,9 @@ TYPED_TEST(Csr, CanBeReadFromMovedDeviceMatrixData)
     using Mtx = typename TestFixture::Mtx;
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
-    auto m = Mtx::create(this->exec,
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec,
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
     gko::matrix_assembly_data<value_type, index_type> data(gko::dim<2>{2, 3});
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);
@@ -371,9 +378,10 @@ TYPED_TEST(Csr, CanBeReadFromMovedDeviceMatrixDataIntoViews)
     row_ptrs.fill(0);
     col_idxs.fill(0);
     values.fill(gko::zero<value_type>());
-    auto m = Mtx::create(this->exec, gko::dim<2>{2, 3}, values.as_view(),
-                         col_idxs.as_view(), row_ptrs.as_view(),
-                         std::make_shared<typename Mtx::load_balance>(2));
+    auto m = Mtx::create(
+        this->exec, gko::dim<2>{2, 3}, values.as_view(), col_idxs.as_view(),
+        row_ptrs.as_view(),
+        gko::matrix::csr::spmv_strategy::load_balance /*load_balance(2)*/);
     gko::matrix_assembly_data<value_type, index_type> data(m->get_size());
     data.set_value(0, 0, 1.0);
     data.set_value(0, 1, 3.0);

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -8,6 +8,7 @@
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 
+#include "core/matrix/csr_builder.hpp"
 #include "core/test/utils.hpp"
 
 
@@ -50,7 +51,7 @@ protected:
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx;
 
-    void assert_equal_to_original_mtx(gko::ptr_param<const Mtx> m)
+    void assert_equal_to_original_mtx(gko::ptr_param<Mtx> m)
     {
         auto v = m->get_const_values();
         auto c = m->get_const_col_idxs();
@@ -70,9 +71,12 @@ protected:
         EXPECT_EQ(v[2], value_type{2.0});
         EXPECT_EQ(v[3], value_type{5.0});
         ASSERT_EQ(s, nullptr);
+        ASSERT_EQ(gko::matrix::make_builder_unique_ptr(m.get())
+                      ->get_max_nnz_per_row(),
+                  3);
     }
 
-    void assert_empty(gko::ptr_param<const Mtx> m)
+    void assert_empty(gko::ptr_param<Mtx> m)
     {
         ASSERT_EQ(m->get_size(), gko::dim<2>(0, 0));
         ASSERT_EQ(m->get_num_stored_elements(), 0);
@@ -80,6 +84,9 @@ protected:
         ASSERT_EQ(m->get_const_col_idxs(), nullptr);
         ASSERT_NE(m->get_const_row_ptrs(), nullptr);
         ASSERT_EQ(m->get_const_srow(), nullptr);
+        ASSERT_EQ(gko::matrix::make_builder_unique_ptr(m.get())
+                      ->get_max_nnz_per_row(),
+                  0);
     }
 };
 

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -155,6 +155,98 @@ TYPED_TEST(Csr, CanBeCreatedFromExistingConstData)
 }
 
 
+GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
+
+TYPED_TEST(Csr, CanBeCreatedFromDeprecatedStrategy)
+{
+    using Mtx = typename TestFixture::Mtx;
+    auto mtx_automatical = Mtx::create(
+        this->exec, std::make_shared<typename Mtx::automatical>(this->exec));
+    auto mtx_nullptr = Mtx::create(
+        this->exec, std::shared_ptr<typename Mtx::strategy_type>{nullptr});
+    auto mtx_classical =
+        Mtx::create(this->exec, std::make_shared<typename Mtx::classical>());
+    auto mtx_merge_path =
+        Mtx::create(this->exec, std::make_shared<typename Mtx::merge_path>());
+    auto mtx_load_balance = Mtx::create(
+        this->exec, std::make_shared<typename Mtx::load_balance>(this->exec));
+    auto mtx_sparselib =
+        Mtx::create(this->exec, std::make_shared<typename Mtx::sparselib>());
+    auto mtx_cusparse =
+        Mtx::create(this->exec, std::make_shared<typename Mtx::cusparse>());
+
+    ASSERT_EQ(mtx_automatical->get_strategy(),
+              gko::matrix::csr::spmv_strategy::automatical);
+    ASSERT_EQ(mtx_nullptr->get_strategy(),
+              gko::matrix::csr::spmv_strategy::automatical);
+    ASSERT_EQ(mtx_classical->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(mtx_merge_path->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
+    ASSERT_EQ(mtx_load_balance->get_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
+    ASSERT_EQ(mtx_sparselib->get_strategy(),
+              gko::matrix::csr::spmv_strategy::sparselib);
+    ASSERT_EQ(mtx_cusparse->get_strategy(),
+              gko::matrix::csr::spmv_strategy::sparselib);
+}
+
+
+TYPED_TEST(Csr, CanBeCreatedFromExistingDataAndDeprecatedStrategy)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    value_type values[] = {1.0, 2.0, 3.0, 4.0};
+    index_type col_idxs[] = {0, 1, 1, 0};
+    index_type row_ptrs[] = {0, 2, 3, 4};
+
+    auto mtx =
+        Mtx::create(this->exec, gko::dim<2>{3, 2},
+                    gko::make_array_view(this->exec, 4, values),
+                    gko::make_array_view(this->exec, 4, col_idxs),
+                    gko::make_array_view(this->exec, 4, row_ptrs),
+                    std::make_shared<typename Mtx::load_balance>(this->exec));
+
+    ASSERT_EQ(mtx->get_num_srow_elements(), 0);
+    ASSERT_EQ(mtx->get_const_values(), values);
+    ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
+    ASSERT_EQ(mtx->get_const_row_ptrs(), row_ptrs);
+    ASSERT_EQ(mtx->get_const_srow(), nullptr);
+    ASSERT_EQ(mtx->get_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
+}
+
+
+TYPED_TEST(Csr, CanBeCreatedFromExistingConstDataAndDeprecatedStrategy)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    const value_type values[] = {1.0, 2.0, 3.0, 4.0};
+    const index_type col_idxs[] = {0, 1, 1, 0};
+    const index_type row_ptrs[] = {0, 2, 3, 4};
+
+    auto mtx = Mtx::create_const(
+        this->exec, gko::dim<2>{3, 2},
+        gko::array<value_type>::const_view(this->exec, 4, values),
+        gko::array<index_type>::const_view(this->exec, 4, col_idxs),
+        gko::array<index_type>::const_view(this->exec, 4, row_ptrs),
+        std::make_shared<typename Mtx::load_balance>(this->exec));
+
+    ASSERT_EQ(mtx->get_num_srow_elements(), 0);
+    ASSERT_EQ(mtx->get_const_values(), values);
+    ASSERT_EQ(mtx->get_const_col_idxs(), col_idxs);
+    ASSERT_EQ(mtx->get_const_row_ptrs(), row_ptrs);
+    ASSERT_EQ(mtx->get_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
+}
+
+
+GKO_END_DISABLE_DEPRECATION_WARNINGS
+
+
 TYPED_TEST(Csr, CanBeCopied)
 {
     using Mtx = typename TestFixture::Mtx;

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -42,7 +42,7 @@ protected:
         v[1] = 3.0;
         v[2] = 2.0;
         v[3] = 5.0;
-        // need set strategy after filling the data, but the automatical
+        // need set strategy after filling the data, but the automatic
         // strategy has nothing on reference.
         mtx->set_strategy(mtx->get_strategy());
     }
@@ -181,9 +181,9 @@ TYPED_TEST(Csr, CanBeCreatedFromDeprecatedStrategy)
         Mtx::create(this->exec, std::make_shared<typename Mtx::cusparse>());
 
     ASSERT_EQ(mtx_automatical->get_strategy(),
-              gko::matrix::csr::spmv_strategy::automatical);
+              gko::matrix::csr::spmv_strategy::automatic);
     ASSERT_EQ(mtx_nullptr->get_strategy(),
-              gko::matrix::csr::spmv_strategy::automatical);
+              gko::matrix::csr::spmv_strategy::automatic);
     ASSERT_EQ(mtx_classical->get_strategy(),
               gko::matrix::csr::spmv_strategy::classical);
     ASSERT_EQ(mtx_merge_path->get_strategy(),

--- a/core/test/matrix/csr.cpp
+++ b/core/test/matrix/csr.cpp
@@ -42,8 +42,8 @@ protected:
         v[1] = 3.0;
         v[2] = 2.0;
         v[3] = 5.0;
-        // need set strategy after filling the data, but the automatic
-        // strategy has nothing on reference.
+        // When changing the sparsity, we need set strategy to trigger
+        // recomputation on srow.
         mtx->set_strategy(mtx->get_strategy());
     }
 
@@ -160,6 +160,33 @@ TYPED_TEST(Csr, CanBeCreatedFromExistingConstData)
 
 
 GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
+
+TYPED_TEST(Csr, DeprecatedStrategyReturnCorrectEnum)
+{
+    using Mtx = typename TestFixture::Mtx;
+    auto automatical_strategy =
+        std::make_shared<typename Mtx::automatical>(this->exec);
+    auto classical_strategy = std::make_shared<typename Mtx::classical>();
+    auto merge_path_strategy = std::make_shared<typename Mtx::merge_path>();
+    auto load_balance_strategy =
+        std::make_shared<typename Mtx::load_balance>(this->exec);
+    auto sparselib_strategy = std::make_shared<typename Mtx::sparselib>();
+    auto cusparse_strategy = std::make_shared<typename Mtx::cusparse>();
+
+    ASSERT_EQ(automatical_strategy->get_enum(),
+              gko::matrix::csr::spmv_strategy::automatic);
+    ASSERT_EQ(classical_strategy->get_enum(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(merge_path_strategy->get_enum(),
+              gko::matrix::csr::spmv_strategy::merge_path);
+    ASSERT_EQ(load_balance_strategy->get_enum(),
+              gko::matrix::csr::spmv_strategy::load_balance);
+    ASSERT_EQ(sparselib_strategy->get_enum(),
+              gko::matrix::csr::spmv_strategy::sparselib);
+    ASSERT_EQ(cusparse_strategy->get_enum(),
+              gko::matrix::csr::spmv_strategy::sparselib);
+}
 
 
 TYPED_TEST(Csr, CanBeCreatedFromDeprecatedStrategy)

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -52,6 +52,18 @@ TYPED_TEST(CsrBuilder, ReturnsCorrectArrays)
 }
 
 
+TYPED_TEST(CsrBuilder, ReturnsCorrectMaxNnzPerRow)
+{
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
+    this->mtx->read(
+        {{2, 3}, {{0, 0, 1.0}, {0, 1, 3.0}, {0, 2, 2.0}, {1, 1, 5.0}}});
+    gko::matrix::CsrBuilder<value_type, index_type> builder{this->mtx};
+
+    ASSERT_EQ(builder.get_max_nnz_per_row(), 3);
+}
+
+
 TYPED_TEST(CsrBuilder, HelperFunctionOnUniquePtrReturnCorrect)
 {
     auto ref_col_idxs = this->mtx->get_col_idxs();

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -50,3 +50,44 @@ TYPED_TEST(CsrBuilder, ReturnsCorrectArrays)
     ASSERT_EQ(builder_values, ref_values);
     ASSERT_EQ(builder_mtx, this->mtx.get());
 }
+
+
+TYPED_TEST(CsrBuilder, HelperFunctionOnUniquePtrReturnCorrect)
+{
+    auto ref_col_idxs = this->mtx->get_col_idxs();
+    auto ref_values = this->mtx->get_values();
+
+    auto builder = gko::matrix::make_builder_unique_ptr(this->mtx);
+
+    ASSERT_EQ(builder->get_col_idx_array().get_data(), ref_col_idxs);
+    ASSERT_EQ(builder->get_value_array().get_data(), ref_values);
+    ASSERT_EQ(builder->get_matrix(), this->mtx.get());
+}
+
+
+TYPED_TEST(CsrBuilder, HelperFunctionOnSharedPtrReturnCorrect)
+{
+    auto ref_mtx = gko::share(this->mtx->clone());
+    auto ref_col_idxs = ref_mtx->get_col_idxs();
+    auto ref_values = ref_mtx->get_values();
+
+    auto builder = gko::matrix::make_builder_unique_ptr(ref_mtx);
+
+    ASSERT_EQ(builder->get_col_idx_array().get_data(), ref_col_idxs);
+    ASSERT_EQ(builder->get_value_array().get_data(), ref_values);
+    ASSERT_EQ(builder->get_matrix(), ref_mtx.get());
+}
+
+
+TYPED_TEST(CsrBuilder, HelperFunctionOnPlainPtrReturnCorrect)
+{
+    auto ref_col_idxs = this->mtx->get_col_idxs();
+    auto ref_values = this->mtx->get_values();
+    auto ref_mtx = this->mtx.get();
+
+    auto builder = gko::matrix::make_builder_unique_ptr(ref_mtx);
+
+    ASSERT_EQ(builder->get_col_idx_array().get_data(), ref_col_idxs);
+    ASSERT_EQ(builder->get_value_array().get_data(), ref_values);
+    ASSERT_EQ(builder->get_matrix(), ref_mtx);
+}

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -53,42 +53,43 @@ TYPED_TEST(CsrBuilder, ReturnsCorrectArrays)
 }
 
 
-TYPED_TEST(CsrBuilder, UpdatesSrowOnDestruction)
-{
-    using Mtx = typename TestFixture::Mtx;
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
-    struct mock_strategy : public Mtx::strategy_type {
-#if defined(_MSC_VER) && defined(__clang__)
-        // only clang_cl in Windows needs this workaround. detail:
-        // https://github.com/llvm/llvm-project/issues/64996
-        using Mtx = Mtx;
-#endif
-        virtual void process(const gko::array<index_type>&,
-                             gko::array<index_type>*) override
-        {
-            *was_called = true;
-        }
+// TYPED_TEST(CsrBuilder, UpdatesSrowOnDestruction)
+// {
+//     using Mtx = typename TestFixture::Mtx;
+//     using value_type = typename TestFixture::value_type;
+//     using index_type = typename TestFixture::index_type;
+//     struct mock_strategy : public Mtx::strategy_type {
+// #if defined(_MSC_VER) && defined(__clang__)
+//         // only clang_cl in Windows needs this workaround. detail:
+//         // https://github.com/llvm/llvm-project/issues/64996
+//         using Mtx = Mtx;
+// #endif
+//         virtual void process(const gko::array<index_type>&,
+//                              gko::array<index_type>*) override
+//         {
+//             *was_called = true;
+//         }
 
-        virtual int64_t clac_size(const int64_t nnz) override { return 0; }
+//         virtual int64_t clac_size(const int64_t nnz) override { return 0; }
 
-        virtual std::shared_ptr<typename Mtx::strategy_type> copy() override
-        {
-            return std::make_shared<mock_strategy>(*was_called);
-        }
+//         virtual std::shared_ptr<typename Mtx::strategy_type> copy() override
+//         {
+//             return std::make_shared<mock_strategy>(*was_called);
+//         }
 
-        mock_strategy(bool& flag) : Mtx::strategy_type(""), was_called(&flag) {}
+//         mock_strategy(bool& flag) : Mtx::strategy_type(""), was_called(&flag)
+//         {}
 
-        bool* was_called;
-    };
-    bool was_called{};
-    this->mtx->set_strategy(std::make_shared<mock_strategy>(was_called));
-    was_called = false;
+//         bool* was_called;
+//     };
+//     bool was_called{};
+//     this->mtx->set_strategy(std::make_shared<mock_strategy>(was_called));
+//     was_called = false;
 
-    gko::matrix::CsrBuilder<value_type, index_type>{this->mtx};
+//     gko::matrix::CsrBuilder<value_type, index_type>{this->mtx};
 
-    ASSERT_TRUE(was_called);
-}
+//     ASSERT_TRUE(was_called);
+// }
 
 
 }  // namespace

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -11,9 +11,6 @@
 #include "core/test/utils.hpp"
 
 
-namespace {
-
-
 template <typename ValueIndexType>
 class CsrBuilder : public ::testing::Test {
 public:
@@ -51,45 +48,3 @@ TYPED_TEST(CsrBuilder, ReturnsCorrectArrays)
     ASSERT_EQ(builder_col_idxs, ref_col_idxs);
     ASSERT_EQ(builder_values, ref_values);
 }
-
-
-// TYPED_TEST(CsrBuilder, UpdatesSrowOnDestruction)
-// {
-//     using Mtx = typename TestFixture::Mtx;
-//     using value_type = typename TestFixture::value_type;
-//     using index_type = typename TestFixture::index_type;
-//     struct mock_strategy : public Mtx::strategy_type {
-// #if defined(_MSC_VER) && defined(__clang__)
-//         // only clang_cl in Windows needs this workaround. detail:
-//         // https://github.com/llvm/llvm-project/issues/64996
-//         using Mtx = Mtx;
-// #endif
-//         virtual void process(const gko::array<index_type>&,
-//                              gko::array<index_type>*) override
-//         {
-//             *was_called = true;
-//         }
-
-//         virtual int64_t clac_size(const int64_t nnz) override { return 0; }
-
-//         virtual std::shared_ptr<typename Mtx::strategy_type> copy() override
-//         {
-//             return std::make_shared<mock_strategy>(*was_called);
-//         }
-
-//         mock_strategy(bool& flag) : Mtx::strategy_type(""), was_called(&flag)
-//         {}
-
-//         bool* was_called;
-//     };
-//     bool was_called{};
-//     this->mtx->set_strategy(std::make_shared<mock_strategy>(was_called));
-//     was_called = false;
-
-//     gko::matrix::CsrBuilder<value_type, index_type>{this->mtx};
-
-//     ASSERT_TRUE(was_called);
-// }
-
-
-}  // namespace

--- a/core/test/matrix/csr_builder.cpp
+++ b/core/test/matrix/csr_builder.cpp
@@ -44,7 +44,9 @@ TYPED_TEST(CsrBuilder, ReturnsCorrectArrays)
     auto builder_values = builder.get_value_array().get_data();
     auto ref_col_idxs = this->mtx->get_col_idxs();
     auto ref_values = this->mtx->get_values();
+    auto builder_mtx = builder.get_matrix();
 
     ASSERT_EQ(builder_col_idxs, ref_col_idxs);
     ASSERT_EQ(builder_values, ref_values);
+    ASSERT_EQ(builder_mtx, this->mtx.get());
 }

--- a/core/test/matrix/fbcsr_sample.hpp
+++ b/core/test/matrix/fbcsr_sample.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -324,7 +324,7 @@ public:
                            gko::dim<2>{static_cast<size_type>(nrows),
                                        static_cast<size_type>(ncols)},
                            vals, c, r,
-                           std::make_shared<typename Csr::classical>());
+                           gko::matrix::csr::spmv_strategy::classical);
     }
 
     std::unique_ptr<Diagonal> extract_diagonal() const
@@ -476,7 +476,7 @@ public:
                            gko::dim<2>{static_cast<size_type>(nrows),
                                        static_cast<size_type>(ncols)},
                            vals, c, r,
-                           std::make_shared<typename Csr::classical>());
+                           gko::matrix::csr::spmv_strategy::classical);
     }
 };
 

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -91,14 +91,14 @@ protected:
         {
             SCOPED_TRACE("With Csr with strategy");
             using ConcreteCsr = Csr<value_type, local_index_type>;
-            auto strategy = std::make_shared<typename ConcreteCsr::classical>();
+            auto strategy = gko::matrix::csr::spmv_strategy::classical;
             f(gko::with_matrix_type<Csr>(strategy),
               ConcreteCsr::create(this->ref, strategy),
               [](gko::ptr_param<const gko::LinOp> local_mat) {
                   auto local_csr = gko::as<ConcreteCsr>(local_mat);
 
                   ASSERT_EQ(local_csr->get_strategy(),
-                            matrix::csr::spmv_strategy::classical);
+                            gko::matrix::csr::spmv_strategy::classical);
               });
         }
         {

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -97,8 +97,8 @@ protected:
               [](gko::ptr_param<const gko::LinOp> local_mat) {
                   auto local_csr = gko::as<ConcreteCsr>(local_mat);
 
-                  ASSERT_NO_THROW(gko::as<typename ConcreteCsr::classical>(
-                      local_csr->get_strategy()));
+                  ASSERT_EQ(local_csr->get_strategy(),
+                            matrix::csr::spmv_strategy::classical);
               });
         }
         {

--- a/dpcpp/factorization/factorization_kernels.dp.cpp
+++ b/dpcpp/factorization/factorization_kernels.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -412,13 +412,14 @@ void initialize_l(dim3 grid, dim3 block, size_type dynamic_shared_memory,
 
 
 template <typename ValueType, typename IndexType>
-void add_diagonal_elements(std::shared_ptr<const DpcppExecutor> exec,
-                           matrix::Csr<ValueType, IndexType>* mtx,
-                           bool is_sorted)
+void add_diagonal_elements(
+    std::shared_ptr<const DpcppExecutor> exec,
+    matrix::CsrBuilder<ValueType, IndexType>* mtx_builder, bool is_sorted)
 {
     // TODO: Runtime can be optimized by choosing a appropriate size for the
     //       subwarp dependent on the matrix properties
     constexpr int subwarp_size = config::warp_size;
+    auto mtx = mtx_builder->get_matrix();
     auto mtx_size = mtx->get_size();
     auto num_rows = static_cast<IndexType>(mtx_size[0]);
     auto num_cols = static_cast<IndexType>(mtx_size[1]);

--- a/dpcpp/factorization/par_ict_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ict_kernels.dp.cpp
@@ -397,12 +397,12 @@ void add_candidates(syn::value_list<int, subgroup_size>,
                     const matrix::Csr<ValueType, IndexType>* llh,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
-                    matrix::Csr<ValueType, IndexType>* l_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
     auto num_rows = static_cast<IndexType>(llh->get_size()[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
-    matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
+    auto l_new = l_new_builder->get_matrix();
     auto llh_row_ptrs = llh->get_const_row_ptrs();
     auto llh_col_idxs = llh->get_const_col_idxs();
     auto llh_vals = as_device_type(llh->get_const_values());
@@ -423,8 +423,8 @@ void add_candidates(syn::value_list<int, subgroup_size>,
 
     // resize output arrays
     auto l_new_nnz = exec->copy_val_to_host(l_new_row_ptrs + num_rows);
-    l_new_builder.get_col_idx_array().resize_and_reset(l_new_nnz);
-    l_new_builder.get_value_array().resize_and_reset(l_new_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_new_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_new_nnz);
 
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = as_device_type(l_new->get_values());
@@ -472,7 +472,7 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* llh,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
-                    matrix::Csr<ValueType, IndexType>* l_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz =
@@ -484,7 +484,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
             return total_nnz_per_row <= compiled_subgroup_size ||
                    compiled_subgroup_size == config::warp_size;
         },
-        syn::value_list<int>(), syn::type_list<>(), exec, llh, a, l, l_new);
+        syn::value_list<int>(), syn::type_list<>(), exec, llh, a, l,
+        l_new_builder);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_filter_kernel.dp.cpp
@@ -54,7 +54,7 @@ void threshold_filter(syn::value_list<int, subgroup_size>,
                       std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto old_row_ptrs = a->get_const_row_ptrs();
@@ -64,6 +64,7 @@ void threshold_filter(syn::value_list<int, subgroup_size>,
     auto num_rows = static_cast<IndexType>(a->get_size()[0]);
     auto block_size = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, block_size);
+    auto m_out = m_out_builder->get_matrix();
     auto new_row_ptrs = m_out->get_row_ptrs();
     kernel::threshold_filter_nnz<subgroup_size>(
         num_blocks, default_block_size, 0, exec->get_queue(), old_row_ptrs,
@@ -75,9 +76,8 @@ void threshold_filter(syn::value_list<int, subgroup_size>,
     // build matrix
     auto new_nnz = exec->copy_val_to_host(new_row_ptrs + num_rows);
     // resize arrays and update aliases
-    matrix::CsrBuilder<ValueType, IndexType> builder{m_out};
-    builder.get_col_idx_array().resize_and_reset(new_nnz);
-    builder.get_value_array().resize_and_reset(new_nnz);
+    m_out_builder->get_col_idx_array().resize_and_reset(new_nnz);
+    m_out_builder->get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
     IndexType* new_row_idxs{};
@@ -107,7 +107,7 @@ template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* a,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool lower)
 {
     auto num_rows = a->get_size()[0];
@@ -119,8 +119,8 @@ void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
             return total_nnz_per_row <= compiled_subgroup_size ||
                    compiled_subgroup_size == config::warp_size;
         },
-        syn::value_list<int>(), syn::type_list<>(), exec, a, threshold, m_out,
-        m_out_coo, lower);
+        syn::value_list<int>(), syn::type_list<>(), exec, a, threshold,
+        m_out_builder, m_out_coo, lower);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/factorization/par_ilut_kernels.dp.cpp
+++ b/dpcpp/factorization/par_ilut_kernels.dp.cpp
@@ -53,7 +53,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
-                     matrix::Csr<ValueType, IndexType>* m_out,
+                     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred) GKO_NOT_IMPLEMENTED;
 
@@ -62,7 +62,7 @@ template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo,
                       bool) GKO_NOT_IMPLEMENTED;
 
@@ -106,8 +106,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
                     const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
+                    matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
     GKO_NOT_IMPLEMENTED;
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
+++ b/dpcpp/factorization/par_ilut_spgeam_kernel.dp.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -349,14 +349,14 @@ void add_candidates(syn::value_list<int, subgroup_size>,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
                     const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
+                    matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
     auto num_rows = static_cast<IndexType>(lu->get_size()[0]);
     auto subwarps_per_block = default_block_size / subgroup_size;
     auto num_blocks = ceildiv(num_rows, subwarps_per_block);
-    matrix::CsrBuilder<ValueType, IndexType> l_new_builder(l_new);
-    matrix::CsrBuilder<ValueType, IndexType> u_new_builder(u_new);
+    auto l_new = l_new->get_matrix();
+    auto u_new = u_new->get_matrix();
     auto lu_row_ptrs = lu->get_const_row_ptrs();
     auto lu_col_idxs = lu->get_const_col_idxs();
     auto lu_vals = as_device_type(lu->get_const_values());
@@ -384,10 +384,10 @@ void add_candidates(syn::value_list<int, subgroup_size>,
     // resize output arrays
     auto l_new_nnz = exec->copy_val_to_host(l_new_row_ptrs + num_rows);
     auto u_new_nnz = exec->copy_val_to_host(u_new_row_ptrs + num_rows);
-    l_new_builder.get_col_idx_array().resize_and_reset(l_new_nnz);
-    l_new_builder.get_value_array().resize_and_reset(l_new_nnz);
-    u_new_builder.get_col_idx_array().resize_and_reset(u_new_nnz);
-    u_new_builder.get_value_array().resize_and_reset(u_new_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_new_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_new_nnz);
+    u_new_builder->get_col_idx_array().resize_and_reset(u_new_nnz);
+    u_new_builder->get_value_array().resize_and_reset(u_new_nnz);
 
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = as_device_type(l_new->get_values());
@@ -416,8 +416,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
                     const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
+                    matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto total_nnz =
@@ -429,8 +429,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
             return total_nnz_per_row <= compiled_subgroup_size ||
                    compiled_subgroup_size == config::warp_size;
         },
-        syn::value_list<int>(), syn::type_list<>(), exec, lu, a, l, u, l_new,
-        u_new);
+        syn::value_list<int>(), syn::type_list<>(), exec, lu, a, l, u,
+        l_new_builder, u_new_builder);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1956,7 +1956,7 @@ template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const DpcppExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto num_rows = a->get_size()[0];
     const auto a_row_ptrs = a->get_const_row_ptrs();
@@ -1965,6 +1965,7 @@ void spgemm(std::shared_ptr<const DpcppExecutor> exec,
     const auto b_row_ptrs = b->get_const_row_ptrs();
     const auto b_cols = b->get_const_col_idxs();
     const auto b_vals = as_device_type(b->get_const_values());
+    auto c = c_builder->get_matrix();
     auto c_row_ptrs = c->get_row_ptrs();
     auto queue = exec->get_queue();
 
@@ -1993,9 +1994,8 @@ void spgemm(std::shared_ptr<const DpcppExecutor> exec,
 
     // second sweep: accumulate non-zeros
     const auto new_nnz = exec->copy_val_to_host(c_row_ptrs + num_rows);
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_col_idxs = c_col_idxs_array.get_data();
@@ -2036,8 +2036,9 @@ void advanced_spgemm(std::shared_ptr<const DpcppExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* b,
                      matrix::view::dense<const ValueType> beta,
                      const matrix::Csr<ValueType, IndexType>* d,
-                     matrix::Csr<ValueType, IndexType>* c)
+                     matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
+    auto c = c_builder->get_matrix();
     auto num_rows = a->get_size()[0];
     const auto a_row_ptrs = a->get_const_row_ptrs();
     const auto a_cols = a->get_const_col_idxs();
@@ -2093,9 +2094,8 @@ void advanced_spgemm(std::shared_ptr<const DpcppExecutor> exec,
 
     // second sweep: accumulate non-zeros
     const auto new_nnz = exec->copy_val_to_host(c_row_ptrs + num_rows);
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
 
@@ -2321,7 +2321,7 @@ void spgeam(std::shared_ptr<const DpcppExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             matrix::view::dense<const ValueType> beta,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
     const auto num_rows = a->get_size()[0];
@@ -2329,6 +2329,7 @@ void spgeam(std::shared_ptr<const DpcppExecutor> exec,
     const auto a_cols = a->get_const_col_idxs();
     const auto b_row_ptrs = b->get_const_row_ptrs();
     const auto b_cols = b->get_const_col_idxs();
+    auto c = c_builder->get_matrix();
     auto c_row_ptrs = c->get_row_ptrs();
     auto queue = exec->get_queue();
 
@@ -2356,9 +2357,8 @@ void spgeam(std::shared_ptr<const DpcppExecutor> exec,
 
     // second sweep: accumulate non-zeros
     const auto new_nnz = exec->copy_val_to_host(c_row_ptrs + num_rows);
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_cols = c_col_idxs_array.get_data();

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1526,6 +1526,8 @@ bool try_sparselib_spmv(
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const DpcppExecutor> exec,
+          const matrix::csr::spmv_strategy strategy,
+          const IndexType max_nnz_per_row,
           const matrix::Csr<MatrixValueType, IndexType>* a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
@@ -1539,7 +1541,7 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
         dense::fill(exec, c, zero<OutputValueType>());
         return;
     }
-    if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
+    if (strategy == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -1553,33 +1555,16 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
             syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
     } else {
         bool use_classical = true;
-        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
+        if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
-        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
+        } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
-            IndexType max_length_per_row = 0;
-            using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else if (a->get_strategy() ==
-                       matrix::csr::spmv_strategy::automatical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else {
-                // as a fall-back: use average row length, at least 1
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            }
-            max_length_per_row = std::max<size_type>(max_length_per_row, 1);
             host_kernel::select_classical_spmv(
                 classical_kernels(),
-                [&max_length_per_row](int compiled_info) {
-                    return max_length_per_row >= compiled_info;
+                [&max_nnz_per_row](int compiled_info) {
+                    return max_nnz_per_row >= compiled_info;
                 },
                 syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
         }
@@ -1593,6 +1578,8 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
+                   const matrix::csr::spmv_strategy strategy,
+                   const IndexType max_nnz_per_row,
                    matrix::view::dense<const MatrixValueType> alpha,
                    const matrix::Csr<MatrixValueType, IndexType>* a,
                    matrix::view::dense<const InputValueType> b,
@@ -1608,7 +1595,7 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
         dense::scale(exec, beta, c);
         return;
     }
-    if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
+    if (strategy == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -1623,35 +1610,18 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
             beta);
     } else {
         bool use_classical = true;
-        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
+        if (strategy == matrix::csr::spmv_strategy::load_balance) {
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
-        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
+        } else if (strategy == matrix::csr::spmv_strategy::sparselib) {
             use_classical =
                 !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
-            IndexType max_length_per_row = 0;
-            using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else if (a->get_strategy() ==
-                       matrix::csr::spmv_strategy::automatical) {
-                // max_length_per_row = strategy->get_max_length_per_row();
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            } else {
-                // as a fall-back: use average row length, at least 1
-                max_length_per_row = a->get_num_stored_elements() /
-                                     std::max<size_type>(a->get_size()[0], 1);
-            }
-            max_length_per_row = std::max<size_type>(max_length_per_row, 1);
             host_kernel::select_classical_spmv(
                 classical_kernels(),
-                [&max_length_per_row](int compiled_info) {
-                    return max_length_per_row >= compiled_info;
+                [&max_nnz_per_row](int compiled_info) {
+                    return max_nnz_per_row >= compiled_info;
                 },
                 syn::value_list<int>(), syn::type_list<>(), exec, a, b, c,
                 alpha, beta);

--- a/dpcpp/matrix/csr_kernels.dp.cpp
+++ b/dpcpp/matrix/csr_kernels.dp.cpp
@@ -1539,7 +1539,7 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
         dense::fill(exec, c, zero<OutputValueType>());
         return;
     }
-    if (a->get_strategy()->get_name() == "merge_path") {
+    if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -1553,23 +1553,23 @@ void spmv(std::shared_ptr<const DpcppExecutor> exec,
             syn::value_list<int>(), syn::type_list<>(), exec, a, b, c);
     } else {
         bool use_classical = true;
-        if (a->get_strategy()->get_name() == "load_balance") {
+        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
             use_classical = !host_kernel::load_balance_spmv(exec, a, b, c);
-        } else if (a->get_strategy()->get_name() == "sparselib" ||
-                   a->get_strategy()->get_name() == "cusparse") {
+        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
             use_classical = !host_kernel::try_sparselib_spmv(exec, a, b, c);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
             using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (auto strategy =
-                    std::dynamic_pointer_cast<const typename Tcsr::classical>(
-                        a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
-            } else if (auto strategy = std::dynamic_pointer_cast<
-                           const typename Tcsr::automatical>(
-                           a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
+            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
+            } else if (a->get_strategy() ==
+                       matrix::csr::spmv_strategy::automatical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
             } else {
                 // as a fall-back: use average row length, at least 1
                 max_length_per_row = a->get_num_stored_elements() /
@@ -1608,7 +1608,7 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
         dense::scale(exec, beta, c);
         return;
     }
-    if (a->get_strategy()->get_name() == "merge_path") {
+    if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
         using arithmetic_type =
             highest_precision<InputValueType, OutputValueType, MatrixValueType>;
         int items_per_thread =
@@ -1623,25 +1623,25 @@ void advanced_spmv(std::shared_ptr<const DpcppExecutor> exec,
             beta);
     } else {
         bool use_classical = true;
-        if (a->get_strategy()->get_name() == "load_balance") {
+        if (a->get_strategy() == matrix::csr::spmv_strategy::load_balance) {
             use_classical =
                 !host_kernel::load_balance_spmv(exec, a, b, c, alpha, beta);
-        } else if (a->get_strategy()->get_name() == "sparselib" ||
-                   a->get_strategy()->get_name() == "cusparse") {
+        } else if (a->get_strategy() == matrix::csr::spmv_strategy::sparselib) {
             use_classical =
                 !host_kernel::try_sparselib_spmv(exec, a, b, c, alpha, beta);
         }
         if (use_classical) {
             IndexType max_length_per_row = 0;
             using Tcsr = matrix::Csr<MatrixValueType, IndexType>;
-            if (auto strategy =
-                    std::dynamic_pointer_cast<const typename Tcsr::classical>(
-                        a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
-            } else if (auto strategy = std::dynamic_pointer_cast<
-                           const typename Tcsr::automatical>(
-                           a->get_strategy())) {
-                max_length_per_row = strategy->get_max_length_per_row();
+            if (a->get_strategy() == matrix::csr::spmv_strategy::classical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
+            } else if (a->get_strategy() ==
+                       matrix::csr::spmv_strategy::automatical) {
+                // max_length_per_row = strategy->get_max_length_per_row();
+                max_length_per_row = a->get_num_stored_elements() /
+                                     std::max<size_type>(a->get_size()[0], 1);
             } else {
                 // as a fall-back: use average row length, at least 1
                 max_length_per_row = a->get_num_stored_elements() /

--- a/include/ginkgo/core/base/types.hpp
+++ b/include/ginkgo/core/base/types.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -59,6 +59,17 @@
 
 
 // Handle deprecated notices correctly on different systems
+/**
+ * It helps the clang-format formatting properly
+ * example: deprecated class with a function having return will lead weird
+ * formatting
+ * ```c++
+ * class [[deprecated("T")]] B {
+ *   public:
+ *    int get() const { return 1; }
+ *   };
+ * ```
+ */
 // clang-format off
 #define GKO_DEPRECATED(_msg) [[deprecated(_msg)]]
 #ifdef __NVCOMPILER

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -81,8 +81,8 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            l_strategy, matrix::csr::spmv_strategy::classical);
 
         /**
          * The `system_matrix`, which will be given to this factory, must be
@@ -139,10 +139,6 @@ protected:
         : Composition<ValueType>{factory->get_executor()},
           parameters_{factory->get_parameters()}
     {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
         auto comp = generate(system_matrix, parameters_.skip_sorting,
                              parameters_.both_factors);
         for (auto& op : comp->get_operators()) {

--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -81,8 +81,30 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            l_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_l_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->l_strategy = value->get_enum();
+            } else {
+                this->l_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the L matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_l_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->l_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy l_strategy{
+            matrix::csr::spmv_strategy::classical};
 
         /**
          * The `system_matrix`, which will be given to this factory, must be

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -76,15 +76,59 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            l_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_l_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->l_strategy = value->get_enum();
+            } else {
+                this->l_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the L matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_l_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->l_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy l_strategy{
+            matrix::csr::spmv_strategy::classical};
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            u_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_u_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->u_strategy = value->get_enum();
+            } else {
+                this->u_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the U matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_u_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->u_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy u_strategy{
+            matrix::csr::spmv_strategy::classical};
 
         /**
          * The `system_matrix`, which will be given to this factory, must be

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -76,15 +76,15 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            l_strategy, matrix::csr::spmv_strategy::classical);
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(u_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            u_strategy, matrix::csr::spmv_strategy::classical);
 
         /**
          * The `system_matrix`, which will be given to this factory, must be
@@ -134,14 +134,6 @@ protected:
         : Composition<ValueType>{factory->get_executor()},
           parameters_{factory->get_parameters()}
     {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.u_strategy == nullptr) {
-            parameters_.u_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
         auto comp = generate_l_u(system_matrix, parameters_.skip_sorting);
         for (auto& op : comp->get_operators()) {
             this->add_operators(op);

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -125,8 +125,30 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            l_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_l_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->l_strategy = value->get_enum();
+            } else {
+                this->l_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the L matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_l_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->l_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy l_strategy{
+            matrix::csr::spmv_strategy::classical};
 
         /**
          * `true` will generate both L and L^H, `false` will only generate the L

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -125,8 +125,8 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            l_strategy, matrix::csr::spmv_strategy::classical);
 
         /**
          * `true` will generate both L and L^H, `false` will only generate the L
@@ -162,10 +162,6 @@ protected:
         : Composition<ValueType>(factory->get_executor()),
           parameters_{factory->get_parameters()}
     {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
         auto comp = generate(system_matrix, parameters_.skip_sorting,
                              parameters_.both_factors);
         for (auto& op : comp->get_operators()) {

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -174,15 +174,15 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            l_strategy, matrix::csr::spmv_strategy::classical);
 
         /**
          * Strategy which will be used by the L^T matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(lt_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            lt_strategy, matrix::csr::spmv_strategy::classical);
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIct, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);
@@ -211,14 +211,6 @@ protected:
         : Composition<ValueType>(factory->get_executor()),
           parameters_{factory->get_parameters()}
     {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.lt_strategy == nullptr) {
-            parameters_.lt_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
         auto comp = generate_l_lt(std::move(system_matrix));
         for (auto& op : comp->get_operators()) {
             this->add_operators(op);

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -174,8 +174,30 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            l_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_l_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->l_strategy = value->get_enum();
+            } else {
+                this->l_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the L matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_l_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->l_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy l_strategy{
+            matrix::csr::spmv_strategy::classical};
 
         /**
          * Strategy which will be used by the L^T matrix. The default value

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -123,15 +123,15 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            l_strategy, matrix::csr::spmv_strategy::classical);
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(u_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            u_strategy, matrix::csr::spmv_strategy::classical);
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIlu, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);
@@ -160,14 +160,6 @@ protected:
         : Composition<ValueType>(factory->get_executor()),
           parameters_{factory->get_parameters()}
     {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.u_strategy == nullptr) {
-            parameters_.u_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
         auto comp =
             generate_l_u(system_matrix, parameters_.skip_sorting,
                          parameters_.l_strategy, parameters_.u_strategy);
@@ -195,8 +187,8 @@ protected:
      */
     std::unique_ptr<Composition<ValueType>> generate_l_u(
         const std::shared_ptr<const LinOp>& system_matrix, bool skip_sorting,
-        std::shared_ptr<typename matrix_type::strategy_type> l_strategy,
-        std::shared_ptr<typename matrix_type::strategy_type> u_strategy) const;
+        matrix::csr::spmv_strategy l_strategy,
+        matrix::csr::spmv_strategy u_strategy) const;
 };
 
 

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -123,15 +123,59 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            l_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_l_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->l_strategy = value->get_enum();
+            } else {
+                this->l_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the L matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_l_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->l_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy l_strategy{
+            matrix::csr::spmv_strategy::classical};
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            u_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_u_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->u_strategy = value->get_enum();
+            } else {
+                this->u_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the U matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_u_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->u_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy u_strategy{
+            matrix::csr::spmv_strategy::classical};
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIlu, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -180,15 +180,59 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            l_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_l_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->l_strategy = value->get_enum();
+            } else {
+                this->l_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the L matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_l_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->l_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy l_strategy{
+            matrix::csr::spmv_strategy::classical};
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
-            u_strategy, matrix::csr::spmv_strategy::classical);
+        GKO_DEPRECATED("use matrix::csr::spmv_strategy instead")
+        parameters_type& with_u_strategy(
+            std::shared_ptr<typename matrix_type::strategy_type> value)
+        {
+            if (value) {
+                this->u_strategy = value->get_enum();
+            } else {
+                this->u_strategy = matrix::csr::spmv_strategy::classical;
+            }
+            return *this;
+        }
+
+        /**
+         * Strategy which will be used by the U matrix. The default value is
+         * `classical`.
+         */
+        parameters_type& with_u_strategy(matrix::csr::spmv_strategy value)
+        {
+            this->u_strategy = value;
+            return *this;
+        }
+
+        matrix::csr::spmv_strategy u_strategy{
+            matrix::csr::spmv_strategy::classical};
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIlut, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -180,15 +180,15 @@ public:
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(l_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            l_strategy, matrix::csr::spmv_strategy::classical);
 
         /**
          * Strategy which will be used by the U matrix. The default value
          * `nullptr` will result in the strategy `classical`.
          */
-        std::shared_ptr<typename matrix_type::strategy_type>
-            GKO_FACTORY_PARAMETER_SCALAR(u_strategy, nullptr);
+        matrix::csr::spmv_strategy GKO_FACTORY_PARAMETER_SCALAR(
+            u_strategy, matrix::csr::spmv_strategy::classical);
     };
     GKO_ENABLE_LIN_OP_FACTORY(ParIlut, parameters, Factory);
     GKO_ENABLE_BUILD_METHOD(Factory);
@@ -217,14 +217,6 @@ protected:
         : Composition<ValueType>(factory->get_executor()),
           parameters_{factory->get_parameters()}
     {
-        if (parameters_.l_strategy == nullptr) {
-            parameters_.l_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
-        if (parameters_.u_strategy == nullptr) {
-            parameters_.u_strategy =
-                std::make_shared<typename matrix_type::classical>();
-        }
         auto comp = generate_l_u(std::move(system_matrix));
         for (auto& op : comp->get_operators()) {
             this->add_operators(op);

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -796,15 +796,6 @@ public:
     csr::spmv_strategy get_strategy() const noexcept;
 
     /**
-     * Returns the actual strategy. When the strategy is automatical, this
-     * returns the actual underlying strategy. This returns the same strategy as
-     * `get_strategy` when the strategy is not automatical.
-     *
-     * @return the acutal strategy
-     */
-    csr::spmv_strategy get_actual_strategy() const noexcept;
-
-    /**
      * Set the strategy
      *
      * @param strategy the csr strategy
@@ -1003,6 +994,14 @@ protected:
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
+    /**
+     * Returns the actual strategy. When the strategy is automatical, this
+     * returns the actual underlying strategy. This returns the same strategy as
+     * `get_strategy` when the strategy is not automatical.
+     *
+     * @return the acutal strategy
+     */
+    csr::spmv_strategy get_actual_strategy() const noexcept;
 
     /**
      * Computes srow. It should be run after changing any row_ptrs_ value.

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -69,14 +69,14 @@ enum class spmv_strategy {
      * load_balance is the strategy trying to distribute the work equally in
      * terms of the number of matrix entries. More detail can be checked in
      * Goran and Enrique: Balanced CSR sparse matrix-vector product on graphics
-     * processors.
+     * processors (doi: 10.1007/978-3-319-64203-1_50).
      */
     load_balance,
     /**
      * merge_path is the strategy trying to distribute the work equally in terms
      * of the number of matrix entries and row pointers. More detail can be
      * checked in Merrill and Garland: Merge-Based Parallel Sparse Matrix-Vector
-     * Multiplication.
+     * Multiplication (doi: 10.1109/SC.2016.57).
      */
     merge_path,
     /**
@@ -87,36 +87,16 @@ enum class spmv_strategy {
     /**
      * sparselib is the strategy calling the backend sparse library
      * implementation when it is supported.
+     *
+     * - reference/omp: ginkgo's classical spmv
+     * - cuda: cuSPARSE
+     * - hip: hipSPARSE
+     * - dpcpp: oneMKL
      */
     sparselib
 };
 
 
-namespace detail {
-
-
-/**
- * Returns the actual strategy passed. When the strategy is automatical, this
- * returns the actual underlying strategy. This returns the same strategy as
- * the input when the input is not automatical.
- *
- * @param exec  Executor associated to the matrix
- * @param strategy  the strategy of CSR
- * @param num_stored_elements  the number of stored elements
- * @param max_nnz_per_row  the maximum number of stored elements per row
- *
- * @return the acutal strategy
- *
- * @note Users should not use this function. This is only make the function
- * public for test
- */
-spmv_strategy get_actual_strategy(std::shared_ptr<const Executor> exec,
-                                  spmv_strategy strategy,
-                                  size_type num_stored_elements,
-                                  size_type max_nnz_per_row);
-
-
-}  // namespace detail
 }  // namespace csr
 
 
@@ -1009,7 +989,7 @@ public:
      * @param col_idxs  the column index array of the matrix
      * @param row_ptrs  the row pointer array of the matrix
      * @param strategy  the strategy the matrix uses for SpMV operations,
-     * default is automatical.
+     *                  default is automatical.
      * @returns A smart pointer to the constant matrix wrapping the input arrays
      *          (if they reside on the same executor as the matrix) or a copy of
      *          these arrays on the correct executor.
@@ -1153,7 +1133,7 @@ protected:
      * returns the actual underlying strategy. This returns the same strategy as
      * `get_strategy` when the strategy is not automatical.
      *
-     * @return the acutal strategy
+     * @return the actual strategy
      */
     csr::spmv_strategy get_actual_strategy() const noexcept;
 

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -60,11 +60,11 @@ namespace csr {
  */
 enum class spmv_strategy {
     /**
-     * automatical is the strategy choosing between load_balance and classical
+     * automatic is the strategy choosing between load_balance and classical
      * based on the maximum number of entries per row and the number of entries
      * of the matrix.
      */
-    automatical,
+    automatic,
     /**
      * load_balance is the strategy trying to distribute the work equally in
      * terms of the number of matrix entries. More detail can be checked in
@@ -241,7 +241,7 @@ public:
 
     class [[deprecated(
         "please use enum "
-        "gko::matrix::csr::spmv_strategy::automatical")]] automatical
+        "gko::matrix::csr::spmv_strategy::automatic")]] automatical
         : public strategy_type{
             public : automatical(std::shared_ptr<const Executor>){}
         };
@@ -925,14 +925,14 @@ public:
      * @param size  size of the matrix
      * @param num_nonzeros  number of nonzeros
      * @param strategy  the strategy the matrix uses for SpMV operations,
-     * default is automatical.
+     *                  default is automatic.
      *
      * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Csr> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size = {},
         size_type num_nonzeros = {},
-        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatic);
 
     /**
      * Creates a CSR matrix from already allocated (and initialized) row
@@ -944,7 +944,7 @@ public:
      * @param col_idxs  array of column indexes
      * @param row_ptrs  array of row pointers
      * @param strategy  the strategy the matrix uses for SpMV operations,
-     * default is automatical.
+     *                  default is automatic.
      *
      * @note If one of `row_ptrs`, `col_idxs` or `values` is not an rvalue, not
      *       an array of IndexType, IndexType and ValueType, respectively, or
@@ -958,7 +958,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         array<value_type> values, array<index_type> col_idxs,
         array<index_type> row_ptrs,
-        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatic);
 
     /**
      * @copydoc std::unique_ptr<Csr> create(std::shared_ptr<const Executor>,
@@ -989,7 +989,7 @@ public:
      * @param col_idxs  the column index array of the matrix
      * @param row_ptrs  the row pointer array of the matrix
      * @param strategy  the strategy the matrix uses for SpMV operations,
-     *                  default is automatical.
+     *                  default is automatic.
      * @returns A smart pointer to the constant matrix wrapping the input arrays
      *          (if they reside on the same executor as the matrix) or a copy of
      *          these arrays on the correct executor.
@@ -1001,7 +1001,7 @@ public:
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
         gko::detail::const_array_view<IndexType>&& row_ptrs,
-        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatic);
 
     GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
@@ -1095,12 +1095,12 @@ public:
 protected:
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
         size_type num_nonzeros = {},
-        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatic);
 
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size,
         array<value_type> values, array<index_type> col_idxs,
         array<index_type> row_ptrs,
-        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatic);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
@@ -1129,9 +1129,9 @@ protected:
     virtual void inv_scale_impl(const LinOp* alpha);
 
     /**
-     * Returns the actual strategy. When the strategy is automatical, this
+     * Returns the actual strategy. When the strategy is automatic, this
      * returns the actual underlying strategy. This returns the same strategy as
-     * `get_strategy` when the strategy is not automatical.
+     * `get_strategy` when the strategy is not automatic.
      *
      * @return the actual strategy
      */

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -968,6 +968,7 @@ public:
         csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
 
     GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
     /**
      * @copydoc std::unique_ptr<Csr> create(std::shared_ptr<const Executor>,
      * csr::spmv_strategy)
@@ -998,6 +999,7 @@ public:
                  gko::detail::const_array_view<IndexType>&& col_idxs,
                  gko::detail::const_array_view<IndexType>&& row_ptrs,
                  std::shared_ptr<strategy_type> strategy);
+
     GKO_END_DISABLE_DEPRECATION_WARNINGS
 
     /**

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -52,14 +52,63 @@ template <typename IndexType>
 class Permutation;
 
 
-namespace detail {
+namespace csr {
 
 
-template <typename ValueType = default_precision, typename IndexType = int32>
-void strategy_rebuild_helper(Csr<ValueType, IndexType>* result);
+enum class spmv_strategy {
+    automatical,
+    load_balance,
+    merge_path,
+    classical,
+    sparselib
+};
 
 
-}  // namespace detail
+}
+
+// after store the max_nnz_per_row in the csr. this should be able to
+// calculate in runtime if the number of stored elements is larger than
+// <nnz_limit> or the maximum number of stored elements per row is larger
+// than <row_len_limit>, use load_balance otherwise use classical
+inline auto auto_select(std::shared_ptr<const Executor> exec,
+                        int64_t max_nnz_per_row)
+{
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 1024 on NVIDIA hardware */
+    const int64_t nvidia_row_len_limit = 1024;
+    /* Use imbalance strategy when the matrix has more more than 1e6 on
+     * NVIDIA hardware */
+    const int64_t nvidia_nnz_limit{static_cast<int64_t>(1e6)};
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 768 on AMD hardware */
+    const int64_t amd_row_len_limit = 768;
+    /* Use imbalance strategy when the matrix has more more than 1e8 on
+     * AMD hardware */
+    const int64_t amd_nnz_limit{static_cast<int64_t>(1e8)};
+    /* Use imbalance strategy when the maximum number of nonzero per row
+     * is more than 25600 on Intel hardware */
+    const int64_t intel_row_len_limit = 25600;
+    /* Use imbalance strategy when the matrix has more more than 3e8 on
+     * Intel hardware */
+    const int64_t intel_nnz_limit{static_cast<int64_t>(3e8)};
+    auto nnz_limit = nvidia_nnz_limit;
+    auto row_len_limit = nvidia_row_len_limit;
+    if (std::dynamic_pointer_cast<const DpcppExecutor>(exec)) {
+        nnz_limit = intel_nnz_limit;
+        row_len_limit = intel_row_len_limit;
+    } else if (std::dynamic_pointer_cast<const HipExecutor>(exec)) {
+        nnz_limit = amd_nnz_limit;
+        row_len_limit = amd_row_len_limit;
+    }
+    nnz_limit += row_len_limit;
+    return csr::spmv_strategy::load_balance;
+    // if (this->get_num_stored_elements() > nnz_limit ||
+    //     max_nnz_per_row > row_len_limit) {
+    //     return csr::spmv_strategy::load_balance;
+    // } else {
+    //     return csr::spmv_strategy::classical;
+    // }
+}
 
 
 /**
@@ -166,538 +215,6 @@ public:
     using device_mat_data = device_matrix_data<ValueType, IndexType>;
     using absolute_type = remove_complex<Csr>;
 
-    class automatical;
-
-    /**
-     * strategy_type is to decide how to set the csr algorithm.
-     *
-     * The practical strategy method should inherit strategy_type and implement
-     * its `process`, `clac_size` function and the corresponding device kernel.
-     */
-    class strategy_type {
-        friend class automatical;
-
-    public:
-        /**
-         * Creates a strategy_type.
-         *
-         * @param name  the name of strategy
-         */
-        strategy_type(std::string name) : name_(name) {}
-
-        virtual ~strategy_type() = default;
-
-        /**
-         * Returns the name of strategy
-         *
-         * @return the name of strategy
-         */
-        std::string get_name() { return name_; }
-
-        /**
-         * Computes srow according to row pointers.
-         *
-         * @param mtx_row_ptrs  the row pointers of the matrix
-         * @param mtx_srow  the srow of the matrix
-         */
-        virtual void process(const array<index_type>& mtx_row_ptrs,
-                             array<index_type>* mtx_srow) = 0;
-
-        /**
-         * Computes the srow size according to the number of nonzeros.
-         *
-         * @param nnz  the number of nonzeros
-         *
-         * @return the size of srow
-         */
-        virtual int64_t clac_size(const int64_t nnz) = 0;
-
-        /**
-         * Copy a strategy. This is a workaround until strategies are revamped,
-         * since strategies like `automatical` do not work when actually shared.
-         */
-        virtual std::shared_ptr<strategy_type> copy() = 0;
-
-    protected:
-        void set_name(std::string name) { name_ = name; }
-
-    private:
-        std::string name_;
-    };
-
-    /**
-     * classical is a strategy_type which uses the same number of threads on
-     * each row. Classical strategy uses multithreads to calculate on parts of
-     * rows and then do a reduction of these threads results. The number of
-     * threads per row depends on the max number of stored elements per row.
-     */
-    class classical : public strategy_type {
-    public:
-        /**
-         * Creates a classical strategy.
-         */
-        classical() : strategy_type("classical"), max_length_per_row_(0) {}
-
-        void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {
-            auto host_mtx_exec = mtx_row_ptrs.get_executor()->get_master();
-            array<index_type> row_ptrs_host(host_mtx_exec);
-            const bool is_mtx_on_host{host_mtx_exec ==
-                                      mtx_row_ptrs.get_executor()};
-            const index_type* row_ptrs{};
-            if (is_mtx_on_host) {
-                row_ptrs = mtx_row_ptrs.get_const_data();
-            } else {
-                row_ptrs_host = mtx_row_ptrs;
-                row_ptrs = row_ptrs_host.get_const_data();
-            }
-            auto num_rows = mtx_row_ptrs.get_size() - 1;
-            max_length_per_row_ = 0;
-            for (size_type i = 0; i < num_rows; i++) {
-                max_length_per_row_ = std::max(max_length_per_row_,
-                                               row_ptrs[i + 1] - row_ptrs[i]);
-            }
-        }
-
-        int64_t clac_size(const int64_t nnz) override { return 0; }
-
-        index_type get_max_length_per_row() const noexcept
-        {
-            return max_length_per_row_;
-        }
-
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<classical>();
-        }
-
-    private:
-        index_type max_length_per_row_;
-    };
-
-    /**
-     * merge_path is a strategy_type which uses the merge_path algorithm.
-     * merge_path is according to Merrill and Garland: Merge-Based Parallel
-     * Sparse Matrix-Vector Multiplication
-     */
-    class merge_path : public strategy_type {
-    public:
-        /**
-         * Creates a merge_path strategy.
-         */
-        merge_path() : strategy_type("merge_path") {}
-
-        void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {}
-
-        int64_t clac_size(const int64_t nnz) override { return 0; }
-
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<merge_path>();
-        }
-    };
-
-    /**
-     * cusparse is a strategy_type which uses the sparselib csr.
-     *
-     * @note cusparse is also known to the hip executor which converts between
-     *       cuda and hip.
-     */
-    class cusparse : public strategy_type {
-    public:
-        /**
-         * Creates a cusparse strategy.
-         */
-        cusparse() : strategy_type("cusparse") {}
-
-        void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {}
-
-        int64_t clac_size(const int64_t nnz) override { return 0; }
-
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<cusparse>();
-        }
-    };
-
-    /**
-     * sparselib is a strategy_type which uses the sparselib csr.
-     *
-     * @note Uses cusparse in cuda and hipsparse in hip.
-     */
-    class sparselib : public strategy_type {
-    public:
-        /**
-         * Creates a sparselib strategy.
-         */
-        sparselib() : strategy_type("sparselib") {}
-
-        void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {}
-
-        int64_t clac_size(const int64_t nnz) override { return 0; }
-
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<sparselib>();
-        }
-    };
-
-    /**
-     * load_balance is a strategy_type which uses the load balance algorithm.
-     */
-    class load_balance : public strategy_type {
-    public:
-        /**
-         * Creates a load_balance strategy.
-         *
-         * @warning this is deprecated! Please rely on the new automatic
-         *          strategy instantiation or use one of the other constructors.
-         */
-        [[deprecated]] load_balance()
-            : load_balance(std::move(
-                  gko::CudaExecutor::create(0, gko::OmpExecutor::create())))
-        {}
-
-        /**
-         * Creates a load_balance strategy with CUDA executor.
-         *
-         * @param exec the CUDA executor
-         */
-        load_balance(std::shared_ptr<const CudaExecutor> exec)
-            : load_balance(exec->get_num_warps(), exec->get_warp_size())
-        {}
-
-        /**
-         * Creates a load_balance strategy with HIP executor.
-         *
-         * @param exec the HIP executor
-         */
-        load_balance(std::shared_ptr<const HipExecutor> exec)
-            : load_balance(exec->get_num_warps(), exec->get_warp_size(), false)
-        {}
-
-        /**
-         * Creates a load_balance strategy with DPCPP executor.
-         *
-         * @param exec the DPCPP executor
-         *
-         * @note TODO: porting - we hardcode the subgroup size is 32
-         */
-        load_balance(std::shared_ptr<const DpcppExecutor> exec)
-            : load_balance(exec->get_num_subgroups(), 32, false, "intel")
-        {}
-
-        /**
-         * Creates a load_balance strategy with specified parameters
-         *
-         * @param nwarps the number of warps in the executor
-         * @param warp_size the warp size of the executor
-         * @param cuda_strategy  whether the `cuda_strategy` needs to be used.
-         *
-         * @note The warp_size must be the size of full warp. When using this
-         *       constructor, set_strategy needs to be called with correct
-         *       parameters which is replaced during the conversion.
-         */
-        load_balance(int64_t nwarps, int warp_size = 32,
-                     bool cuda_strategy = true,
-                     std::string strategy_name = "none")
-            : strategy_type("load_balance"),
-              nwarps_(nwarps),
-              warp_size_(warp_size),
-              cuda_strategy_(cuda_strategy),
-              strategy_name_(strategy_name)
-        {}
-
-        void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {
-            auto nwarps = mtx_srow->get_size();
-
-            if (nwarps > 0) {
-                auto host_srow_exec = mtx_srow->get_executor()->get_master();
-                auto host_mtx_exec = mtx_row_ptrs.get_executor()->get_master();
-                const bool is_srow_on_host{host_srow_exec ==
-                                           mtx_srow->get_executor()};
-                const bool is_mtx_on_host{host_mtx_exec ==
-                                          mtx_row_ptrs.get_executor()};
-                array<index_type> row_ptrs_host(host_mtx_exec);
-                array<index_type> srow_host(host_srow_exec);
-                const index_type* row_ptrs{};
-                index_type* srow{};
-                if (is_srow_on_host) {
-                    srow = mtx_srow->get_data();
-                } else {
-                    srow_host = *mtx_srow;
-                    srow = srow_host.get_data();
-                }
-                if (is_mtx_on_host) {
-                    row_ptrs = mtx_row_ptrs.get_const_data();
-                } else {
-                    row_ptrs_host = mtx_row_ptrs;
-                    row_ptrs = row_ptrs_host.get_const_data();
-                }
-                for (size_type i = 0; i < nwarps; i++) {
-                    srow[i] = 0;
-                }
-                const auto num_rows = mtx_row_ptrs.get_size() - 1;
-                const auto num_elems = row_ptrs[num_rows];
-                const auto bucket_divider =
-                    num_elems > 0 ? ceildiv(num_elems, warp_size_) : 1;
-                for (size_type i = 0; i < num_rows; i++) {
-                    auto bucket =
-                        ceildiv((ceildiv(row_ptrs[i + 1], warp_size_) * nwarps),
-                                bucket_divider);
-                    if (bucket < nwarps) {
-                        srow[bucket]++;
-                    }
-                }
-                // find starting row for thread i
-                for (size_type i = 1; i < nwarps; i++) {
-                    srow[i] += srow[i - 1];
-                }
-                if (!is_srow_on_host) {
-                    *mtx_srow = srow_host;
-                }
-            }
-        }
-
-        int64_t clac_size(const int64_t nnz) override
-        {
-            if (warp_size_ > 0) {
-                int multiple = 8;
-                if (nnz >= static_cast<int64_t>(2e8)) {
-                    multiple = 2048;
-                } else if (nnz >= static_cast<int64_t>(2e7)) {
-                    multiple = 512;
-                } else if (nnz >= static_cast<int64_t>(2e6)) {
-                    multiple = 128;
-                } else if (nnz >= static_cast<int64_t>(2e5)) {
-                    multiple = 32;
-                }
-                if (strategy_name_ == "intel") {
-                    multiple = 8;
-                    if (nnz >= static_cast<int64_t>(2e8)) {
-                        multiple = 256;
-                    } else if (nnz >= static_cast<int64_t>(2e7)) {
-                        multiple = 32;
-                    }
-                }
-#if GINKGO_HIP_PLATFORM_HCC
-                if (!cuda_strategy_) {
-                    multiple = 8;
-                    if (nnz >= static_cast<int64_t>(1e7)) {
-                        multiple = 64;
-                    } else if (nnz >= static_cast<int64_t>(1e6)) {
-                        multiple = 16;
-                    }
-                }
-#endif  // GINKGO_HIP_PLATFORM_HCC
-
-                auto nwarps = nwarps_ * multiple;
-                return min(ceildiv(nnz, warp_size_), nwarps);
-            } else {
-                return 0;
-            }
-        }
-
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<load_balance>(
-                nwarps_, warp_size_, cuda_strategy_, strategy_name_);
-        }
-
-    private:
-        int64_t nwarps_;
-        int warp_size_;
-        bool cuda_strategy_;
-        std::string strategy_name_;
-    };
-
-    class automatical : public strategy_type {
-    public:
-        /* Use imbalance strategy when the maximum number of nonzero per row is
-         * more than 1024 on NVIDIA hardware */
-        const index_type nvidia_row_len_limit = 1024;
-        /* Use imbalance strategy when the matrix has more more than 1e6 on
-         * NVIDIA hardware */
-        const index_type nvidia_nnz_limit{static_cast<index_type>(1e6)};
-        /* Use imbalance strategy when the maximum number of nonzero per row is
-         * more than 768 on AMD hardware */
-        const index_type amd_row_len_limit = 768;
-        /* Use imbalance strategy when the matrix has more more than 1e8 on AMD
-         * hardware */
-        const index_type amd_nnz_limit{static_cast<index_type>(1e8)};
-        /* Use imbalance strategy when the maximum number of nonzero per row is
-         * more than 25600 on Intel hardware */
-        const index_type intel_row_len_limit = 25600;
-        /* Use imbalance strategy when the matrix has more more than 3e8 on
-         * Intel hardware */
-        const index_type intel_nnz_limit{static_cast<index_type>(3e8)};
-
-    public:
-        /**
-         * Creates an automatical strategy.
-         *
-         * @warning this is deprecated! Please rely on the new automatic
-         *          strategy instantiation or use one of the other constructors.
-         */
-        [[deprecated]] automatical()
-            : automatical(std::move(
-                  gko::CudaExecutor::create(0, gko::OmpExecutor::create())))
-        {}
-
-        /**
-         * Creates an automatical strategy with CUDA executor.
-         *
-         * @param exec the CUDA executor
-         */
-        automatical(std::shared_ptr<const CudaExecutor> exec)
-            : automatical(exec->get_num_warps(), exec->get_warp_size())
-        {}
-
-        /**
-         * Creates an automatical strategy with HIP executor.
-         *
-         * @param exec the HIP executor
-         */
-        automatical(std::shared_ptr<const HipExecutor> exec)
-            : automatical(exec->get_num_warps(), exec->get_warp_size(), false)
-        {}
-
-        /**
-         * Creates an automatical strategy with Dpcpp executor.
-         *
-         * @param exec the Dpcpp executor
-         *
-         * @note TODO: porting - we hardcode the subgroup size is 32
-         */
-        automatical(std::shared_ptr<const DpcppExecutor> exec)
-            : automatical(exec->get_num_subgroups(), 32, false, "intel")
-        {}
-
-        /**
-         * Creates an automatical strategy with specified parameters
-         *
-         * @param nwarps the number of warps in the executor
-         * @param warp_size the warp size of the executor
-         * @param cuda_strategy  whether the `cuda_strategy` needs to be used.
-         *
-         * @note The warp_size must be the size of full warp. When using this
-         *       constructor, set_strategy needs to be called with correct
-         *       parameters which is replaced during the conversion.
-         */
-        automatical(int64_t nwarps, int warp_size = 32,
-                    bool cuda_strategy = true,
-                    std::string strategy_name = "none")
-            : strategy_type("automatical"),
-              nwarps_(nwarps),
-              warp_size_(warp_size),
-              cuda_strategy_(cuda_strategy),
-              strategy_name_(strategy_name),
-              max_length_per_row_(0)
-        {}
-
-        void process(const array<index_type>& mtx_row_ptrs,
-                     array<index_type>* mtx_srow) override
-        {
-            // if the number of stored elements is larger than <nnz_limit> or
-            // the maximum number of stored elements per row is larger than
-            // <row_len_limit>, use load_balance otherwise use classical
-            index_type nnz_limit = nvidia_nnz_limit;
-            index_type row_len_limit = nvidia_row_len_limit;
-            if (strategy_name_ == "intel") {
-                nnz_limit = intel_nnz_limit;
-                row_len_limit = intel_row_len_limit;
-            }
-#if GINKGO_HIP_PLATFORM_HCC
-            if (!cuda_strategy_) {
-                nnz_limit = amd_nnz_limit;
-                row_len_limit = amd_row_len_limit;
-            }
-#endif  // GINKGO_HIP_PLATFORM_HCC
-            auto host_mtx_exec = mtx_row_ptrs.get_executor()->get_master();
-            const bool is_mtx_on_host{host_mtx_exec ==
-                                      mtx_row_ptrs.get_executor()};
-            array<index_type> row_ptrs_host(host_mtx_exec);
-            const index_type* row_ptrs{};
-            if (is_mtx_on_host) {
-                row_ptrs = mtx_row_ptrs.get_const_data();
-            } else {
-                row_ptrs_host = mtx_row_ptrs;
-                row_ptrs = row_ptrs_host.get_const_data();
-            }
-            const auto num_rows = mtx_row_ptrs.get_size() - 1;
-            if (row_ptrs[num_rows] > nnz_limit) {
-                load_balance actual_strategy(nwarps_, warp_size_,
-                                             cuda_strategy_, strategy_name_);
-                if (is_mtx_on_host) {
-                    actual_strategy.process(mtx_row_ptrs, mtx_srow);
-                } else {
-                    actual_strategy.process(row_ptrs_host, mtx_srow);
-                }
-                this->set_name(actual_strategy.get_name());
-            } else {
-                index_type maxnum = 0;
-                for (size_type i = 0; i < num_rows; i++) {
-                    maxnum = std::max(maxnum, row_ptrs[i + 1] - row_ptrs[i]);
-                }
-                if (maxnum > row_len_limit) {
-                    load_balance actual_strategy(
-                        nwarps_, warp_size_, cuda_strategy_, strategy_name_);
-                    if (is_mtx_on_host) {
-                        actual_strategy.process(mtx_row_ptrs, mtx_srow);
-                    } else {
-                        actual_strategy.process(row_ptrs_host, mtx_srow);
-                    }
-                    this->set_name(actual_strategy.get_name());
-                } else {
-                    classical actual_strategy;
-                    if (is_mtx_on_host) {
-                        actual_strategy.process(mtx_row_ptrs, mtx_srow);
-                        max_length_per_row_ =
-                            actual_strategy.get_max_length_per_row();
-                    } else {
-                        actual_strategy.process(row_ptrs_host, mtx_srow);
-                        max_length_per_row_ =
-                            actual_strategy.get_max_length_per_row();
-                    }
-                    this->set_name(actual_strategy.get_name());
-                }
-            }
-        }
-
-        int64_t clac_size(const int64_t nnz) override
-        {
-            return std::make_shared<load_balance>(
-                       nwarps_, warp_size_, cuda_strategy_, strategy_name_)
-                ->clac_size(nnz);
-        }
-
-        index_type get_max_length_per_row() const noexcept
-        {
-            return max_length_per_row_;
-        }
-
-        std::shared_ptr<strategy_type> copy() override
-        {
-            return std::make_shared<automatical>(
-                nwarps_, warp_size_, cuda_strategy_, strategy_name_);
-        }
-
-    private:
-        int64_t nwarps_;
-        int warp_size_;
-        bool cuda_strategy_;
-        std::string strategy_name_;
-        index_type max_length_per_row_;
-    };
 
     friend class Csr<previous_precision<ValueType>, IndexType>;
 
@@ -1319,19 +836,16 @@ public:
      *
      * @return the strategy
      */
-    std::shared_ptr<strategy_type> get_strategy() const noexcept
-    {
-        return strategy_;
-    }
+    csr::spmv_strategy get_strategy() const noexcept { return strategy_; }
 
     /**
      * Set the strategy
      *
      * @param strategy the csr strategy
      */
-    void set_strategy(std::shared_ptr<strategy_type> strategy)
+    void set_strategy(csr::spmv_strategy strategy)
     {
-        strategy_ = std::move(strategy->copy());
+        strategy_ = strategy;
         this->make_srow();
     }
 
@@ -1370,7 +884,7 @@ public:
      * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Csr> create(std::shared_ptr<const Executor> exec,
-                                       std::shared_ptr<strategy_type> strategy);
+                                       csr::spmv_strategy strategy);
 
     /**
      * Creates an uninitialized CSR matrix of the specified size.
@@ -1378,15 +892,14 @@ public:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param num_nonzeros  number of nonzeros
-     * @param strategy  the strategy of CSR, or the default strategy if set to
-     *                  nullptr
+     * @param strategy  the strategy of CSR. default is automatical.
      *
      * @return A smart pointer to the newly created matrix.
      */
     static std::unique_ptr<Csr> create(
         std::shared_ptr<const Executor> exec, const dim<2>& size = {},
         size_type num_nonzeros = {},
-        std::shared_ptr<strategy_type> strategy = nullptr);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
 
     /**
      * Creates a CSR matrix from already allocated (and initialized) row
@@ -1411,7 +924,7 @@ public:
         std::shared_ptr<const Executor> exec, const dim<2>& size,
         array<value_type> values, array<index_type> col_idxs,
         array<index_type> row_ptrs,
-        std::shared_ptr<strategy_type> strategy = nullptr);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
 
     /**
      * @copydoc std::unique_ptr<Csr> create(std::shared_ptr<const Executor>,
@@ -1453,7 +966,7 @@ public:
         gko::detail::const_array_view<ValueType>&& values,
         gko::detail::const_array_view<IndexType>&& col_idxs,
         gko::detail::const_array_view<IndexType>&& row_ptrs,
-        std::shared_ptr<strategy_type> strategy = nullptr);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
 
     /**
      * Creates a submatrix from this Csr matrix given row and column index_set
@@ -1512,148 +1025,23 @@ public:
 protected:
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
         size_type num_nonzeros = {},
-        std::shared_ptr<strategy_type> strategy = nullptr);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
 
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size,
         array<value_type> values, array<index_type> col_idxs,
         array<index_type> row_ptrs,
-        std::shared_ptr<strategy_type> strategy = nullptr);
+        csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
 
     void apply_impl(const LinOp* b, LinOp* x) const override;
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
 
-    // TODO: This provides some more sane settings. Please fix this!
-    static std::shared_ptr<strategy_type> make_default_strategy(
-        std::shared_ptr<const Executor> exec)
-    {
-        auto cuda_exec = std::dynamic_pointer_cast<const CudaExecutor>(exec);
-        auto hip_exec = std::dynamic_pointer_cast<const HipExecutor>(exec);
-        auto dpcpp_exec = std::dynamic_pointer_cast<const DpcppExecutor>(exec);
-        std::shared_ptr<strategy_type> new_strategy;
-        if (cuda_exec) {
-            new_strategy = std::make_shared<automatical>(cuda_exec);
-        } else if (hip_exec) {
-            new_strategy = std::make_shared<automatical>(hip_exec);
-        } else if (dpcpp_exec) {
-            new_strategy = std::make_shared<automatical>(dpcpp_exec);
-        } else {
-            new_strategy = std::make_shared<classical>();
-        }
-        return new_strategy;
-    }
-
-    // TODO clean this up as soon as we improve strategy_type
-    template <typename CsrType>
-    void convert_strategy_helper(CsrType* result) const
-    {
-        auto strat = this->get_strategy().get();
-        std::shared_ptr<typename CsrType::strategy_type> new_strat;
-        if (dynamic_cast<classical*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::classical>();
-        } else if (dynamic_cast<merge_path*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::merge_path>();
-        } else if (dynamic_cast<cusparse*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::cusparse>();
-        } else if (dynamic_cast<sparselib*>(strat)) {
-            new_strat = std::make_shared<typename CsrType::sparselib>();
-        } else {
-            auto rexec = result->get_executor();
-            auto cuda_exec =
-                std::dynamic_pointer_cast<const CudaExecutor>(rexec);
-            auto hip_exec = std::dynamic_pointer_cast<const HipExecutor>(rexec);
-            auto dpcpp_exec =
-                std::dynamic_pointer_cast<const DpcppExecutor>(rexec);
-            auto lb = dynamic_cast<load_balance*>(strat);
-            if (cuda_exec) {
-                if (lb) {
-                    new_strat =
-                        std::make_shared<typename CsrType::load_balance>(
-                            cuda_exec);
-                } else {
-                    new_strat = std::make_shared<typename CsrType::automatical>(
-                        cuda_exec);
-                }
-            } else if (hip_exec) {
-                if (lb) {
-                    new_strat =
-                        std::make_shared<typename CsrType::load_balance>(
-                            hip_exec);
-                } else {
-                    new_strat = std::make_shared<typename CsrType::automatical>(
-                        hip_exec);
-                }
-            } else if (dpcpp_exec) {
-                if (lb) {
-                    new_strat =
-                        std::make_shared<typename CsrType::load_balance>(
-                            dpcpp_exec);
-                } else {
-                    new_strat = std::make_shared<typename CsrType::automatical>(
-                        dpcpp_exec);
-                }
-            } else {
-                // Try to preserve this executor's configuration
-                auto this_cuda_exec =
-                    std::dynamic_pointer_cast<const CudaExecutor>(
-                        this->get_executor());
-                auto this_hip_exec =
-                    std::dynamic_pointer_cast<const HipExecutor>(
-                        this->get_executor());
-                auto this_dpcpp_exec =
-                    std::dynamic_pointer_cast<const DpcppExecutor>(
-                        this->get_executor());
-                if (this_cuda_exec) {
-                    if (lb) {
-                        new_strat =
-                            std::make_shared<typename CsrType::load_balance>(
-                                this_cuda_exec);
-                    } else {
-                        new_strat =
-                            std::make_shared<typename CsrType::automatical>(
-                                this_cuda_exec);
-                    }
-                } else if (this_hip_exec) {
-                    if (lb) {
-                        new_strat =
-                            std::make_shared<typename CsrType::load_balance>(
-                                this_hip_exec);
-                    } else {
-                        new_strat =
-                            std::make_shared<typename CsrType::automatical>(
-                                this_hip_exec);
-                    }
-                } else if (this_dpcpp_exec) {
-                    if (lb) {
-                        new_strat =
-                            std::make_shared<typename CsrType::load_balance>(
-                                this_dpcpp_exec);
-                    } else {
-                        new_strat =
-                            std::make_shared<typename CsrType::automatical>(
-                                this_dpcpp_exec);
-                    }
-                } else {
-                    // FIXME: this changes strategies.
-                    // We had a load balance or automatical strategy from a non
-                    // HIP or Cuda executor and are moving to a non HIP or Cuda
-                    // executor.
-                    new_strat = std::make_shared<typename CsrType::classical>();
-                }
-            }
-        }
-        result->set_strategy(new_strat);
-    }
 
     /**
      * Computes srow. It should be run after changing any row_ptrs_ value.
      */
-    void make_srow()
-    {
-        srow_.resize_and_reset(strategy_->clac_size(values_.get_size()));
-        strategy_->process(row_ptrs_, &srow_);
-    }
+    void make_srow();
 
     /**
      * @copydoc scale(const LinOp *)
@@ -1672,53 +1060,17 @@ protected:
     virtual void inv_scale_impl(const LinOp* alpha);
 
 private:
-    std::shared_ptr<strategy_type> strategy_;
+    csr::spmv_strategy strategy_;
     array<value_type> values_;
     array<index_type> col_idxs_;
     array<index_type> row_ptrs_;
     array<index_type> srow_;
+    index_type max_nnz_per_row_;
 
     void add_scaled_identity_impl(const LinOp* a, const LinOp* b) override;
 };
 
 
-namespace detail {
-
-
-/**
- * When strategy is load_balance or automatical, rebuild the strategy
- * according to executor's property.
- *
- * @param result  the csr matrix.
- */
-template <typename ValueType, typename IndexType>
-void strategy_rebuild_helper(Csr<ValueType, IndexType>* result)
-{
-    using load_balance = typename Csr<ValueType, IndexType>::load_balance;
-    using automatical = typename Csr<ValueType, IndexType>::automatical;
-    auto strategy = result->get_strategy();
-    auto executor = result->get_executor();
-    if (std::dynamic_pointer_cast<load_balance>(strategy)) {
-        if (auto exec =
-                std::dynamic_pointer_cast<const HipExecutor>(executor)) {
-            result->set_strategy(std::make_shared<load_balance>(exec));
-        } else if (auto exec = std::dynamic_pointer_cast<const CudaExecutor>(
-                       executor)) {
-            result->set_strategy(std::make_shared<load_balance>(exec));
-        }
-    } else if (std::dynamic_pointer_cast<automatical>(strategy)) {
-        if (auto exec =
-                std::dynamic_pointer_cast<const HipExecutor>(executor)) {
-            result->set_strategy(std::make_shared<automatical>(exec));
-        } else if (auto exec = std::dynamic_pointer_cast<const CudaExecutor>(
-                       executor)) {
-            result->set_strategy(std::make_shared<automatical>(exec));
-        }
-    }
-}
-
-
-}  // namespace detail
 }  // namespace matrix
 }  // namespace gko
 

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -55,16 +55,44 @@ class Permutation;
 namespace csr {
 
 
+/**
+ * Type describes the Csr SpMV strategy.
+ */
 enum class spmv_strategy {
+    /**
+     * automatical is the strategy choosing between load_balance and classical
+     * based on the maximum number of entries per row and the number of entries
+     * of the matrix.
+     */
     automatical,
+    /**
+     * load_balance is the strategy trying to distribute the work equally in
+     * terms of the number of matrix entries. More detail can be checked in
+     * Goran and Enrique: Balanced CSR sparse matrix-vector product on graphics
+     * processors.
+     */
     load_balance,
+    /**
+     * merge_path is the strategy trying to distribute the work equally in terms
+     * of the number of matrix entries and row pointers. More detail can be
+     * checked in Merrill and Garland: Merge-Based Parallel Sparse Matrix-Vector
+     * Multiplication.
+     */
     merge_path,
+    /**
+     * classical is the strategy assigning the same amount of the working
+     * resource to each row.
+     */
     classical,
+    /**
+     * sparselib is the strategy calling the backend sparse library
+     * implementation when it is supported.
+     */
     sparselib
 };
 
 
-}
+}  // namespace csr
 
 
 /**
@@ -891,7 +919,8 @@ public:
      * @param exec  Executor associated to the matrix
      * @param size  size of the matrix
      * @param num_nonzeros  number of nonzeros
-     * @param strategy  the strategy of CSR. default is automatical.
+     * @param strategy  the strategy the matrix uses for SpMV operations,
+     * default is automatical.
      *
      * @return A smart pointer to the newly created matrix.
      */
@@ -909,7 +938,8 @@ public:
      * @param values  array of matrix values
      * @param col_idxs  array of column indexes
      * @param row_ptrs  array of row pointers
-     * @param strategy  the strategy the matrix uses for SpMV operations
+     * @param strategy  the strategy the matrix uses for SpMV operations,
+     * default is automatical.
      *
      * @note If one of `row_ptrs`, `col_idxs` or `values` is not an rvalue, not
      *       an array of IndexType, IndexType and ValueType, respectively, or
@@ -953,7 +983,8 @@ public:
      * @param values  the value array of the matrix
      * @param col_idxs  the column index array of the matrix
      * @param row_ptrs  the row pointer array of the matrix
-     * @param strategy  the strategy the matrix uses for SpMV operations
+     * @param strategy  the strategy the matrix uses for SpMV operations,
+     * default is automatical.
      * @returns A smart pointer to the constant matrix wrapping the input arrays
      *          (if they reside on the same executor as the matrix) or a copy of
      *          these arrays on the correct executor.
@@ -1056,6 +1087,15 @@ public:
      */
     Csr(Csr&&);
 
+    /**
+     * Returns the actual strategy. When the strategy is automatical, this
+     * returns the actual underlying strategy. This returns the same strategy as
+     * `get_strategy` when the strategy is not automatical.
+     *
+     * @return the acutal strategy
+     */
+    csr::spmv_strategy get_actual_strategy() const noexcept;
+
 protected:
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
         size_type num_nonzeros = {},
@@ -1070,15 +1110,6 @@ protected:
 
     void apply_impl(const LinOp* alpha, const LinOp* b, const LinOp* beta,
                     LinOp* x) const override;
-
-    /**
-     * Returns the actual strategy. When the strategy is automatical, this
-     * returns the actual underlying strategy. This returns the same strategy as
-     * `get_strategy` when the strategy is not automatical.
-     *
-     * @return the acutal strategy
-     */
-    csr::spmv_strategy get_actual_strategy() const noexcept;
 
     /**
      * Computes srow. It should be run after changing any row_ptrs_ value.

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -204,47 +204,79 @@ public:
     using device_mat_data = device_matrix_data<ValueType, IndexType>;
     using absolute_type = remove_complex<Csr>;
 
-    class [[deprecated(
-        "please use enum "
-        "gko::matrix::csr::spmv_strategy::<strategy>")]] strategy_type
-    {
+    class GKO_DEPRECATED(
+        "please use enum gko::matrix::csr::spmv_strategy::<strategy>")
+        strategy_type {
     public:
         virtual ~strategy_type() = default;
+
+        // return the corresponding enum in incoming release
+        virtual csr::spmv_strategy get_enum() const = 0;
     };
 
-    class [[deprecated(
-        "please use enum "
-        "gko::matrix::csr::spmv_strategy::classical")]] classical
-        : public strategy_type{};
+    class GKO_DEPRECATED(
+        "please use enum gko::matrix::csr::spmv_strategy::classical") classical
+        : public strategy_type {
+    public:
+        csr::spmv_strategy get_enum() const override
+        {
+            return csr::spmv_strategy::classical;
+        }
+    };
 
-    class [[deprecated(
-        "please use enum "
-        "gko::matrix::csr::spmv_strategy::merge_path")]] merge_path
-        : public strategy_type{};
+    class GKO_DEPRECATED(
+        "please use enum gko::matrix::csr::spmv_strategy::merge_path")
+        merge_path : public strategy_type {
+    public:
+        csr::spmv_strategy get_enum() const override
+        {
+            return csr::spmv_strategy::merge_path;
+        }
+    };
 
-    class [[deprecated(
-        "please use enum "
-        "gko::matrix::csr::spmv_strategy::sparselib")]] cusparse
-        : public strategy_type{};
+    class GKO_DEPRECATED(
+        "please use enum gko::matrix::csr::spmv_strategy::sparselib") cusparse
+        : public strategy_type {
+    public:
+        csr::spmv_strategy get_enum() const override
+        {
+            return csr::spmv_strategy::sparselib;
+        }
+    };
 
-    class [[deprecated(
-        "please use enum "
-        "gko::matrix::csr::spmv_strategy::sparselib")]] sparselib
-        : public strategy_type{};
+    class GKO_DEPRECATED(
+        "please use enum gko::matrix::csr::spmv_strategy::sparselib") sparselib
+        : public strategy_type {
+    public:
+        csr::spmv_strategy get_enum() const override
+        {
+            return csr::spmv_strategy::sparselib;
+        }
+    };
 
-    class [[deprecated(
-        "please use enum "
-        "gko::matrix::csr::spmv_strategy::load_balance")]] load_balance
-        : public strategy_type{
-            public : load_balance(std::shared_ptr<const Executor>){}
-        };
+    class GKO_DEPRECATED(
+        "please use enum gko::matrix::csr::spmv_strategy::load_balance")
+        load_balance : public strategy_type {
+    public:
+        load_balance(std::shared_ptr<const Executor>) {}
 
-    class [[deprecated(
-        "please use enum "
-        "gko::matrix::csr::spmv_strategy::automatic")]] automatical
-        : public strategy_type{
-            public : automatical(std::shared_ptr<const Executor>){}
-        };
+        csr::spmv_strategy get_enum() const override
+        {
+            return csr::spmv_strategy::load_balance;
+        }
+    };
+
+    class GKO_DEPRECATED(
+        "please use enum gko::matrix::csr::spmv_strategy::automatic")
+        automatical : public strategy_type {
+    public:
+        automatical(std::shared_ptr<const Executor>) {}
+
+        csr::spmv_strategy get_enum() const override
+        {
+            return csr::spmv_strategy::automatic;
+        }
+    };
 
 
     friend class Csr<previous_precision<ValueType>, IndexType>;

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -66,50 +66,6 @@ enum class spmv_strategy {
 
 }
 
-// after store the max_nnz_per_row in the csr. this should be able to
-// calculate in runtime if the number of stored elements is larger than
-// <nnz_limit> or the maximum number of stored elements per row is larger
-// than <row_len_limit>, use load_balance otherwise use classical
-inline auto auto_select(std::shared_ptr<const Executor> exec,
-                        int64_t max_nnz_per_row)
-{
-    /* Use imbalance strategy when the maximum number of nonzero per row
-     * is more than 1024 on NVIDIA hardware */
-    const int64_t nvidia_row_len_limit = 1024;
-    /* Use imbalance strategy when the matrix has more more than 1e6 on
-     * NVIDIA hardware */
-    const int64_t nvidia_nnz_limit{static_cast<int64_t>(1e6)};
-    /* Use imbalance strategy when the maximum number of nonzero per row
-     * is more than 768 on AMD hardware */
-    const int64_t amd_row_len_limit = 768;
-    /* Use imbalance strategy when the matrix has more more than 1e8 on
-     * AMD hardware */
-    const int64_t amd_nnz_limit{static_cast<int64_t>(1e8)};
-    /* Use imbalance strategy when the maximum number of nonzero per row
-     * is more than 25600 on Intel hardware */
-    const int64_t intel_row_len_limit = 25600;
-    /* Use imbalance strategy when the matrix has more more than 3e8 on
-     * Intel hardware */
-    const int64_t intel_nnz_limit{static_cast<int64_t>(3e8)};
-    auto nnz_limit = nvidia_nnz_limit;
-    auto row_len_limit = nvidia_row_len_limit;
-    if (std::dynamic_pointer_cast<const DpcppExecutor>(exec)) {
-        nnz_limit = intel_nnz_limit;
-        row_len_limit = intel_row_len_limit;
-    } else if (std::dynamic_pointer_cast<const HipExecutor>(exec)) {
-        nnz_limit = amd_nnz_limit;
-        row_len_limit = amd_row_len_limit;
-    }
-    nnz_limit += row_len_limit;
-    return csr::spmv_strategy::load_balance;
-    // if (this->get_num_stored_elements() > nnz_limit ||
-    //     max_nnz_per_row > row_len_limit) {
-    //     return csr::spmv_strategy::load_balance;
-    // } else {
-    //     return csr::spmv_strategy::classical;
-    // }
-}
-
 
 /**
  * CSR is a matrix format which stores only the nonzero coefficients by
@@ -832,11 +788,21 @@ public:
         return values_.get_size();
     }
 
-    /** Returns the strategy
+    /**
+     * Returns the strategy
      *
      * @return the strategy
      */
-    csr::spmv_strategy get_strategy() const noexcept { return strategy_; }
+    csr::spmv_strategy get_strategy() const noexcept;
+
+    /**
+     * Returns the actual strategy. When the strategy is automatical, this
+     * returns the actual underlying strategy. This returns the same strategy as
+     * `get_strategy` when the strategy is not automatical.
+     *
+     * @return the acutal strategy
+     */
+    csr::spmv_strategy get_actual_strategy() const noexcept;
 
     /**
      * Set the strategy

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -171,6 +171,48 @@ public:
     using device_mat_data = device_matrix_data<ValueType, IndexType>;
     using absolute_type = remove_complex<Csr>;
 
+    class [[deprecated(
+        "please use enum "
+        "gko::matrix::csr::spmv_strategy::<strategy>")]] strategy_type
+    {
+    public:
+        virtual ~strategy_type() = default;
+    };
+
+    class [[deprecated(
+        "please use enum "
+        "gko::matrix::csr::spmv_strategy::classical")]] classical
+        : public strategy_type{};
+
+    class [[deprecated(
+        "please use enum "
+        "gko::matrix::csr::spmv_strategy::merge_path")]] merge_path
+        : public strategy_type{};
+
+    class [[deprecated(
+        "please use enum "
+        "gko::matrix::csr::spmv_strategy::sparselib")]] cusparse
+        : public strategy_type{};
+
+    class [[deprecated(
+        "please use enum "
+        "gko::matrix::csr::spmv_strategy::sparselib")]] sparselib
+        : public strategy_type{};
+
+    class [[deprecated(
+        "please use enum "
+        "gko::matrix::csr::spmv_strategy::load_balance")]] load_balance
+        : public strategy_type{
+            public : load_balance(std::shared_ptr<const Executor>){}
+        };
+
+    class [[deprecated(
+        "please use enum "
+        "gko::matrix::csr::spmv_strategy::automatical")]] automatical
+        : public strategy_type{
+            public : automatical(std::shared_ptr<const Executor>){}
+        };
+
 
     friend class Csr<previous_precision<ValueType>, IndexType>;
 
@@ -924,6 +966,39 @@ public:
         gko::detail::const_array_view<IndexType>&& col_idxs,
         gko::detail::const_array_view<IndexType>&& row_ptrs,
         csr::spmv_strategy strategy = csr::spmv_strategy::automatical);
+
+    GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+    /**
+     * @copydoc std::unique_ptr<Csr> create(std::shared_ptr<const Executor>,
+     * csr::spmv_strategy)
+     */
+    [[deprecated("please use enum version")]] static std::unique_ptr<Csr>
+    create(std::shared_ptr<const Executor> exec,
+           std::shared_ptr<strategy_type> strategy);
+
+    /**
+     * @copydoc std::unique_ptr<Csr> create(std::shared_ptr<const Executor>,
+     * const dim<2>&, array<value_type>, array<index_type>, array<index_type>,
+     * csr::spmv_strategy)
+     */
+    [[deprecated("please use enum version")]] static std::unique_ptr<Csr>
+    create(std::shared_ptr<const Executor> exec, const dim<2>& size,
+           array<value_type> values, array<index_type> col_idxs,
+           array<index_type> row_ptrs, std::shared_ptr<strategy_type> strategy);
+
+    /**
+     * @copydoc std::unique_ptr<const Csr> create_const(std::shared_ptr<const
+     * Executor>, const dim<2>&, gko::detail::const_array_view<ValueType>&&,
+     * gko::detail::const_array_view<IndexType>&&,
+     * gko::detail::const_array_view<IndexType>&&, csr::spmv_strategy)
+     */
+    [[deprecated("please use enum version")]] static std::unique_ptr<const Csr>
+    create_const(std::shared_ptr<const Executor> exec, const dim<2>& size,
+                 gko::detail::const_array_view<ValueType>&& values,
+                 gko::detail::const_array_view<IndexType>&& col_idxs,
+                 gko::detail::const_array_view<IndexType>&& row_ptrs,
+                 std::shared_ptr<strategy_type> strategy);
+    GKO_END_DISABLE_DEPRECATION_WARNINGS
 
     /**
      * Creates a submatrix from this Csr matrix given row and column index_set

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -92,6 +92,31 @@ enum class spmv_strategy {
 };
 
 
+namespace detail {
+
+
+/**
+ * Returns the actual strategy passed. When the strategy is automatical, this
+ * returns the actual underlying strategy. This returns the same strategy as
+ * the input when the input is not automatical.
+ *
+ * @param exec  Executor associated to the matrix
+ * @param strategy  the strategy of CSR
+ * @param num_stored_elements  the number of stored elements
+ * @param max_nnz_per_row  the maximum number of stored elements per row
+ *
+ * @return the acutal strategy
+ *
+ * @note Users should not use this function. This is only make the function
+ * public for test
+ */
+spmv_strategy get_actual_strategy(std::shared_ptr<const Executor> exec,
+                                  spmv_strategy strategy,
+                                  size_type num_stored_elements,
+                                  size_type max_nnz_per_row);
+
+
+}  // namespace detail
 }  // namespace csr
 
 
@@ -1087,15 +1112,6 @@ public:
      */
     Csr(Csr&&);
 
-    /**
-     * Returns the actual strategy. When the strategy is automatical, this
-     * returns the actual underlying strategy. This returns the same strategy as
-     * `get_strategy` when the strategy is not automatical.
-     *
-     * @return the acutal strategy
-     */
-    csr::spmv_strategy get_actual_strategy() const noexcept;
-
 protected:
     Csr(std::shared_ptr<const Executor> exec, const dim<2>& size = {},
         size_type num_nonzeros = {},
@@ -1131,6 +1147,15 @@ protected:
      *        instead of inv_scale(const LinOp *alpha).
      */
     virtual void inv_scale_impl(const LinOp* alpha);
+
+    /**
+     * Returns the actual strategy. When the strategy is automatical, this
+     * returns the actual underlying strategy. This returns the same strategy as
+     * `get_strategy` when the strategy is not automatical.
+     *
+     * @return the acutal strategy
+     */
+    csr::spmv_strategy get_actual_strategy() const noexcept;
 
 private:
     csr::spmv_strategy strategy_;

--- a/omp/factorization/factorization_kernels.cpp
+++ b/omp/factorization/factorization_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -138,10 +138,11 @@ void add_missing_diagonal_elements(const matrix::Csr<ValueType, IndexType>* mtx,
 
 
 template <typename ValueType, typename IndexType>
-void add_diagonal_elements(std::shared_ptr<const OmpExecutor> exec,
-                           matrix::Csr<ValueType, IndexType>* mtx,
-                           bool is_sorted)
+void add_diagonal_elements(
+    std::shared_ptr<const OmpExecutor> exec,
+    matrix::CsrBuilder<ValueType, IndexType>* mtx_builder, bool is_sorted)
 {
+    auto mtx = mtx_builder->get_matrix();
     auto mtx_size = mtx->get_size();
     size_type row_ptrs_size = mtx_size[0] + 1;
     array<IndexType> row_ptrs_addition{exec, row_ptrs_size};
@@ -176,9 +177,8 @@ void add_diagonal_elements(std::shared_ptr<const OmpExecutor> exec,
         old_row_ptrs_ptr[i] += row_ptrs_addition_ptr[i];
     }
 
-    matrix::CsrBuilder<ValueType, IndexType> mtx_builder{mtx};
-    mtx_builder.get_value_array() = std::move(new_values);
-    mtx_builder.get_col_idx_array() = std::move(new_col_idxs);
+    mtx_builder->get_value_array() = std::move(new_values);
+    mtx_builder->get_col_idx_array() = std::move(new_col_idxs);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/omp/factorization/par_ict_kernels.cpp
+++ b/omp/factorization/par_ict_kernels.cpp
@@ -102,12 +102,13 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* llh,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
-                    matrix::Csr<ValueType, IndexType>* l_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l->get_const_row_ptrs();
     auto l_col_idxs = l->get_const_col_idxs();
     auto l_vals = l->get_const_values();
+    auto l_new = l_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
     // count nnz
@@ -122,9 +123,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
 
     // resize arrays
     auto l_nnz = l_new_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> l_builder{l_new};
-    l_builder.get_col_idx_array().resize_and_reset(l_nnz);
-    l_builder.get_value_array().resize_and_reset(l_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_nnz);
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = l_new->get_values();
 

--- a/omp/factorization/par_ilut_kernels.cpp
+++ b/omp/factorization/par_ilut_kernels.cpp
@@ -68,7 +68,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
-                     matrix::Csr<ValueType, IndexType>* m_out,
+                     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
@@ -77,6 +77,7 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
 
+    auto m_out = m_out_builder->get_matrix();
     // first sweep: count nnz for each row
     auto new_row_ptrs = m_out->get_row_ptrs();
 
@@ -95,9 +96,8 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     // second sweep: accumulate non-zeros
     auto new_nnz = new_row_ptrs[num_rows];
     // resize arrays and update aliases
-    matrix::CsrBuilder<ValueType, IndexType> builder{m_out};
-    builder.get_col_idx_array().resize_and_reset(new_nnz);
-    builder.get_value_array().resize_and_reset(new_nnz);
+    m_out_builder->get_col_idx_array().resize_and_reset(new_nnz);
+    m_out_builder->get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
     IndexType* new_row_idxs{};
@@ -134,13 +134,13 @@ template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
     abstract_filter(
-        exec, m, m_out, m_out_coo, [&](IndexType row, IndexType nz) {
+        exec, m, m_out_builder, m_out_coo, [&](IndexType row, IndexType nz) {
             return abs(vals[nz]) >= threshold || col_idxs[nz] == row;
         });
 }
@@ -154,12 +154,12 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
 
 
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto vals = m->get_const_values();
     auto col_idxs = m->get_const_col_idxs();
@@ -226,7 +226,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                                      : zero<remove_complex<ValueType>>();
     // filter elements
     abstract_filter(
-        exec, m, m_out, m_out_coo, [&](IndexType row, IndexType nz) {
+        exec, m, m_out_builder, m_out_coo, [&](IndexType row, IndexType nz) {
             auto bucket_it = std::upper_bound(sample, sample + bucket_count - 1,
                                               abs(vals[nz]));
             auto bucket = std::distance(sample, bucket_it);
@@ -328,8 +328,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
                     const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
+                    matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l->get_const_row_ptrs();
@@ -338,6 +338,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
     auto u_row_ptrs = u->get_const_row_ptrs();
     auto u_col_idxs = u->get_const_col_idxs();
     auto u_vals = u->get_const_values();
+    auto l_new = l_new_builder->get_matrix();
+    auto u_new = u_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
@@ -360,12 +362,10 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
     // resize arrays
     auto l_nnz = l_new_row_ptrs[num_rows];
     auto u_nnz = u_new_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> l_builder{l_new};
-    matrix::CsrBuilder<ValueType, IndexType> u_builder{u_new};
-    l_builder.get_col_idx_array().resize_and_reset(l_nnz);
-    l_builder.get_value_array().resize_and_reset(l_nnz);
-    u_builder.get_col_idx_array().resize_and_reset(u_nnz);
-    u_builder.get_value_array().resize_and_reset(u_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_nnz);
+    u_new_builder->get_col_idx_array().resize_and_reset(u_nnz);
+    u_new_builder->get_value_array().resize_and_reset(u_nnz);
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = l_new->get_values();
     auto u_new_col_idxs = u_new->get_col_idxs();

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -204,6 +204,7 @@ void classical_spmv(std::shared_ptr<const OmpExecutor> exec,
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const OmpExecutor> exec,
+          const matrix::csr::spmv_strategy strategy, const IndexType,
           const matrix::Csr<MatrixValueType, IndexType>* a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
@@ -212,7 +213,7 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
+    } else if (strategy == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
             exec, a, b, c, [](auto val) { return val; },
             [](auto) { return zero<arithmetic_type>(); });
@@ -228,6 +229,7 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
+                   const matrix::csr::spmv_strategy strategy, const IndexType,
                    matrix::view::dense<const MatrixValueType> alpha,
                    const matrix::Csr<MatrixValueType, IndexType>* a,
                    matrix::view::dense<const InputValueType> b,
@@ -240,7 +242,7 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto vbeta = static_cast<arithmetic_type>(beta(0, 0));
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
+    } else if (strategy == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
             exec, a, b, c, [valpha](auto val) { return valpha * val; },
             [vbeta](auto val) {

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -212,7 +212,7 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
         highest_precision<MatrixValueType, InputValueType, OutputValueType>;
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy()->get_name() == "merge_path") {
+    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
             exec, a, b, c, [](auto val) { return val; },
             [](auto) { return zero<arithmetic_type>(); });
@@ -240,7 +240,7 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto vbeta = static_cast<arithmetic_type>(beta(0, 0));
     if (c.size[0] == 0 || c.size[1] == 0) {
         // empty output: nothing to do
-    } else if (a->get_strategy()->get_name() == "merge_path") {
+    } else if (a->get_strategy() == matrix::csr::spmv_strategy::merge_path) {
         merge_spmv(
             exec, a, b, c, [valpha](auto val) { return valpha * val; },
             [vbeta](auto val) {

--- a/omp/matrix/csr_kernels.cpp
+++ b/omp/matrix/csr_kernels.cpp
@@ -456,9 +456,10 @@ template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const OmpExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto num_rows = a->get_size()[0];
+    auto c = c_builder->get_matrix();
     auto c_row_ptrs = c->get_row_ptrs();
 
     array<col_heap_element<ValueType, IndexType>> col_heap_array(
@@ -487,9 +488,8 @@ void spgemm(std::shared_ptr<const OmpExecutor> exec,
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_col_idxs = c_col_idxs_array.get_data();
@@ -523,13 +523,14 @@ void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* b,
                      matrix::view::dense<const ValueType> beta,
                      const matrix::Csr<ValueType, IndexType>* d,
-                     matrix::Csr<ValueType, IndexType>* c)
+                     matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto num_rows = a->get_size()[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
 
+    auto c = c_builder->get_matrix();
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
     auto d_row_ptrs = d->get_const_row_ptrs();
@@ -570,9 +571,8 @@ void advanced_spgemm(std::shared_ptr<const OmpExecutor> exec,
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_col_idxs = c_col_idxs_array.get_data();
@@ -765,12 +765,13 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             matrix::view::dense<const ValueType> beta,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto num_rows = a->get_size()[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
 
+    auto c = c_builder->get_matrix();
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
 
@@ -786,9 +787,8 @@ void spgeam(std::shared_ptr<const OmpExecutor> exec,
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_col_idxs = c_col_idxs_array.get_data();

--- a/reference/factorization/factorization_kernels.cpp
+++ b/reference/factorization/factorization_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -52,10 +52,11 @@ size_type count_missing_elements(IndexType num_rows, IndexType num_cols,
 
 
 template <typename ValueType, typename IndexType>
-void add_diagonal_elements(std::shared_ptr<const ReferenceExecutor> exec,
-                           matrix::Csr<ValueType, IndexType>* mtx,
-                           bool /*is_sorted*/)
+void add_diagonal_elements(
+    std::shared_ptr<const ReferenceExecutor> exec,
+    matrix::CsrBuilder<ValueType, IndexType>* mtx_builder, bool /*is_sorted*/)
 {
+    auto mtx = mtx_builder->get_matrix();
     const auto values = mtx->get_const_values();
     const auto col_idxs = mtx->get_const_col_idxs();
     auto row_ptrs = mtx->get_row_ptrs();
@@ -123,9 +124,8 @@ void add_diagonal_elements(std::shared_ptr<const ReferenceExecutor> exec,
     }
     row_ptrs[num_rows] = static_cast<IndexType>(new_nnz);
 
-    matrix::CsrBuilder<ValueType, IndexType> mtx_builder{mtx};
-    mtx_builder.get_value_array() = std::move(new_values_array);
-    mtx_builder.get_col_idx_array() = std::move(new_col_idxs_array);
+    mtx_builder->get_value_array() = std::move(new_values_array);
+    mtx_builder->get_col_idx_array() = std::move(new_col_idxs_array);
 }
 
 GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(

--- a/reference/factorization/par_ict_kernels.cpp
+++ b/reference/factorization/par_ict_kernels.cpp
@@ -98,12 +98,13 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* llh,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
-                    matrix::Csr<ValueType, IndexType>* l_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l->get_const_row_ptrs();
     auto l_col_idxs = l->get_const_col_idxs();
     auto l_vals = l->get_const_values();
+    auto l_new = l_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
     // count nnz
@@ -121,9 +122,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
     l_new_row_ptrs[num_rows] = l_nnz;
 
     // resize arrays
-    matrix::CsrBuilder<ValueType, IndexType> l_builder{l_new};
-    l_builder.get_col_idx_array().resize_and_reset(l_nnz);
-    l_builder.get_value_array().resize_and_reset(l_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_nnz);
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = l_new->get_values();
 

--- a/reference/factorization/par_ilut_kernels.cpp
+++ b/reference/factorization/par_ilut_kernels.cpp
@@ -71,7 +71,7 @@ GKO_INSTANTIATE_FOR_EACH_VALUE_AND_INDEX_TYPE(
 template <typename Predicate, typename ValueType, typename IndexType>
 void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* m,
-                     matrix::Csr<ValueType, IndexType>* m_out,
+                     matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                      matrix::Coo<ValueType, IndexType>* m_out_coo,
                      Predicate pred)
 {
@@ -80,6 +80,7 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
 
+    auto m_out = m_out_builder->get_matrix();
     // first sweep: count nnz for each row
     auto new_row_ptrs = m_out->get_row_ptrs();
     for (size_type row = 0; row < num_rows; ++row) {
@@ -96,9 +97,8 @@ void abstract_filter(std::shared_ptr<const DefaultExecutor> exec,
     // second sweep: accumulate non-zeros
     auto new_nnz = new_row_ptrs[num_rows];
     // resize arrays and update aliases
-    matrix::CsrBuilder<ValueType, IndexType> builder{m_out};
-    builder.get_col_idx_array().resize_and_reset(new_nnz);
-    builder.get_value_array().resize_and_reset(new_nnz);
+    m_out_builder->get_col_idx_array().resize_and_reset(new_nnz);
+    m_out_builder->get_value_array().resize_and_reset(new_nnz);
     auto new_col_idxs = m_out->get_col_idxs();
     auto new_vals = m_out->get_values();
     IndexType* new_row_idxs{};
@@ -139,13 +139,13 @@ template <typename ValueType, typename IndexType>
 void threshold_filter(std::shared_ptr<const DefaultExecutor> exec,
                       const matrix::Csr<ValueType, IndexType>* m,
                       remove_complex<ValueType> threshold,
-                      matrix::Csr<ValueType, IndexType>* m_out,
+                      matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
                       matrix::Coo<ValueType, IndexType>* m_out_coo, bool)
 {
     auto col_idxs = m->get_const_col_idxs();
     auto vals = m->get_const_values();
     abstract_filter(
-        exec, m, m_out, m_out_coo, [&](IndexType row, IndexType nz) {
+        exec, m, m_out_builder, m_out_coo, [&](IndexType row, IndexType nz) {
             return abs(vals[nz]) >= threshold || col_idxs[nz] == row;
         });
 }
@@ -165,12 +165,12 @@ constexpr auto sample_size = bucket_count * sampleselect_oversampling;
  * and removes all elements below this threshold from the input matrix.
  */
 template <typename ValueType, typename IndexType>
-void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
-                             const matrix::Csr<ValueType, IndexType>* m,
-                             IndexType rank, array<ValueType>& tmp,
-                             remove_complex<ValueType>& threshold,
-                             matrix::Csr<ValueType, IndexType>* m_out,
-                             matrix::Coo<ValueType, IndexType>* m_out_coo)
+void threshold_filter_approx(
+    std::shared_ptr<const DefaultExecutor> exec,
+    const matrix::Csr<ValueType, IndexType>* m, IndexType rank,
+    array<ValueType>& tmp, remove_complex<ValueType>& threshold,
+    matrix::CsrBuilder<ValueType, IndexType>* m_out_builder,
+    matrix::Coo<ValueType, IndexType>* m_out_coo)
 {
     auto vals = m->get_const_values();
     auto col_idxs = m->get_const_col_idxs();
@@ -221,7 +221,7 @@ void threshold_filter_approx(std::shared_ptr<const DefaultExecutor> exec,
                                      : zero<remove_complex<ValueType>>();
     // filter elements
     abstract_filter(
-        exec, m, m_out, m_out_coo, [&](IndexType row, IndexType nz) {
+        exec, m, m_out_builder, m_out_coo, [&](IndexType row, IndexType nz) {
             return abs(vals[nz]) >= threshold || col_idxs[nz] == row;
         });
 }
@@ -331,8 +331,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
                     const matrix::Csr<ValueType, IndexType>* a,
                     const matrix::Csr<ValueType, IndexType>* l,
                     const matrix::Csr<ValueType, IndexType>* u,
-                    matrix::Csr<ValueType, IndexType>* l_new,
-                    matrix::Csr<ValueType, IndexType>* u_new)
+                    matrix::CsrBuilder<ValueType, IndexType>* l_new_builder,
+                    matrix::CsrBuilder<ValueType, IndexType>* u_new_builder)
 {
     auto num_rows = a->get_size()[0];
     auto l_row_ptrs = l->get_const_row_ptrs();
@@ -341,6 +341,8 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
     auto u_row_ptrs = u->get_const_row_ptrs();
     auto u_col_idxs = u->get_const_col_idxs();
     auto u_vals = u->get_const_values();
+    auto l_new = l_new_builder->get_matrix();
+    auto u_new = u_new_builder->get_matrix();
     auto l_new_row_ptrs = l_new->get_row_ptrs();
     auto u_new_row_ptrs = u_new->get_row_ptrs();
     constexpr auto sentinel = std::numeric_limits<IndexType>::max();
@@ -363,12 +365,10 @@ void add_candidates(std::shared_ptr<const DefaultExecutor> exec,
     u_new_row_ptrs[num_rows] = u_nnz;
 
     // resize arrays
-    matrix::CsrBuilder<ValueType, IndexType> l_builder{l_new};
-    matrix::CsrBuilder<ValueType, IndexType> u_builder{u_new};
-    l_builder.get_col_idx_array().resize_and_reset(l_nnz);
-    l_builder.get_value_array().resize_and_reset(l_nnz);
-    u_builder.get_col_idx_array().resize_and_reset(u_nnz);
-    u_builder.get_value_array().resize_and_reset(u_nnz);
+    l_new_builder->get_col_idx_array().resize_and_reset(l_nnz);
+    l_new_builder->get_value_array().resize_and_reset(l_nnz);
+    u_new_builder->get_col_idx_array().resize_and_reset(u_nnz);
+    u_new_builder->get_value_array().resize_and_reset(u_nnz);
     auto l_new_col_idxs = l_new->get_col_idxs();
     auto l_new_vals = l_new->get_values();
     auto u_new_col_idxs = u_new->get_col_idxs();

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -81,7 +81,8 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
-                   const matrix::csr::spmv_strategy, const IndexType,
+                   const matrix::csr::spmv_strategy,
+                   const IndexType /* max_nnz_per_row */,
                    matrix::view::dense<const MatrixValueType> alpha,
                    const matrix::Csr<MatrixValueType, IndexType>* a,
                    matrix::view::dense<const InputValueType> b,

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -43,6 +43,7 @@ namespace csr {
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void spmv(std::shared_ptr<const ReferenceExecutor> exec,
+          const matrix::csr::spmv_strategy, const IndexType,
           const matrix::Csr<MatrixValueType, IndexType>* a,
           matrix::view::dense<const InputValueType> b,
           matrix::view::dense<OutputValueType> c)
@@ -80,6 +81,7 @@ GKO_INSTANTIATE_FOR_EACH_MIXED_VALUE_AND_INDEX_TYPE(
 template <typename MatrixValueType, typename InputValueType,
           typename OutputValueType, typename IndexType>
 void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
+                   const matrix::csr::spmv_strategy, const IndexType,
                    matrix::view::dense<const MatrixValueType> alpha,
                    const matrix::Csr<MatrixValueType, IndexType>* a,
                    matrix::view::dense<const InputValueType> b,

--- a/reference/matrix/csr_kernels.cpp
+++ b/reference/matrix/csr_kernels.cpp
@@ -198,10 +198,11 @@ template <typename ValueType, typename IndexType>
 void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto num_rows = a->get_size()[0];
 
+    auto c = c_builder->get_matrix();
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
 
@@ -217,9 +218,8 @@ void spgemm(std::shared_ptr<const ReferenceExecutor> exec,
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_col_idxs = c_col_idxs_array.get_data();
@@ -249,12 +249,13 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
                      const matrix::Csr<ValueType, IndexType>* b,
                      matrix::view::dense<const ValueType> beta,
                      const matrix::Csr<ValueType, IndexType>* d,
-                     matrix::Csr<ValueType, IndexType>* c)
+                     matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto num_rows = a->get_size()[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
 
+    auto c = c_builder->get_matrix();
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
 
@@ -271,9 +272,8 @@ void advanced_spgemm(std::shared_ptr<const ReferenceExecutor> exec,
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_col_idxs = c_col_idxs_array.get_data();
@@ -425,12 +425,13 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
             const matrix::Csr<ValueType, IndexType>* a,
             matrix::view::dense<const ValueType> beta,
             const matrix::Csr<ValueType, IndexType>* b,
-            matrix::Csr<ValueType, IndexType>* c)
+            matrix::CsrBuilder<ValueType, IndexType>* c_builder)
 {
     auto num_rows = a->get_size()[0];
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
 
+    auto c = c_builder->get_matrix();
     // first sweep: count nnz for each row
     auto c_row_ptrs = c->get_row_ptrs();
 
@@ -446,9 +447,8 @@ void spgeam(std::shared_ptr<const ReferenceExecutor> exec,
 
     // second sweep: accumulate non-zeros
     auto new_nnz = c_row_ptrs[num_rows];
-    matrix::CsrBuilder<ValueType, IndexType> c_builder{c};
-    auto& c_col_idxs_array = c_builder.get_col_idx_array();
-    auto& c_vals_array = c_builder.get_value_array();
+    auto& c_col_idxs_array = c_builder->get_col_idx_array();
+    auto& c_vals_array = c_builder->get_value_array();
     c_col_idxs_array.resize_and_reset(new_nnz);
     c_vals_array.resize_and_reset(new_nnz);
     auto c_col_idxs = c_col_idxs_array.get_data();

--- a/reference/test/factorization/ic_kernels.cpp
+++ b/reference/test/factorization/ic_kernels.cpp
@@ -120,17 +120,16 @@ TYPED_TEST(Ic, SetStrategy)
 {
     using Csr = typename TestFixture::Csr;
     using factorization_type = typename TestFixture::factorization_type;
-    auto l_strategy = std::make_shared<typename Csr::merge_path>();
+
+    auto l_strategy = gko::matrix::csr::spmv_strategy::merge_path;
 
     auto factory =
         factorization_type::build().with_l_strategy(l_strategy).on(this->ref);
     auto fact = factory->generate(this->mtx_system);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(fact->get_l_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
-    ASSERT_EQ(fact->get_lt_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
+    ASSERT_EQ(fact->get_l_factor()->get_strategy(), l_strategy);
+    ASSERT_EQ(fact->get_lt_factor()->get_strategy(), l_strategy);
 }
 
 

--- a/reference/test/factorization/ilu_kernels.cpp
+++ b/reference/test/factorization/ilu_kernels.cpp
@@ -215,14 +215,13 @@ TYPED_TEST(Ilu, SetLStrategy)
 {
     using Csr = typename TestFixture::Csr;
     using ilu_type = typename TestFixture::ilu_type;
-    auto l_strategy = std::make_shared<typename Csr::classical>();
+    auto l_strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = ilu_type::build().with_l_strategy(l_strategy).on(this->ref);
     auto ilu = factory->generate(this->mtx_small);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(ilu->get_l_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
+    ASSERT_EQ(ilu->get_l_factor()->get_strategy(), l_strategy);
 }
 
 
@@ -230,14 +229,13 @@ TYPED_TEST(Ilu, SetUStrategy)
 {
     using Csr = typename TestFixture::Csr;
     using ilu_type = typename TestFixture::ilu_type;
-    auto u_strategy = std::make_shared<typename Csr::classical>();
+    auto u_strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = ilu_type::build().with_u_strategy(u_strategy).on(this->ref);
     auto ilu = factory->generate(this->mtx_small);
 
     ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
-    ASSERT_EQ(ilu->get_u_factor()->get_strategy()->get_name(),
-              u_strategy->get_name());
+    ASSERT_EQ(ilu->get_u_factor()->get_strategy(), u_strategy);
 }
 
 

--- a/reference/test/factorization/par_ic_kernels.cpp
+++ b/reference/test/factorization/par_ic_kernels.cpp
@@ -147,17 +147,15 @@ TYPED_TEST(ParIc, SetStrategy)
 {
     using Csr = typename TestFixture::Csr;
     using factorization_type = typename TestFixture::factorization_type;
-    auto l_strategy = std::make_shared<typename Csr::merge_path>();
+    auto l_strategy = gko::matrix::csr::spmv_strategy::merge_path;
 
     auto factory =
         factorization_type::build().with_l_strategy(l_strategy).on(this->ref);
     auto fact = factory->generate(this->mtx_system);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(fact->get_l_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
-    ASSERT_EQ(fact->get_lt_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
+    ASSERT_EQ(fact->get_l_factor()->get_strategy(), l_strategy);
+    ASSERT_EQ(fact->get_lt_factor()->get_strategy(), l_strategy);
 }
 
 

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -181,11 +181,13 @@ TYPED_TEST(ParIct, KernelAddCandidates)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
         this->ref, this->mtx_llh.get(), this->mtx_system.get(),
-        this->mtx_l.get(), &builder);
+        this->mtx_l.get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx_l)
+            .get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, this->mtx_l_add_expect, this->tol);

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -227,8 +227,8 @@ TYPED_TEST(ParIct, SetStrategies)
 {
     using Csr = typename TestFixture::Csr;
     using factorization_type = typename TestFixture::factorization_type;
-    auto l_strategy = std::make_shared<typename Csr::merge_path>();
-    auto lt_strategy = std::make_shared<typename Csr::classical>();
+    auto l_strategy = gko::matrix::csr::spmv_strategy::merge_path;
+    auto lt_strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = factorization_type::build()
                        .with_l_strategy(l_strategy)
@@ -237,11 +237,9 @@ TYPED_TEST(ParIct, SetStrategies)
     auto fact = factory->generate(this->mtx_system);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(fact->get_l_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
+    ASSERT_EQ(fact->get_l_factor()->get_strategy(), l_strategy);
     ASSERT_EQ(factory->get_parameters().lt_strategy, lt_strategy);
-    ASSERT_EQ(fact->get_lt_factor()->get_strategy()->get_name(),
-              lt_strategy->get_name());
+    ASSERT_EQ(fact->get_lt_factor()->get_strategy(), lt_strategy);
 }
 
 

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -185,9 +185,7 @@ TYPED_TEST(ParIct, KernelAddCandidates)
     gko::kernels::reference::par_ict_factorization::add_candidates(
         this->ref, this->mtx_llh.get(), this->mtx_system.get(),
         this->mtx_l.get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx_l)
-            .get());
+        gko::matrix::make_builder_unique_ptr(res_mtx_l).get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, this->mtx_l_add_expect, this->tol);

--- a/reference/test/factorization/par_ict_kernels.cpp
+++ b/reference/test/factorization/par_ict_kernels.cpp
@@ -179,11 +179,13 @@ TYPED_TEST(ParIct, KernelAddCandidates)
 {
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
         this->ref, this->mtx_llh.get(), this->mtx_system.get(),
-        this->mtx_l.get(), res_mtx_l.get());
+        this->mtx_l.get(), &builder);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, this->mtx_l_add_expect, this->tol);

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -194,10 +194,13 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsEmpty)
                     gko::array<index_type>{this->ref, {0, 1, 2}},
                     gko::array<index_type>{this->ref, {0, 1, 2, 3}});
     auto empty_mtx = this->empty_csr->clone();
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(empty_mtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, true);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            empty_mtx)
+            .get(),
+        true);
 
     GKO_ASSERT_MTX_NEAR(empty_mtx, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(empty_mtx, expected_mtx);
@@ -216,10 +219,13 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare)
         gko::array<value_type>{this->ref, {0., 1., 0., 1., 1., 1., 1., 1., 1.}},
         gko::array<index_type>{this->ref, {0, 0, 1, 0, 1, 2, 0, 1, 2}},
         gko::array<index_type>{this->ref, {0, 1, 3, 6, 9}});
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(matrix);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, true);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            matrix)
+            .get(),
+        true);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -237,10 +243,13 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare2)
                     gko::array<value_type>{this->ref, {1., 1., 0.}},
                     gko::array<index_type>{this->ref, {0, 0, 1}},
                     gko::array<index_type>{this->ref, {0, 1, 3}});
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(matrix);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, true);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            matrix)
+            .get(),
+        true);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -268,10 +277,13 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsorted)
         gko::array<value_type>{this->ref, {1., 2., 3., 1., 0., 3., 1., 2., 0.}},
         gko::array<index_type>{this->ref, {0, 1, 2, 0, 1, 2, 0, 1, 2}},
         gko::array<index_type>{this->ref, {0, 3, 6, 9}});
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(matrix);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, false);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            matrix)
+            .get(),
+        false);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -308,9 +320,12 @@ TYPED_TEST(ParIlu, KernelInitializeRowPtrsLUZeroMatrix)
     using index_type = typename TestFixture::index_type;
     using Csr = typename TestFixture::Csr;
     auto empty_mtx = this->empty_csr->clone();
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(empty_mtx);
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, true);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            empty_mtx)
+            .get(),
+        true);
     auto empty_mtx_l_expected = Csr::create(this->ref);
     this->identity->convert_to(empty_mtx_l_expected);
     auto empty_mtx_u_expected = Csr::create(this->ref);

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -444,15 +444,14 @@ TYPED_TEST(ParIlu, SetLStrategy)
 {
     using Csr = typename TestFixture::Csr;
     using par_ilu_type = typename TestFixture::par_ilu_type;
-    auto l_strategy = std::make_shared<typename Csr::classical>();
+    auto l_strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         par_ilu_type::build().with_l_strategy(l_strategy).on(this->ref);
     auto par_ilu = factory->generate(this->mtx_small);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(par_ilu->get_l_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
+    ASSERT_EQ(par_ilu->get_l_factor()->get_strategy(), l_strategy);
 }
 
 
@@ -460,15 +459,14 @@ TYPED_TEST(ParIlu, SetUStrategy)
 {
     using Csr = typename TestFixture::Csr;
     using par_ilu_type = typename TestFixture::par_ilu_type;
-    auto u_strategy = std::make_shared<typename Csr::classical>();
+    auto u_strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory =
         par_ilu_type::build().with_u_strategy(u_strategy).on(this->ref);
     auto par_ilu = factory->generate(this->mtx_small);
 
     ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
-    ASSERT_EQ(par_ilu->get_u_factor()->get_strategy()->get_name(),
-              u_strategy->get_name());
+    ASSERT_EQ(par_ilu->get_u_factor()->get_strategy(), u_strategy);
 }
 
 

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -196,11 +196,7 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsEmpty)
     auto empty_mtx = this->empty_csr->clone();
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            empty_mtx)
-            .get(),
-        true);
+        this->ref, gko::matrix::make_builder_unique_ptr(empty_mtx).get(), true);
 
     GKO_ASSERT_MTX_NEAR(empty_mtx, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(empty_mtx, expected_mtx);
@@ -221,11 +217,7 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare)
         gko::array<index_type>{this->ref, {0, 1, 3, 6, 9}});
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            matrix)
-            .get(),
-        true);
+        this->ref, gko::matrix::make_builder_unique_ptr(matrix).get(), true);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -245,11 +237,7 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare2)
                     gko::array<index_type>{this->ref, {0, 1, 3}});
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            matrix)
-            .get(),
-        true);
+        this->ref, gko::matrix::make_builder_unique_ptr(matrix).get(), true);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -279,11 +267,7 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsorted)
         gko::array<index_type>{this->ref, {0, 3, 6, 9}});
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            matrix)
-            .get(),
-        false);
+        this->ref, gko::matrix::make_builder_unique_ptr(matrix).get(), false);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -321,11 +305,7 @@ TYPED_TEST(ParIlu, KernelInitializeRowPtrsLUZeroMatrix)
     using Csr = typename TestFixture::Csr;
     auto empty_mtx = this->empty_csr->clone();
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            empty_mtx)
-            .get(),
-        true);
+        this->ref, gko::matrix::make_builder_unique_ptr(empty_mtx).get(), true);
     auto empty_mtx_l_expected = Csr::create(this->ref);
     this->identity->convert_to(empty_mtx_l_expected);
     auto empty_mtx_u_expected = Csr::create(this->ref);

--- a/reference/test/factorization/par_ilu_kernels.cpp
+++ b/reference/test/factorization/par_ilu_kernels.cpp
@@ -194,9 +194,10 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsEmpty)
                     gko::array<index_type>{this->ref, {0, 1, 2}},
                     gko::array<index_type>{this->ref, {0, 1, 2, 3}});
     auto empty_mtx = this->empty_csr->clone();
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(empty_mtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, empty_mtx.get(), true);
+        this->ref, &builder, true);
 
     GKO_ASSERT_MTX_NEAR(empty_mtx, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(empty_mtx, expected_mtx);
@@ -215,9 +216,10 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare)
         gko::array<value_type>{this->ref, {0., 1., 0., 1., 1., 1., 1., 1., 1.}},
         gko::array<index_type>{this->ref, {0, 0, 1, 0, 1, 2, 0, 1, 2}},
         gko::array<index_type>{this->ref, {0, 1, 3, 6, 9}});
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(matrix);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, matrix.get(), true);
+        this->ref, &builder, true);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -235,9 +237,10 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquare2)
                     gko::array<value_type>{this->ref, {1., 1., 0.}},
                     gko::array<index_type>{this->ref, {0, 0, 1}},
                     gko::array<index_type>{this->ref, {0, 1, 3}});
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(matrix);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, matrix.get(), true);
+        this->ref, &builder, true);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -265,9 +268,10 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsorted)
         gko::array<value_type>{this->ref, {1., 2., 3., 1., 0., 3., 1., 2., 0.}},
         gko::array<index_type>{this->ref, {0, 1, 2, 0, 1, 2, 0, 1, 2}},
         gko::array<index_type>{this->ref, {0, 3, 6, 9}});
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(matrix);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, matrix.get(), false);
+        this->ref, &builder, false);
 
     GKO_ASSERT_MTX_NEAR(matrix, expected_mtx, 0.);
     GKO_ASSERT_MTX_EQ_SPARSITY(matrix, expected_mtx);
@@ -300,11 +304,13 @@ TYPED_TEST(ParIlu, KernelInitializeRowPtrsLU)
 
 TYPED_TEST(ParIlu, KernelInitializeRowPtrsLUZeroMatrix)
 {
+    using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Csr = typename TestFixture::Csr;
     auto empty_mtx = this->empty_csr->clone();
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(empty_mtx);
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, empty_mtx.get(), true);
+        this->ref, &builder, true);
     auto empty_mtx_l_expected = Csr::create(this->ref);
     this->identity->convert_to(empty_mtx_l_expected);
     auto empty_mtx_u_expected = Csr::create(this->ref);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -336,12 +336,14 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
-    auto res_mtx_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx);
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx1.get(), 0.0, &res_mtx_builder, null_coo, true);
+        this->ref, this->mtx1.get(), 0.0,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx)
+            .get(),
+        null_coo, true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
     GKO_ASSERT_MTX_NEAR(this->mtx1, res_mtx, 0);
@@ -417,15 +419,16 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCoo)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
-    auto res_mtx_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx);
     auto tmp = gko::array<value_type>{this->ref};
     gko::remove_complex<value_type> threshold{};
     Coo* null_coo = nullptr;
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx1.get(), rank, tmp, threshold, &res_mtx_builder,
+        this->ref, this->mtx1.get(), rank, tmp, threshold,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx)
+            .get(),
         null_coo);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
@@ -471,15 +474,16 @@ TYPED_TEST(ParIlut, KernelAddCandidates)
     using index_type = typename TestFixture::index_type;
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
     auto res_mtx_u = Csr::create(this->exec, this->mtx_system->get_size());
-    auto res_mtx_l_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
-    auto res_mtx_u_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_u);
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
         this->ref, this->mtx_lu.get(), this->mtx_system.get(),
-        this->mtx_l.get(), this->mtx_u.get(), &res_mtx_l_builder,
-        &res_mtx_u_builder);
+        this->mtx_l.get(), this->mtx_u.get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx_l)
+            .get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx_u)
+            .get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, this->mtx_u_add_expect);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -203,6 +203,9 @@ protected:
                      const std::unique_ptr<Mtx>& expected, bool lower)
     {
         auto res_mtx = Mtx::create(exec, mtx->get_size());
+        auto res_mtx_builder =
+            gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                    typename Mtx::index_type>(res_mtx);
         auto res_mtx_coo = Coo::create(exec, mtx->get_size());
 
         auto local_mtx = gko::as<Mtx>(lower ? mtx->clone() : mtx->transpose());
@@ -210,8 +213,8 @@ protected:
             gko::as<Mtx>(lower ? expected->clone() : expected->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, res_mtx.get(), res_mtx_coo.get(),
-            lower);
+            ref, local_mtx.get(), threshold, &res_mtx_builder,
+            res_mtx_coo.get(), lower);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(local_expected, res_mtx);
         GKO_ASSERT_MTX_NEAR(local_expected, res_mtx, 0);
@@ -226,17 +229,23 @@ protected:
                             const std::unique_ptr<Mtx>& expected)
     {
         auto res_mtx = Mtx::create(exec, mtx->get_size());
+        auto res_mtx_builder =
+            gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                    typename Mtx::index_type>(res_mtx);
         auto res_mtx_coo = Coo::create(exec, mtx->get_size());
         auto res_mtx2 = Mtx::create(exec, mtx->get_size());
+        auto res_mtx2_builder =
+            gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                    typename Mtx::index_type>(res_mtx2);
         auto res_mtx_coo2 = Coo::create(exec, mtx->get_size());
 
         auto tmp = gko::array<typename Mtx::value_type>{exec};
         gko::remove_complex<typename Mtx::value_type> threshold{};
         gko::kernels::reference::par_ilut_factorization::
             threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    res_mtx.get(), res_mtx_coo.get());
+                                    &res_mtx_builder, res_mtx_coo.get());
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, mtx.get(), threshold, res_mtx2.get(), res_mtx_coo2.get(),
+            ref, mtx.get(), threshold, &res_mtx2_builder, res_mtx_coo2.get(),
             true);
 
         GKO_ASSERT_MTX_EQ_SPARSITY(expected, res_mtx);
@@ -324,11 +333,15 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
 {
     using Csr = typename TestFixture::Csr;
     using Coo = typename TestFixture::Coo;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
+    auto res_mtx_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx);
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx1.get(), 0.0, res_mtx.get(), null_coo, true);
+        this->ref, this->mtx1.get(), 0.0, &res_mtx_builder, null_coo, true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
     GKO_ASSERT_MTX_NEAR(this->mtx1, res_mtx, 0);
@@ -404,13 +417,15 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCoo)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
+    auto res_mtx_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx);
     auto tmp = gko::array<value_type>{this->ref};
     gko::remove_complex<value_type> threshold{};
     Coo* null_coo = nullptr;
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx1.get(), rank, tmp, threshold, res_mtx.get(),
+        this->ref, this->mtx1.get(), rank, tmp, threshold, &res_mtx_builder,
         null_coo);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
@@ -453,12 +468,18 @@ TYPED_TEST(ParIlut, KernelAddCandidates)
 {
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
     auto res_mtx_u = Csr::create(this->exec, this->mtx_system->get_size());
+    auto res_mtx_l_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
+    auto res_mtx_u_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_u);
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
         this->ref, this->mtx_lu.get(), this->mtx_system.get(),
-        this->mtx_l.get(), this->mtx_u.get(), res_mtx_l.get(), res_mtx_u.get());
+        this->mtx_l.get(), this->mtx_u.get(), &res_mtx_l_builder,
+        &res_mtx_u_builder);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, this->mtx_u_add_expect);

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -310,21 +310,18 @@ TYPED_TEST(ParIlut, KernelThresholdSelectMax)
 
 TYPED_TEST(ParIlut, KernelComplexThresholdSelect)
 {
-    using value_type = typename TestFixture::value_type;
     this->test_select(this->mtx1_complex, 5, sqrt(2), this->tol);
 }
 
 
 TYPED_TEST(ParIlut, KernelComplexThresholdSelectMin)
 {
-    using value_type = typename TestFixture::value_type;
     this->test_select(this->mtx1_complex, 0, 0.1, this->tol);
 }
 
 
 TYPED_TEST(ParIlut, KernelComplexThresholdSelectMax)
 {
-    using value_type = typename TestFixture::value_type;
     this->test_select(this->mtx1_complex, 9, sqrt(9.01), this->tol);
 }
 
@@ -333,8 +330,6 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
 {
     using Csr = typename TestFixture::Csr;
     using Coo = typename TestFixture::Coo;
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     auto res_mtx = Csr::create(this->exec, this->mtx1->get_size());
     Coo* null_coo = nullptr;
 
@@ -464,8 +459,6 @@ TYPED_TEST(ParIlut, KernelComplexThresholdFilterNoneApprox)
 TYPED_TEST(ParIlut, KernelAddCandidates)
 {
     using Csr = typename TestFixture::Csr;
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     auto res_mtx_l = Csr::create(this->exec, this->mtx_system->get_size());
     auto res_mtx_u = Csr::create(this->exec, this->mtx_system->get_size());
 
@@ -486,7 +479,6 @@ TYPED_TEST(ParIlut, KernelComputeLU)
 {
     using Csr = typename TestFixture::Csr;
     using Coo = typename TestFixture::Coo;
-    using value_type = typename TestFixture::value_type;
     auto mtx_l_coo = Coo::create(this->exec, this->mtx_system->get_size());
     this->mtx_l_system->convert_to(mtx_l_coo);
     auto mtx_u_transp = this->mtx_u_system->transpose();

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -512,8 +512,8 @@ TYPED_TEST(ParIlut, SetStrategies)
 {
     using Csr = typename TestFixture::Csr;
     using factorization_type = typename TestFixture::factorization_type;
-    auto l_strategy = std::make_shared<typename Csr::merge_path>();
-    auto u_strategy = std::make_shared<typename Csr::classical>();
+    auto l_strategy = gko::matrix::csr::spmv_strategy::merge_path;
+    auto u_strategy = gko::matrix::csr::spmv_strategy::classical;
 
     auto factory = factorization_type::build()
                        .with_l_strategy(l_strategy)
@@ -522,11 +522,9 @@ TYPED_TEST(ParIlut, SetStrategies)
     auto fact = factory->generate(this->mtx_system);
 
     ASSERT_EQ(factory->get_parameters().l_strategy, l_strategy);
-    ASSERT_EQ(fact->get_l_factor()->get_strategy()->get_name(),
-              l_strategy->get_name());
+    ASSERT_EQ(fact->get_l_factor()->get_strategy(), l_strategy);
     ASSERT_EQ(factory->get_parameters().u_strategy, u_strategy);
-    ASSERT_EQ(fact->get_u_factor()->get_strategy()->get_name(),
-              u_strategy->get_name());
+    ASSERT_EQ(fact->get_u_factor()->get_strategy(), u_strategy);
 }
 
 

--- a/reference/test/factorization/par_ilut_kernels.cpp
+++ b/reference/test/factorization/par_ilut_kernels.cpp
@@ -340,10 +340,7 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCoo)
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
         this->ref, this->mtx1.get(), 0.0,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx)
-            .get(),
-        null_coo, true);
+        gko::matrix::make_builder_unique_ptr(res_mtx).get(), null_coo, true);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
     GKO_ASSERT_MTX_NEAR(this->mtx1, res_mtx, 0);
@@ -426,10 +423,7 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCoo)
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
         this->ref, this->mtx1.get(), rank, tmp, threshold,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx)
-            .get(),
-        null_coo);
+        gko::matrix::make_builder_unique_ptr(res_mtx).get(), null_coo);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(this->mtx1, res_mtx);
     GKO_ASSERT_MTX_NEAR(this->mtx1, res_mtx, 0);
@@ -478,12 +472,8 @@ TYPED_TEST(ParIlut, KernelAddCandidates)
     gko::kernels::reference::par_ilut_factorization::add_candidates(
         this->ref, this->mtx_lu.get(), this->mtx_system.get(),
         this->mtx_l.get(), this->mtx_u.get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx_l)
-            .get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx_u)
-            .get());
+        gko::matrix::make_builder_unique_ptr(res_mtx_l).get(),
+        gko::matrix::make_builder_unique_ptr(res_mtx_u).get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, this->mtx_l_add_expect);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, this->mtx_u_add_expect);

--- a/reference/test/matrix/coo_kernels.cpp
+++ b/reference/test/matrix/coo_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -124,8 +124,8 @@ TYPED_TEST(Coo, ConvertsToCsr)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx->get_executor(), csr_s_merge);
 
@@ -134,8 +134,10 @@ TYPED_TEST(Coo, ConvertsToCsr)
 
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_c.get());
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 
@@ -144,8 +146,8 @@ TYPED_TEST(Coo, MovesToCsr)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx->clone();
@@ -155,8 +157,10 @@ TYPED_TEST(Coo, MovesToCsr)
 
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_c.get());
     this->assert_equal_to_mtx_in_csr_format(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -52,15 +52,16 @@ protected:
 
     Csr()
         : exec(gko::ReferenceExecutor::create()),
+          // load_balance(2)
           mtx(Mtx::create(exec, gko::dim<2>{2, 3}, 4,
-                          std::make_shared<typename Mtx::load_balance>(2))),
+                          gko::matrix::csr::spmv_strategy::load_balance)),
           mtx2(Mtx::create(exec, gko::dim<2>{2, 3}, 5,
-                           std::make_shared<typename Mtx::classical>())),
+                           gko::matrix::csr::spmv_strategy::classical)),
           mtx3_sorted(Mtx::create(exec, gko::dim<2>(3, 3), 7,
-                                  std::make_shared<typename Mtx::classical>())),
+                                  gko::matrix::csr::spmv_strategy::classical)),
           mtx3_unsorted(
               Mtx::create(exec, gko::dim<2>(3, 3), 7,
-                          std::make_shared<typename Mtx::classical>())),
+                          gko::matrix::csr::spmv_strategy::classical)),
           perm3(Perm::create(exec, gko::array<index_type>{exec, {1, 2, 0}})),
           perm3_rev(perm3->compute_inverse()),
           perm2(Perm::create(exec, gko::array<index_type>{exec, {1, 0}})),
@@ -86,7 +87,6 @@ protected:
         value_type* v = m->get_values();
         index_type* c = m->get_col_idxs();
         index_type* r = m->get_row_ptrs();
-        auto* s = m->get_srow();
         /*
          * 1   3   2
          * 0   5   0
@@ -102,7 +102,9 @@ protected:
         v[1] = 3.0;
         v[2] = 2.0;
         v[3] = 5.0;
-        s[0] = 0;
+        // set srow after filling the matrix
+        m->set_strategy(m->get_strategy());
+        // s[0] = 0;
     }
 
     void create_mtx2(Mtx* m)
@@ -1170,7 +1172,7 @@ TYPED_TEST(Csr, ConvertsToPrecision)
     GKO_ASSERT_MTX_NEAR(this->mtx2, res, residual);
     auto first_strategy = this->mtx2->get_strategy();
     auto second_strategy = res->get_strategy();
-    GKO_ASSERT_DYNAMIC_TYPE_EQ(first_strategy, second_strategy);
+    ASSERT_EQ(first_strategy, second_strategy);
 }
 
 
@@ -1196,7 +1198,7 @@ TYPED_TEST(Csr, MovesToPrecision)
     GKO_ASSERT_MTX_NEAR(this->mtx2, res, residual);
     auto first_strategy = this->mtx2->get_strategy();
     auto second_strategy = res->get_strategy();
-    GKO_ASSERT_DYNAMIC_TYPE_EQ(first_strategy, second_strategy);
+    ASSERT_EQ(first_strategy, second_strategy);
 }
 
 
@@ -2379,8 +2381,7 @@ TYPED_TEST(Csr, OutplaceAbsolute)
 
     GKO_ASSERT_MTX_NEAR(
         abs_mtx, l({{1.0, 2.0, 2.0}, {3.0, 5.0, 0.0}, {0.0, 1.0, 1.5}}), 0.0);
-    ASSERT_EQ(mtx->get_strategy()->get_name(),
-              abs_mtx->get_strategy()->get_name());
+    ASSERT_EQ(mtx->get_strategy(), abs_mtx->get_strategy());
 }
 
 
@@ -2674,8 +2675,7 @@ TYPED_TEST(CsrComplex, OutplaceAbsolute)
 
     GKO_ASSERT_MTX_NEAR(
         abs_mtx, l({{1.0, 5.0, 2.0}, {5.0, 1.0, 0.0}, {0.0, 1.5, 2.0}}), 0.0);
-    ASSERT_EQ(mtx->get_strategy()->get_name(),
-              abs_mtx->get_strategy()->get_name());
+    ASSERT_EQ(mtx->get_strategy(), abs_mtx->get_strategy());
 }
 
 

--- a/reference/test/matrix/csr_kernels.cpp
+++ b/reference/test/matrix/csr_kernels.cpp
@@ -52,7 +52,6 @@ protected:
 
     Csr()
         : exec(gko::ReferenceExecutor::create()),
-          // load_balance(2)
           mtx(Mtx::create(exec, gko::dim<2>{2, 3}, 4,
                           gko::matrix::csr::spmv_strategy::load_balance)),
           mtx2(Mtx::create(exec, gko::dim<2>{2, 3}, 5,
@@ -104,7 +103,6 @@ protected:
         v[3] = 5.0;
         // set srow after filling the matrix
         m->set_strategy(m->get_strategy());
-        // s[0] = 0;
     }
 
     void create_mtx2(Mtx* m)

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -1503,8 +1503,8 @@ TYPED_TEST(DenseWithIndexType, ConvertsToCsr)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Csr = typename gko::matrix::Csr<value_type, index_type>;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx4->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx4->get_executor(), csr_s_merge);
 
@@ -1512,9 +1512,11 @@ TYPED_TEST(DenseWithIndexType, ConvertsToCsr)
     this->mtx4->convert_to(csr_mtx_m);
 
     assert_csr_eq_mtx4(csr_mtx_c.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
     GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 
@@ -1523,8 +1525,8 @@ TYPED_TEST(DenseWithIndexType, MovesToCsr)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     using Csr = typename gko::matrix::Csr<value_type, index_type>;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx4->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx4->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx4->clone();
@@ -1533,9 +1535,11 @@ TYPED_TEST(DenseWithIndexType, MovesToCsr)
     mtx_clone->move_to(csr_mtx_m);
 
     assert_csr_eq_mtx4(csr_mtx_c.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
     GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 

--- a/reference/test/matrix/ell_kernels.cpp
+++ b/reference/test/matrix/ell_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -672,8 +672,8 @@ TYPED_TEST(Ell, ConvertsToCsr)
 {
     using Vec = typename TestFixture::Vec;
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
@@ -682,8 +682,10 @@ TYPED_TEST(Ell, ConvertsToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 
@@ -691,8 +693,8 @@ TYPED_TEST(Ell, MovesToCsr)
 {
     using Vec = typename TestFixture::Vec;
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
@@ -701,8 +703,10 @@ TYPED_TEST(Ell, MovesToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 
@@ -710,8 +714,8 @@ TYPED_TEST(Ell, ConvertsWithStrideToCsr)
 {
     using Vec = typename TestFixture::Vec;
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx2->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx2->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx2->clone();
@@ -721,8 +725,10 @@ TYPED_TEST(Ell, ConvertsWithStrideToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 
@@ -730,8 +736,8 @@ TYPED_TEST(Ell, MovesWithStrideToCsr)
 {
     using Vec = typename TestFixture::Vec;
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx2->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx2->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx2->clone();
@@ -741,8 +747,10 @@ TYPED_TEST(Ell, MovesWithStrideToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 

--- a/reference/test/matrix/fbcsr_kernels.cpp
+++ b/reference/test/matrix/fbcsr_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -133,7 +133,7 @@ TYPED_TEST(Fbcsr, AppliesToDenseVector)
     auto yref = Vec::create(this->exec, gko::dim<2>{(gko::size_type)nrows, 1});
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx->get_executor(),
-                               std::make_shared<typename Csr::classical>());
+                               gko::matrix::csr::spmv_strategy::classical);
     this->mtx2->convert_to(csr_mtx);
 
     this->mtx2->apply(x, y);
@@ -342,12 +342,12 @@ TYPED_TEST(Fbcsr, ConvertsToCsr)
 {
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx->get_executor(),
-                               std::make_shared<typename Csr::classical>());
+                               gko::matrix::csr::spmv_strategy::classical);
     this->mtx->convert_to(csr_mtx);
     this->assert_equal_to_mtx(csr_mtx.get());
 
     auto csr_mtx_2 = Csr::create(this->mtx->get_executor(),
-                                 std::make_shared<typename Csr::classical>());
+                                 gko::matrix::csr::spmv_strategy::classical);
     this->ref2mtx->convert_to(csr_mtx_2);
     GKO_ASSERT_MTX_NEAR(csr_mtx_2, this->ref2csrmtx, 0.0);
 }
@@ -357,7 +357,7 @@ TYPED_TEST(Fbcsr, MovesToCsr)
 {
     using Csr = typename TestFixture::Csr;
     auto csr_mtx = Csr::create(this->mtx->get_executor(),
-                               std::make_shared<typename Csr::classical>());
+                               gko::matrix::csr::spmv_strategy::classical);
 
     this->mtx->move_to(csr_mtx);
 
@@ -493,7 +493,7 @@ TYPED_TEST(Fbcsr, SquareMtxIsTransposable)
     using Fbcsr = typename TestFixture::Mtx;
     using Csr = typename TestFixture::Csr;
     auto csrmtxsq =
-        Csr::create(this->exec, std::make_shared<typename Csr::classical>());
+        Csr::create(this->exec, gko::matrix::csr::spmv_strategy::classical);
     this->mtxsq->convert_to(csrmtxsq);
 
     std::unique_ptr<const gko::LinOp> reftmtx = csrmtxsq->transpose();
@@ -510,7 +510,7 @@ TYPED_TEST(Fbcsr, NonSquareMtxIsTransposable)
     using Fbcsr = typename TestFixture::Mtx;
     using Csr = typename TestFixture::Csr;
     auto csrmtx =
-        Csr::create(this->exec, std::make_shared<typename Csr::classical>());
+        Csr::create(this->exec, gko::matrix::csr::spmv_strategy::classical);
     this->mtx2->convert_to(csrmtx);
 
     std::unique_ptr<gko::LinOp> reftmtx = csrmtx->transpose();
@@ -633,7 +633,7 @@ TYPED_TEST(FbcsrComplex, ConvertsComplexToCsr)
     gko::testing::FbcsrSampleComplex<T, index_type> csample(exec);
     std::unique_ptr<const Fbcsr> mtx = csample.generate_fbcsr();
     auto csr_mtx =
-        Csr::create(exec, std::make_shared<typename Csr::classical>());
+        Csr::create(exec, gko::matrix::csr::spmv_strategy::classical);
 
     mtx->convert_to(csr_mtx);
 

--- a/reference/test/matrix/hybrid_kernels.cpp
+++ b/reference/test/matrix/hybrid_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -307,8 +307,8 @@ TYPED_TEST(Hybrid, MovesToDense)
 TYPED_TEST(Hybrid, ConvertsToCsr)
 {
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
@@ -317,16 +317,18 @@ TYPED_TEST(Hybrid, ConvertsToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 
 TYPED_TEST(Hybrid, MovesToCsr)
 {
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx1->clone();
@@ -336,8 +338,10 @@ TYPED_TEST(Hybrid, MovesToCsr)
 
     this->assert_equal_to_mtx(csr_mtx_c.get());
     this->assert_equal_to_mtx(csr_mtx_m.get());
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 

--- a/reference/test/matrix/sellp_kernels.cpp
+++ b/reference/test/matrix/sellp_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -279,8 +279,8 @@ TYPED_TEST(Sellp, MovesToDense)
 TYPED_TEST(Sellp, ConvertsToCsr)
 {
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
 
@@ -293,16 +293,18 @@ TYPED_TEST(Sellp, ConvertsToCsr)
                            {0.0, 5.0, 0.0}}), 0.0);
     // clang-format on
     GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 
 TYPED_TEST(Sellp, MovesToCsr)
 {
     using Csr = typename TestFixture::Csr;
-    auto csr_s_classical = std::make_shared<typename Csr::classical>();
-    auto csr_s_merge = std::make_shared<typename Csr::merge_path>();
+    auto csr_s_classical = gko::matrix::csr::spmv_strategy::classical;
+    auto csr_s_merge = gko::matrix::csr::spmv_strategy::merge_path;
     auto csr_mtx_c = Csr::create(this->mtx1->get_executor(), csr_s_classical);
     auto csr_mtx_m = Csr::create(this->mtx1->get_executor(), csr_s_merge);
     auto mtx_clone = this->mtx1->clone();
@@ -316,8 +318,10 @@ TYPED_TEST(Sellp, MovesToCsr)
                            {0.0, 5.0, 0.0}}), 0.0);
     // clang-format on
     GKO_ASSERT_MTX_NEAR(csr_mtx_c, csr_mtx_m, 0.0);
-    ASSERT_EQ(csr_mtx_c->get_strategy()->get_name(), "classical");
-    ASSERT_EQ(csr_mtx_m->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(csr_mtx_c->get_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+    ASSERT_EQ(csr_mtx_m->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 

--- a/reference/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/reference/test/multigrid/fixed_coarsening_kernels.cpp
@@ -44,9 +44,9 @@ protected:
     FixedCoarsening()
         : exec(gko::ReferenceExecutor::create()),
           mtx(Mtx::create(exec, gko::dim<2>(5, 5), 15,
-                          std::make_shared<typename Mtx::classical>())),
+                          gko::matrix::csr::spmv_strategy::classical)),
           coarse(Mtx::create(exec, gko::dim<2>(3, 3), 5,
-                             std::make_shared<typename Mtx::classical>())),
+                             gko::matrix::csr::spmv_strategy::classical)),
           coarse_rows(exec, {0, 2, 3}),
           gen_coarse_rows(exec, 5),
           fixed_coarsening_factory(MgLevel::build()

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -51,12 +51,11 @@ protected:
                           .with_skip_sorting(true)
                           .on(exec)),
           mtx(Mtx::create(exec, gko::dim<2>(5, 5), 15,
-                          std::make_shared<typename Mtx::classical>())),
-          weight(WeightMtx::create(
-              exec, gko::dim<2>(5, 5), 15,
-              std::make_shared<typename WeightMtx::classical>())),
+                          gko::matrix::csr::spmv_strategy::classical)),
+          weight(WeightMtx::create(exec, gko::dim<2>(5, 5), 15,
+                                   gko::matrix::csr::spmv_strategy::classical)),
           coarse(Mtx::create(exec, gko::dim<2>(2, 2), 4,
-                             std::make_shared<typename Mtx::classical>())),
+                             gko::matrix::csr::spmv_strategy::classical)),
           agg(exec, 5)
     {
         fine_b = gko::initialize<Vec>(

--- a/test/factorization/ic_kernels.cpp
+++ b/test/factorization/ic_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -189,13 +189,15 @@ TEST_F(Ic, SetsCorrectStrategy)
 {
     auto dfact =
         gko::factorization::Ic<>::build()
-            .with_l_strategy(std::make_shared<Csr::merge_path>())
+            .with_l_strategy(gko::matrix::csr::spmv_strategy::merge_path)
             .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
             .on(exec)
             ->generate(dmtx);
 
-    ASSERT_EQ(dfact->get_l_factor()->get_strategy()->get_name(), "merge_path");
-    ASSERT_EQ(dfact->get_lt_factor()->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(dfact->get_l_factor()->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
+    ASSERT_EQ(dfact->get_lt_factor()->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 }
 
 

--- a/test/factorization/ilu_kernels.cpp
+++ b/test/factorization/ilu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -183,22 +183,24 @@ TEST_F(Ilu, SetsCorrectStrategy)
 {
     auto dfact =
         gko::factorization::Ilu<>::build()
-            .with_l_strategy(std::make_shared<Csr::merge_path>())
+            .with_l_strategy(gko::matrix::csr::spmv_strategy::merge_path)
 #ifdef GKO_COMPILING_OMP
-            .with_u_strategy(std::make_shared<Csr::merge_path>())
+            .with_u_strategy(gko::matrix::csr::spmv_strategy::merge_path)
 #else
-            .with_u_strategy(std::make_shared<Csr::load_balance>(exec))
+            .with_u_strategy(gko::matrix::csr::spmv_strategy::load_balance)
 #endif
             .with_algorithm(gko::factorization::incomplete_algorithm::syncfree)
             .on(exec)
             ->generate(dmtx);
 
-    ASSERT_EQ(dfact->get_l_factor()->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(dfact->get_l_factor()->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 #ifdef GKO_COMPILING_OMP
-    ASSERT_EQ(dfact->get_u_factor()->get_strategy()->get_name(), "merge_path");
+    ASSERT_EQ(dfact->get_u_factor()->get_strategy(),
+              gko::matrix::csr::spmv_strategy::merge_path);
 #else
-    ASSERT_EQ(dfact->get_u_factor()->get_strategy()->get_name(),
-              "load_balance");
+    ASSERT_EQ(dfact->get_u_factor()->get_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
 #endif
 }
 

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -120,14 +120,17 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
     dmtx_llh->copy_from(mtx_llh);
     auto res_mtx_l = Csr::create(this->ref, this->mtx_size);
     auto dres_mtx_l = Csr::create(this->exec, this->mtx_size);
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
-    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dres_mtx_l);
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, mtx_llh.get(), this->mtx.get(), this->mtx_l.get(), &builder);
+        this->ref, mtx_llh.get(), this->mtx.get(), this->mtx_l.get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx_l)
+            .get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::add_candidates(
         this->exec, dmtx_llh.get(), this->dmtx.get(), this->dmtx_l.get(),
-        &dbuilder);
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            dres_mtx_l)
+            .get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, dres_mtx_l, r<value_type>::value);

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -100,6 +100,7 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     if (std::is_same_v<gko::remove_complex<value_type>, gko::float16>) {
         // We set the diagonal larger than 1 in half precision to reduce the
         // possibility of resulting inf. It might introduce (a - llh)/diag when
@@ -119,13 +120,14 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
     dmtx_llh->copy_from(mtx_llh);
     auto res_mtx_l = Csr::create(this->ref, this->mtx_size);
     auto dres_mtx_l = Csr::create(this->exec, this->mtx_size);
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
+    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dres_mtx_l);
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
-        this->ref, mtx_llh.get(), this->mtx.get(), this->mtx_l.get(),
-        res_mtx_l.get());
+        this->ref, mtx_llh.get(), this->mtx.get(), this->mtx_l.get(), &builder);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::add_candidates(
         this->exec, dmtx_llh.get(), this->dmtx.get(), this->dmtx_l.get(),
-        dres_mtx_l.get());
+        &dbuilder);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, dres_mtx_l, r<value_type>::value);

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -123,14 +123,10 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
 
     gko::kernels::reference::par_ict_factorization::add_candidates(
         this->ref, mtx_llh.get(), this->mtx.get(), this->mtx_l.get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx_l)
-            .get());
+        gko::matrix::make_builder_unique_ptr(res_mtx_l).get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ict_factorization::add_candidates(
         this->exec, dmtx_llh.get(), this->dmtx.get(), this->dmtx_l.get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            dres_mtx_l)
-            .get());
+        gko::matrix::make_builder_unique_ptr(dres_mtx_l).get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_NEAR(res_mtx_l, dres_mtx_l, r<value_type>::value);

--- a/test/factorization/par_ict_kernels.cpp
+++ b/test/factorization/par_ict_kernels.cpp
@@ -100,7 +100,6 @@ TYPED_TEST(ParIct, KernelAddCandidatesIsEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     if (std::is_same_v<gko::remove_complex<value_type>, gko::float16>) {
         // We set the diagonal larger than 1 in half precision to reduce the
         // possibility of resulting inf. It might introduce (a - llh)/diag when

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -151,8 +151,6 @@ TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsSortedEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     auto mtx = this->template gen_mtx<Csr>(600, 600);
     auto dmtx = gko::clone(this->exec, mtx);
 
@@ -169,8 +167,6 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsSortedEquivalentToRef)
 
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsortedEquivalentToRef)
 {
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     auto mtx = this->gen_unsorted_mtx(600, 600);
     auto dmtx = gko::clone(this->exec, mtx);
 
@@ -188,8 +184,6 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsortedEquivalentToRef)
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquareEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     auto mtx = this->template gen_mtx<Csr>(600, 500);
     auto dmtx = gko::clone(this->exec, mtx);
 

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -45,9 +45,13 @@ protected:
         std::string file_name(gko::matrices::location_ani4_mtx);
         auto input_file = std::ifstream(file_name, std::ios::in);
         auto mtx_temp = gko::read<Csr>(input_file, ref);
-        // Make sure there are diagonal elements present
-        gko::kernels::reference::factorization::add_diagonal_elements(
-            ref, mtx_temp.get(), false);
+        {
+            auto builder =
+                gko::matrix::CsrBuilder<value_type, index_type>(mtx_temp);
+            // Make sure there are diagonal elements present
+            gko::kernels::reference::factorization::add_diagonal_elements(
+                ref, &builder, false);
+        }
         auto dmtx_temp = gko::clone(exec, mtx_temp);
         mtx = gko::give(mtx_temp);
         dmtx = gko::give(dmtx_temp);
@@ -151,13 +155,17 @@ TYPED_TEST_SUITE(ParIlu, gko::test::ValueIndexTypes, PairTypenameNameGenerator);
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsSortedEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto mtx = this->template gen_mtx<Csr>(600, 600);
     auto dmtx = gko::clone(this->exec, mtx);
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(mtx);
+    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dmtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, mtx.get(), true);
+        this->ref, &builder, true);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec, dmtx.get(), true);
+        this->exec, &dbuilder, true);
 
     ASSERT_TRUE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);
@@ -167,13 +175,17 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsSortedEquivalentToRef)
 
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsortedEquivalentToRef)
 {
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto mtx = this->gen_unsorted_mtx(600, 600);
     auto dmtx = gko::clone(this->exec, mtx);
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(mtx);
+    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dmtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, mtx.get(), false);
+        this->ref, &builder, false);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec, dmtx.get(), false);
+        this->exec, &dbuilder, false);
 
     ASSERT_FALSE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);
@@ -184,13 +196,17 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsortedEquivalentToRef)
 TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquareEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto mtx = this->template gen_mtx<Csr>(600, 500);
     auto dmtx = gko::clone(this->exec, mtx);
+    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(mtx);
+    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dmtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, mtx.get(), true);
+        this->ref, &builder, true);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec, dmtx.get(), true);
+        this->exec, &dbuilder, true);
 
     ASSERT_TRUE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -47,11 +47,7 @@ protected:
         auto mtx_temp = gko::read<Csr>(input_file, ref);
         // Make sure there are diagonal elements present
         gko::kernels::reference::factorization::add_diagonal_elements(
-            ref,
-            std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-                mtx_temp)
-                .get(),
-            false);
+            ref, gko::matrix::make_builder_unique_ptr(mtx_temp).get(), false);
         auto dmtx_temp = gko::clone(exec, mtx_temp);
         mtx = gko::give(mtx_temp);
         dmtx = gko::give(dmtx_temp);
@@ -161,15 +157,9 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsSortedEquivalentToRef)
     auto dmtx = gko::clone(this->exec, mtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(mtx)
-            .get(),
-        true);
+        this->ref, gko::matrix::make_builder_unique_ptr(mtx).get(), true);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(dmtx)
-            .get(),
-        true);
+        this->exec, gko::matrix::make_builder_unique_ptr(dmtx).get(), true);
 
     ASSERT_TRUE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);
@@ -185,15 +175,9 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsortedEquivalentToRef)
     auto dmtx = gko::clone(this->exec, mtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(mtx)
-            .get(),
-        false);
+        this->ref, gko::matrix::make_builder_unique_ptr(mtx).get(), false);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(dmtx)
-            .get(),
-        false);
+        this->exec, gko::matrix::make_builder_unique_ptr(dmtx).get(), false);
 
     ASSERT_FALSE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);
@@ -210,15 +194,9 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquareEquivalentToRef)
     auto dmtx = gko::clone(this->exec, mtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(mtx)
-            .get(),
-        true);
+        this->ref, gko::matrix::make_builder_unique_ptr(mtx).get(), true);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(dmtx)
-            .get(),
-        true);
+        this->exec, gko::matrix::make_builder_unique_ptr(dmtx).get(), true);
 
     ASSERT_TRUE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);

--- a/test/factorization/par_ilu_kernels.cpp
+++ b/test/factorization/par_ilu_kernels.cpp
@@ -45,13 +45,13 @@ protected:
         std::string file_name(gko::matrices::location_ani4_mtx);
         auto input_file = std::ifstream(file_name, std::ios::in);
         auto mtx_temp = gko::read<Csr>(input_file, ref);
-        {
-            auto builder =
-                gko::matrix::CsrBuilder<value_type, index_type>(mtx_temp);
-            // Make sure there are diagonal elements present
-            gko::kernels::reference::factorization::add_diagonal_elements(
-                ref, &builder, false);
-        }
+        // Make sure there are diagonal elements present
+        gko::kernels::reference::factorization::add_diagonal_elements(
+            ref,
+            std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+                mtx_temp)
+                .get(),
+            false);
         auto dmtx_temp = gko::clone(exec, mtx_temp);
         mtx = gko::give(mtx_temp);
         dmtx = gko::give(dmtx_temp);
@@ -159,13 +159,17 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsSortedEquivalentToRef)
     using index_type = typename TestFixture::index_type;
     auto mtx = this->template gen_mtx<Csr>(600, 600);
     auto dmtx = gko::clone(this->exec, mtx);
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(mtx);
-    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dmtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, true);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(mtx)
+            .get(),
+        true);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec, &dbuilder, true);
+        this->exec,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(dmtx)
+            .get(),
+        true);
 
     ASSERT_TRUE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);
@@ -179,13 +183,17 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsUnsortedEquivalentToRef)
     using index_type = typename TestFixture::index_type;
     auto mtx = this->gen_unsorted_mtx(600, 600);
     auto dmtx = gko::clone(this->exec, mtx);
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(mtx);
-    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dmtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, false);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(mtx)
+            .get(),
+        false);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec, &dbuilder, false);
+        this->exec,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(dmtx)
+            .get(),
+        false);
 
     ASSERT_FALSE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);
@@ -200,13 +208,17 @@ TYPED_TEST(ParIlu, KernelAddDiagonalElementsNonSquareEquivalentToRef)
     using index_type = typename TestFixture::index_type;
     auto mtx = this->template gen_mtx<Csr>(600, 500);
     auto dmtx = gko::clone(this->exec, mtx);
-    auto builder = gko::matrix::CsrBuilder<value_type, index_type>(mtx);
-    auto dbuilder = gko::matrix::CsrBuilder<value_type, index_type>(dmtx);
 
     gko::kernels::reference::factorization::add_diagonal_elements(
-        this->ref, &builder, true);
+        this->ref,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(mtx)
+            .get(),
+        true);
     gko::kernels::GKO_DEVICE_NAMESPACE::factorization::add_diagonal_elements(
-        this->exec, &dbuilder, true);
+        this->exec,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(dmtx)
+            .get(),
+        true);
 
     ASSERT_TRUE(mtx->is_sorted_by_column_index());
     GKO_ASSERT_MTX_NEAR(mtx, dmtx, 0.);

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -162,18 +162,12 @@ protected:
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
             ref, local_mtx.get(), threshold,
-            std::make_unique<gko::matrix::CsrBuilder<typename Mtx::value_type,
-                                                     typename Mtx::index_type>>(
-                res)
-                .get(),
-            res_coo.get(), lower);
+            gko::matrix::make_builder_unique_ptr(res).get(), res_coo.get(),
+            lower);
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_filter(
-                exec, local_dmtx.get(), threshold,
-                std::make_unique<gko::matrix::CsrBuilder<
-                    typename Mtx::value_type, typename Mtx::index_type>>(dres)
-                    .get(),
-                dres_coo.get(), lower);
+            threshold_filter(exec, local_dmtx.get(), threshold,
+                             gko::matrix::make_builder_unique_ptr(dres).get(),
+                             dres_coo.get(), lower);
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
         GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -205,16 +199,11 @@ protected:
         gko::kernels::reference::par_ilut_factorization::
             threshold_filter_approx(
                 ref, mtx.get(), rank, tmp, threshold,
-                std::make_unique<gko::matrix::CsrBuilder<
-                    typename Mtx::value_type, typename Mtx::index_type>>(res)
-                    .get(),
-                res_coo.get());
+                gko::matrix::make_builder_unique_ptr(res).get(), res_coo.get());
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
             threshold_filter_approx(
                 exec, dmtx.get(), rank, dtmp, dthreshold,
-                std::make_unique<gko::matrix::CsrBuilder<
-                    typename Mtx::value_type, typename Mtx::index_type>>(dres)
-                    .get(),
+                gko::matrix::make_builder_unique_ptr(dres).get(),
                 dres_coo.get());
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
@@ -313,16 +302,11 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCooIsEquivalentToRef)
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
         this->ref, this->mtx_l.get(), 0.5,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(res)
-            .get(),
-        null_coo, true);
+        gko::matrix::make_builder_unique_ptr(res).get(), null_coo, true);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-        threshold_filter(
-            this->exec, this->dmtx_l.get(), 0.5,
-            std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-                dres)
-                .get(),
-            null_coo, true);
+        threshold_filter(this->exec, this->dmtx_l.get(), 0.5,
+                         gko::matrix::make_builder_unique_ptr(dres).get(),
+                         null_coo, true);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -390,16 +374,11 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCooIsEquivalentToRef)
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
         this->ref, this->mtx_l.get(), rank, tmp, threshold,
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(res)
-            .get(),
-        null_coo);
+        gko::matrix::make_builder_unique_ptr(res).get(), null_coo);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
         threshold_filter_approx(
             this->exec, this->dmtx_l.get(), rank, dtmp, dthreshold,
-            std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-                dres)
-                .get(),
-            null_coo);
+            gko::matrix::make_builder_unique_ptr(dres).get(), null_coo);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -484,21 +463,13 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
     gko::kernels::reference::par_ilut_factorization::add_candidates(
         this->ref, mtx_lu.get(), this->mtx_square.get(), this->mtx_l2.get(),
         this->mtx_u.get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx_l)
-            .get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            res_mtx_u)
-            .get());
+        gko::matrix::make_builder_unique_ptr(res_mtx_l).get(),
+        gko::matrix::make_builder_unique_ptr(res_mtx_u).get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::add_candidates(
         this->exec, dmtx_lu.get(), this->dmtx_square.get(), this->dmtx_l2.get(),
         this->dmtx_u.get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            dres_mtx_l)
-            .get(),
-        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
-            dres_mtx_u)
-            .get());
+        gko::matrix::make_builder_unique_ptr(dres_mtx_l).get(),
+        gko::matrix::make_builder_unique_ptr(dres_mtx_u).get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, dres_mtx_u);

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -154,12 +154,6 @@ protected:
     {
         auto res = Mtx::create(ref, mtx_size);
         auto dres = Mtx::create(exec, mtx_size);
-        auto res_builder =
-            gko::matrix::CsrBuilder<typename Mtx::value_type,
-                                    typename Mtx::index_type>(res);
-        auto dres_builder =
-            gko::matrix::CsrBuilder<typename Mtx::value_type,
-                                    typename Mtx::index_type>(dres);
         auto res_coo = Coo::create(ref, mtx_size);
         auto dres_coo = Coo::create(exec, mtx_size);
         auto local_mtx = gko::as<Mtx>(lower ? mtx->clone() : mtx->transpose());
@@ -167,11 +161,19 @@ protected:
             gko::as<Mtx>(lower ? dmtx->clone() : dmtx->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, &res_builder, res_coo.get(),
-            lower);
+            ref, local_mtx.get(), threshold,
+            std::make_unique<gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                                     typename Mtx::index_type>>(
+                res)
+                .get(),
+            res_coo.get(), lower);
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_filter(exec, local_dmtx.get(), threshold, &dres_builder,
-                             dres_coo.get(), lower);
+            threshold_filter(
+                exec, local_dmtx.get(), threshold,
+                std::make_unique<gko::matrix::CsrBuilder<
+                    typename Mtx::value_type, typename Mtx::index_type>>(dres)
+                    .get(),
+                dres_coo.get(), lower);
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
         GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -191,12 +193,6 @@ protected:
             gko::is_complex<value_type>() ? double(r<value_type>::value) : 0.0;
         auto res = Mtx::create(ref, mtx_size);
         auto dres = Mtx::create(exec, mtx_size);
-        auto res_builder =
-            gko::matrix::CsrBuilder<typename Mtx::value_type,
-                                    typename Mtx::index_type>(res);
-        auto dres_builder =
-            gko::matrix::CsrBuilder<typename Mtx::value_type,
-                                    typename Mtx::index_type>(dres);
         auto res_coo = Coo::create(ref, mtx_size);
         auto dres_coo = Coo::create(exec, mtx_size);
         using ValueType = typename Mtx::value_type;
@@ -207,11 +203,19 @@ protected:
         gko::remove_complex<ValueType> dthreshold{};
 
         gko::kernels::reference::par_ilut_factorization::
-            threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    &res_builder, res_coo.get());
+            threshold_filter_approx(
+                ref, mtx.get(), rank, tmp, threshold,
+                std::make_unique<gko::matrix::CsrBuilder<
+                    typename Mtx::value_type, typename Mtx::index_type>>(res)
+                    .get(),
+                res_coo.get());
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_filter_approx(exec, dmtx.get(), rank, dtmp, dthreshold,
-                                    &dres_builder, dres_coo.get());
+            threshold_filter_approx(
+                exec, dmtx.get(), rank, dtmp, dthreshold,
+                std::make_unique<gko::matrix::CsrBuilder<
+                    typename Mtx::value_type, typename Mtx::index_type>>(dres)
+                    .get(),
+                dres_coo.get());
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
         GKO_ASSERT_MTX_NEAR(res, res_coo, 0);
@@ -305,15 +309,20 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCooIsEquivalentToRef)
     using index_type = typename TestFixture::index_type;
     auto res = Csr::create(this->ref, this->mtx_size);
     auto dres = Csr::create(this->exec, this->mtx_size);
-    auto res_builder = gko::matrix::CsrBuilder<value_type, index_type>(res);
-    auto dres_builder = gko::matrix::CsrBuilder<value_type, index_type>(dres);
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx_l.get(), 0.5, &res_builder, null_coo, true);
+        this->ref, this->mtx_l.get(), 0.5,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(res)
+            .get(),
+        null_coo, true);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-        threshold_filter(this->exec, this->dmtx_l.get(), 0.5, &dres_builder,
-                         null_coo, true);
+        threshold_filter(
+            this->exec, this->dmtx_l.get(), 0.5,
+            std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+                dres)
+                .get(),
+            null_coo, true);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -372,8 +381,6 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCooIsEquivalentToRef)
     this->test_filter(this->mtx_l, this->dmtx_l, 0.5, true);
     auto res = Csr::create(this->ref, this->mtx_size);
     auto dres = Csr::create(this->exec, this->mtx_size);
-    auto res_builder = gko::matrix::CsrBuilder<value_type, index_type>(res);
-    auto dres_builder = gko::matrix::CsrBuilder<value_type, index_type>(dres);
     Coo* null_coo = nullptr;
     gko::array<value_type> tmp(this->ref);
     gko::array<value_type> dtmp(this->exec);
@@ -382,11 +389,17 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCooIsEquivalentToRef)
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx_l.get(), rank, tmp, threshold, &res_builder,
+        this->ref, this->mtx_l.get(), rank, tmp, threshold,
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(res)
+            .get(),
         null_coo);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-        threshold_filter_approx(this->exec, this->dmtx_l.get(), rank, dtmp,
-                                dthreshold, &dres_builder, null_coo);
+        threshold_filter_approx(
+            this->exec, this->dmtx_l.get(), rank, dtmp, dthreshold,
+            std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+                dres)
+                .get(),
+            null_coo);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -467,21 +480,25 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
     auto res_mtx_u = Csr::create(this->ref, square_size);
     auto dres_mtx_l = Csr::create(this->exec, square_size);
     auto dres_mtx_u = Csr::create(this->exec, square_size);
-    auto res_mtx_l_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
-    auto dres_mtx_l_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(dres_mtx_l);
-    auto res_mtx_u_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_u);
-    auto dres_mtx_u_builder =
-        gko::matrix::CsrBuilder<value_type, index_type>(dres_mtx_u);
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
         this->ref, mtx_lu.get(), this->mtx_square.get(), this->mtx_l2.get(),
-        this->mtx_u.get(), &res_mtx_l_builder, &res_mtx_u_builder);
+        this->mtx_u.get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx_l)
+            .get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            res_mtx_u)
+            .get());
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::add_candidates(
         this->exec, dmtx_lu.get(), this->dmtx_square.get(), this->dmtx_l2.get(),
-        this->dmtx_u.get(), &dres_mtx_l_builder, &dres_mtx_u_builder);
+        this->dmtx_u.get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            dres_mtx_l)
+            .get(),
+        std::make_unique<gko::matrix::CsrBuilder<value_type, index_type>>(
+            dres_mtx_u)
+            .get());
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, dres_mtx_u);

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -294,8 +294,6 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCooIsEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
     using Coo = typename TestFixture::Coo;
-    using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     auto res = Csr::create(this->ref, this->mtx_size);
     auto dres = Csr::create(this->exec, this->mtx_size);
     Coo* null_coo = nullptr;
@@ -437,7 +435,6 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
-    using index_type = typename TestFixture::index_type;
     if (std::is_same_v<gko::remove_complex<value_type>, gko::float16>) {
         // We set the diagonal larger than 1 in half precision to reduce the
         // possibility of resulting inf. It might introduce (a - lu)/u_diag when

--- a/test/factorization/par_ilut_kernels.cpp
+++ b/test/factorization/par_ilut_kernels.cpp
@@ -154,6 +154,12 @@ protected:
     {
         auto res = Mtx::create(ref, mtx_size);
         auto dres = Mtx::create(exec, mtx_size);
+        auto res_builder =
+            gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                    typename Mtx::index_type>(res);
+        auto dres_builder =
+            gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                    typename Mtx::index_type>(dres);
         auto res_coo = Coo::create(ref, mtx_size);
         auto dres_coo = Coo::create(exec, mtx_size);
         auto local_mtx = gko::as<Mtx>(lower ? mtx->clone() : mtx->transpose());
@@ -161,9 +167,10 @@ protected:
             gko::as<Mtx>(lower ? dmtx->clone() : dmtx->transpose());
 
         gko::kernels::reference::par_ilut_factorization::threshold_filter(
-            ref, local_mtx.get(), threshold, res.get(), res_coo.get(), lower);
+            ref, local_mtx.get(), threshold, &res_builder, res_coo.get(),
+            lower);
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-            threshold_filter(exec, local_dmtx.get(), threshold, dres.get(),
+            threshold_filter(exec, local_dmtx.get(), threshold, &dres_builder,
                              dres_coo.get(), lower);
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
@@ -184,6 +191,12 @@ protected:
             gko::is_complex<value_type>() ? double(r<value_type>::value) : 0.0;
         auto res = Mtx::create(ref, mtx_size);
         auto dres = Mtx::create(exec, mtx_size);
+        auto res_builder =
+            gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                    typename Mtx::index_type>(res);
+        auto dres_builder =
+            gko::matrix::CsrBuilder<typename Mtx::value_type,
+                                    typename Mtx::index_type>(dres);
         auto res_coo = Coo::create(ref, mtx_size);
         auto dres_coo = Coo::create(exec, mtx_size);
         using ValueType = typename Mtx::value_type;
@@ -195,10 +208,10 @@ protected:
 
         gko::kernels::reference::par_ilut_factorization::
             threshold_filter_approx(ref, mtx.get(), rank, tmp, threshold,
-                                    res.get(), res_coo.get());
+                                    &res_builder, res_coo.get());
         gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
             threshold_filter_approx(exec, dmtx.get(), rank, dtmp, dthreshold,
-                                    dres.get(), dres_coo.get());
+                                    &dres_builder, dres_coo.get());
 
         GKO_ASSERT_MTX_NEAR(res, dres, 0);
         GKO_ASSERT_MTX_NEAR(res, res_coo, 0);
@@ -288,14 +301,18 @@ TYPED_TEST(ParIlut, KernelThresholdFilterNullptrCooIsEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
     using Coo = typename TestFixture::Coo;
+    using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     auto res = Csr::create(this->ref, this->mtx_size);
     auto dres = Csr::create(this->exec, this->mtx_size);
+    auto res_builder = gko::matrix::CsrBuilder<value_type, index_type>(res);
+    auto dres_builder = gko::matrix::CsrBuilder<value_type, index_type>(dres);
     Coo* null_coo = nullptr;
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter(
-        this->ref, this->mtx_l.get(), 0.5, res.get(), null_coo, true);
+        this->ref, this->mtx_l.get(), 0.5, &res_builder, null_coo, true);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
-        threshold_filter(this->exec, this->dmtx_l.get(), 0.5, dres.get(),
+        threshold_filter(this->exec, this->dmtx_l.get(), 0.5, &dres_builder,
                          null_coo, true);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
@@ -355,6 +372,8 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCooIsEquivalentToRef)
     this->test_filter(this->mtx_l, this->dmtx_l, 0.5, true);
     auto res = Csr::create(this->ref, this->mtx_size);
     auto dres = Csr::create(this->exec, this->mtx_size);
+    auto res_builder = gko::matrix::CsrBuilder<value_type, index_type>(res);
+    auto dres_builder = gko::matrix::CsrBuilder<value_type, index_type>(dres);
     Coo* null_coo = nullptr;
     gko::array<value_type> tmp(this->ref);
     gko::array<value_type> dtmp(this->exec);
@@ -363,11 +382,11 @@ TYPED_TEST(ParIlut, KernelThresholdFilterApproxNullptrCooIsEquivalentToRef)
     index_type rank{};
 
     gko::kernels::reference::par_ilut_factorization::threshold_filter_approx(
-        this->ref, this->mtx_l.get(), rank, tmp, threshold, res.get(),
+        this->ref, this->mtx_l.get(), rank, tmp, threshold, &res_builder,
         null_coo);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::
         threshold_filter_approx(this->exec, this->dmtx_l.get(), rank, dtmp,
-                                dthreshold, dres.get(), null_coo);
+                                dthreshold, &dres_builder, null_coo);
 
     GKO_ASSERT_MTX_NEAR(res, dres, 0);
     GKO_ASSERT_MTX_EQ_SPARSITY(res, dres);
@@ -426,6 +445,7 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
 {
     using Csr = typename TestFixture::Csr;
     using value_type = typename TestFixture::value_type;
+    using index_type = typename TestFixture::index_type;
     if (std::is_same_v<gko::remove_complex<value_type>, gko::float16>) {
         // We set the diagonal larger than 1 in half precision to reduce the
         // possibility of resulting inf. It might introduce (a - lu)/u_diag when
@@ -447,13 +467,21 @@ TYPED_TEST(ParIlut, KernelAddCandidatesIsEquivalentToRef)
     auto res_mtx_u = Csr::create(this->ref, square_size);
     auto dres_mtx_l = Csr::create(this->exec, square_size);
     auto dres_mtx_u = Csr::create(this->exec, square_size);
+    auto res_mtx_l_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_l);
+    auto dres_mtx_l_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(dres_mtx_l);
+    auto res_mtx_u_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(res_mtx_u);
+    auto dres_mtx_u_builder =
+        gko::matrix::CsrBuilder<value_type, index_type>(dres_mtx_u);
 
     gko::kernels::reference::par_ilut_factorization::add_candidates(
         this->ref, mtx_lu.get(), this->mtx_square.get(), this->mtx_l2.get(),
-        this->mtx_u.get(), res_mtx_l.get(), res_mtx_u.get());
+        this->mtx_u.get(), &res_mtx_l_builder, &res_mtx_u_builder);
     gko::kernels::GKO_DEVICE_NAMESPACE::par_ilut_factorization::add_candidates(
         this->exec, dmtx_lu.get(), this->dmtx_square.get(), this->dmtx_l2.get(),
-        this->dmtx_u.get(), dres_mtx_l.get(), dres_mtx_u.get());
+        this->dmtx_u.get(), &dres_mtx_l_builder, &dres_mtx_u_builder);
 
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_l, dres_mtx_l);
     GKO_ASSERT_MTX_EQ_SPARSITY(res_mtx_u, dres_mtx_u);

--- a/test/matrix/CMakeLists.txt
+++ b/test/matrix/CMakeLists.txt
@@ -1,6 +1,8 @@
 ginkgo_create_common_test(batch_csr_kernels)
 ginkgo_create_common_test(batch_dense_kernels)
 ginkgo_create_common_test(batch_ell_kernels)
+# omp does not have load balance, so we do not have srow to test
+ginkgo_create_common_test(csr_builder DISABLE_EXECUTORS omp)
 ginkgo_create_common_device_test(csr_kernels)
 ginkgo_create_common_test(csr_kernels2)
 ginkgo_create_common_test(coo_kernels)

--- a/test/matrix/csr_builder.cpp
+++ b/test/matrix/csr_builder.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "core/matrix/csr_builder.hpp"
+
+#include <random>
+
+#include <gtest/gtest.h>
+
+#include <ginkgo/core/base/exception.hpp>
+#include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/matrix/csr.hpp>
+
+#include "core/test/utils.hpp"
+#include "core/test/utils/assertions.hpp"
+#include "core/utils/matrix_utils.hpp"
+#include "test/utils/common_fixture.hpp"
+
+
+class CsrBuilder : public CommonTestFixture {
+protected:
+    using Arr = gko::array<index_type>;
+    using Vec = gko::matrix::Dense<value_type>;
+    using Mtx = gko::matrix::Csr<value_type>;
+
+    CsrBuilder()
+#ifdef GINKGO_FAST_TESTS
+        : mtx_size(152, 231),
+#else
+        : mtx_size(532, 231),
+#endif
+          rand_engine(42)
+    {}
+
+    template <typename MtxType>
+    std::unique_ptr<MtxType> gen_mtx(int num_rows, int num_cols,
+                                     int min_nnz_row, int max_nnz_row)
+    {
+        return gko::test::generate_random_matrix<MtxType>(
+            num_rows, num_cols,
+            std::uniform_int_distribution<>(min_nnz_row, max_nnz_row),
+            std::normal_distribution<value_type>(-1.0, 1.0), rand_engine, ref);
+    }
+
+    template <typename MtxType>
+    std::unique_ptr<MtxType> gen_mtx(int num_rows, int num_cols,
+                                     int min_nnz_row)
+    {
+        return gen_mtx<MtxType>(num_rows, num_cols, min_nnz_row, num_cols);
+    }
+
+    const gko::dim<2> mtx_size;
+    std::default_random_engine rand_engine;
+};
+
+
+TEST_F(CsrBuilder, SrowIsCorrectFromLoadBalance)
+{
+    auto mtx = Mtx::create(exec, gko::matrix::csr::spmv_strategy::load_balance);
+    mtx->move_from(gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 1));
+    int warp_size = 0;
+    if (auto dexec = std::dynamic_pointer_cast<const gko::CudaExecutor>(exec)) {
+        warp_size = dexec->get_warp_size();
+    } else if (auto dexec =
+                   std::dynamic_pointer_cast<const gko::HipExecutor>(exec)) {
+        warp_size = dexec->get_warp_size();
+    } else if (auto dexec =
+                   std::dynamic_pointer_cast<const gko::DpcppExecutor>(exec)) {
+        warp_size = 32;
+    }
+    const auto srow_size = mtx->get_num_srow_elements();
+    auto srow_view = gko::make_array_view(exec, srow_size, mtx->get_srow());
+    Arr original_srow(exec);
+    // keep the original srow as answer
+    original_srow = srow_view;
+    std::vector<index_type> changed_srow(srow_size, -1);
+    Arr changed_srow_view(ref, changed_srow.begin(), changed_srow.end());
+    // modify srow to -1
+    srow_view = changed_srow_view;
+
+    ASSERT_NE(original_srow.get_data(), mtx->get_srow());
+    GKO_ASSERT_ARRAY_EQ(srow_view, changed_srow_view);
+    // after CsrBuilder destructor, it should rebuild srow to original one
+    gko::matrix::CsrBuilder<value_type, index_type>{mtx};
+    GKO_ASSERT_ARRAY_EQ(srow_view, original_srow);
+}

--- a/test/matrix/csr_builder.cpp
+++ b/test/matrix/csr_builder.cpp
@@ -57,18 +57,9 @@ protected:
 
 TEST_F(CsrBuilder, SrowIsCorrectFromLoadBalance)
 {
-    auto mtx = Mtx::create(exec, gko::matrix::csr::spmv_strategy::load_balance);
+    auto mtx = Mtx::create(exec);
     mtx->move_from(gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 1));
-    int warp_size = 0;
-    if (auto dexec = std::dynamic_pointer_cast<const gko::CudaExecutor>(exec)) {
-        warp_size = dexec->get_warp_size();
-    } else if (auto dexec =
-                   std::dynamic_pointer_cast<const gko::HipExecutor>(exec)) {
-        warp_size = dexec->get_warp_size();
-    } else if (auto dexec =
-                   std::dynamic_pointer_cast<const gko::DpcppExecutor>(exec)) {
-        warp_size = 32;
-    }
+    mtx->set_strategy(gko::matrix::csr::spmv_strategy::load_balance);
     const auto srow_size = mtx->get_num_srow_elements();
     auto srow_view = gko::make_array_view(exec, srow_size, mtx->get_srow());
     Arr original_srow(exec);

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -467,15 +467,35 @@ TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
     auto load_balance_mtx =
         gen_mtx<Mtx>(1, row_len_limit + 1000, row_len_limit + 1);
     auto classical_mtx = gen_mtx<Mtx>(50, 50, 1);
+    auto get_max_nnz_per_row = [](gko::size_type num_rows, auto row_ptrs) {
+        int64_t max_row_nnz = 0;
+        for (gko::size_type i = 0; i < num_rows; i++) {
+            max_row_nnz =
+                std::max(max_row_nnz,
+                         static_cast<int64_t>(row_ptrs[i + 1] - row_ptrs[i]));
+        }
+        return max_row_nnz;
+    };
+    auto load_balance_max_row_nnz =
+        get_max_nnz_per_row(load_balance_mtx->get_size()[0],
+                            load_balance_mtx->get_const_row_ptrs());
+    auto classical_max_row_nnz = get_max_nnz_per_row(
+        classical_mtx->get_size()[0], classical_mtx->get_const_row_ptrs());
     auto load_balance_mtx_d = gko::clone(exec, load_balance_mtx);
     auto classical_mtx_d = gko::clone(exec, classical_mtx);
 
     load_balance_mtx_d->set_strategy(automatical);
     classical_mtx_d->set_strategy(automatical);
 
-    EXPECT_EQ(load_balance_mtx_d->get_actual_strategy(),
+    EXPECT_EQ(gko::matrix::csr::detail::get_actual_strategy(
+                  exec, load_balance_mtx_d->get_strategy(),
+                  load_balance_mtx_d->get_num_stored_elements(),
+                  static_cast<gko::size_type>(load_balance_max_row_nnz)),
               gko::matrix::csr::spmv_strategy::load_balance);
-    EXPECT_EQ(classical_mtx_d->get_actual_strategy(),
+    EXPECT_EQ(gko::matrix::csr::detail::get_actual_strategy(
+                  exec, classical_mtx_d->get_strategy(),
+                  classical_mtx_d->get_num_stored_elements(),
+                  static_cast<gko::size_type>(classical_max_row_nnz)),
               gko::matrix::csr::spmv_strategy::classical);
 }
 

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -447,33 +447,37 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 }
 
 
-// TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
-// {
-//     auto automatical =gko::matrix::csr::spmv_strategy::automatical;
-// #ifdef GKO_COMPILING_CUDA
-//     auto row_len_limit = automatical->nvidia_row_len_limit;
-// #elif defined(GKO_COMPILING_HIP)
-//     auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
-//                                   automatical->amd_row_len_limit);
-// #else
-//     auto row_len_limit = automatical->intel_row_len_limit;
-// #endif
-//     auto load_balance_mtx =
-//         gen_mtx<Mtx>(1, row_len_limit + 1000, row_len_limit + 1);
-//     auto classical_mtx = gen_mtx<Mtx>(50, 50, 1);
-//     auto load_balance_mtx_d = gko::clone(exec, load_balance_mtx);
-//     auto classical_mtx_d = gko::clone(exec, classical_mtx);
+TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
+{
+    if (std::dynamic_pointer_cast<const gko::OmpExecutor>(exec)) {
+        GTEST_SKIP() << "Csr does not have load balance under automatical on "
+                        "OmpExecutor";
+    }
+    auto automatical = gko::matrix::csr::spmv_strategy::automatical;
+#ifdef GKO_COMPILING_CUDA
+    int64_t nnz_limit = 1e6;
+    int64_t row_len_limit = 1024;
+#elif defined(GKO_COMPILING_HIP)
+    int64_t nnz_limit = 1e8;
+    int64_t row_len_limit = 768;
+#else  // INTEL
+    int64_t nnz_limit = 3e8;
+    int64_t row_len_limit = 25600;
+#endif
+    auto load_balance_mtx =
+        gen_mtx<Mtx>(1, row_len_limit + 1000, row_len_limit + 1);
+    auto classical_mtx = gen_mtx<Mtx>(50, 50, 1);
+    auto load_balance_mtx_d = gko::clone(exec, load_balance_mtx);
+    auto classical_mtx_d = gko::clone(exec, classical_mtx);
 
-//     load_balance_mtx_d->set_strategy(automatical);
-//     classical_mtx_d->set_strategy(automatical);
+    load_balance_mtx_d->set_strategy(automatical);
+    classical_mtx_d->set_strategy(automatical);
 
-//     EXPECT_EQ(load_balance_mtx_d->get_strategy(),
-//               gko::matrix::csr::spmv_strategy::load_balance);
-//     EXPECT_EQ(classical_mtx_d->get_strategy(),
-//               gko::matrix::csr::spmv_strategy::classical);
-//     ASSERT_NE(load_balance_mtx_d->get_strategy(),
-//               classical_mtx_d->get_strategy());
-// }
+    EXPECT_EQ(load_balance_mtx_d->get_actual_strategy(),
+              gko::matrix::csr::spmv_strategy::load_balance);
+    EXPECT_EQ(classical_mtx_d->get_actual_strategy(),
+              gko::matrix::csr::spmv_strategy::classical);
+}
 
 
 #endif

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -206,7 +206,7 @@ TEST_F(Csr, SrowIsCorrectFromLoadBalance)
         auto srow_val = exec->copy_val_to_host(dmtx->get_const_srow() + i);
         if (srow_val > 0) {
             // the number of elements before this row should be less than the
-            // assgined number
+            // assigned number
             ASSERT_LE(exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
                                              srow_val - 1),
                       current);

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -74,49 +74,9 @@ protected:
         dmtx2->copy_from(mtx2);
     }
 
-    template <typename Mtx>
-    void set_up_strategy(std::shared_ptr<typename Mtx::automatical>& strategy)
-    {
-#ifdef GKO_COMPILING_OMP
-        throw std::runtime_error{"We shouldn't be testing this"};
-#else
-        strategy = std::make_shared<typename Mtx::automatical>(exec);
-#endif
-    }
-
-    template <typename Mtx>
-    void set_up_strategy(std::shared_ptr<typename Mtx::sparselib>& strategy)
-    {
-        strategy = std::make_shared<typename Mtx::sparselib>();
-    }
-
-    template <typename Mtx>
-    void set_up_strategy(std::shared_ptr<typename Mtx::load_balance>& strategy)
-    {
-#ifdef GKO_COMPILING_OMP
-        throw std::runtime_error{"We shouldn't be testing this"};
-#else
-        strategy = std::make_shared<typename Mtx::load_balance>(exec);
-#endif
-    }
-
-    template <typename Mtx>
-    void set_up_strategy(std::shared_ptr<typename Mtx::classical>& strategy)
-    {
-        strategy = std::make_shared<typename Mtx::classical>();
-    }
-
-    template <typename Mtx>
-    void set_up_strategy(std::shared_ptr<typename Mtx::merge_path>& strategy)
-    {
-        strategy = std::make_shared<typename Mtx::merge_path>();
-    }
-
-    template <typename StrategyType>
+    template <gko::matrix::csr::spmv_strategy strategy>
     void set_up_apply_data(int num_vectors = 1)
     {
-        std::shared_ptr<StrategyType> strategy;
-        set_up_strategy<Mtx>(strategy);
         mtx = Mtx::create(ref, strategy);
         mtx->move_from(gen_mtx<Vec>(mtx_size[0], mtx_size[1], 1));
         square_mtx = Mtx::create(ref, strategy);
@@ -159,11 +119,9 @@ protected:
             *cpermute_idxs);
     }
 
-    template <typename StrategyType>
+    template <gko::matrix::csr::spmv_strategy strategy>
     void set_up_apply_complex_data()
     {
-        std::shared_ptr<StrategyType> strategy;
-        set_up_strategy<ComplexMtx>(strategy);
         complex_mtx = ComplexMtx::create(ref, strategy);
         complex_mtx->move_from(
             gen_mtx<ComplexVec>(mtx_size[0], mtx_size[1], 1));
@@ -208,16 +166,25 @@ protected:
 
 TEST_F(Csr, StrategyAfterCopyIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::merge_path>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::merge_path>();
 
-    ASSERT_EQ(mtx->get_strategy()->get_name(),
-              dmtx->get_strategy()->get_name());
+    ASSERT_EQ(mtx->get_strategy(), dmtx->get_strategy());
 }
 
+// Reference and Omp does not have srow
+// TEST_F(Csr, SrowIsCorrectFromLoadBalance)
+// {
+//     set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>();
+
+//     if (std::dynamic_pointer_cast<const OmpExecutor>(exec)) {
+//         GTEST_SKIP();
+//     }
+
+// }
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassical)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -228,7 +195,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassical)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassicalUnsorted)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     unsort_mtx();
 
     mtx->apply(y, expected);
@@ -240,7 +207,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassicalUnsorted)
 
 TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithClassical)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     mtx->apply(alpha, y, beta, expected);
     dmtx->apply(dalpha, dy, dbeta, dresult);
@@ -251,7 +218,7 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithClassical)
 
 TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithClassical)
 {
-    set_up_apply_data<Mtx::classical>(3);
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>(3);
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -262,7 +229,7 @@ TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithClassical)
 
 TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithClassical)
 {
-    set_up_apply_data<Mtx::classical>(3);
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>(3);
 
     mtx->apply(alpha, y, beta, expected);
     dmtx->apply(dalpha, dy, dbeta, dresult);
@@ -277,7 +244,7 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithClassical)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithLoadBalance)
 {
-    set_up_apply_data<Mtx::load_balance>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>();
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -288,7 +255,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithLoadBalance)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithLoadBalanceUnsorted)
 {
-    set_up_apply_data<Mtx::load_balance>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>();
     unsort_mtx();
 
     mtx->apply(y, expected);
@@ -300,7 +267,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithLoadBalanceUnsorted)
 
 TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithLoadBalance)
 {
-    set_up_apply_data<Mtx::load_balance>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>();
 
     mtx->apply(alpha, y, beta, expected);
     dmtx->apply(dalpha, dy, dbeta, dresult);
@@ -311,7 +278,7 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithLoadBalance)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithSparselib)
 {
-    set_up_apply_data<Mtx::sparselib>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::sparselib>();
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -322,7 +289,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithSparselib)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithSparselibUnsorted)
 {
-    set_up_apply_data<Mtx::sparselib>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::sparselib>();
     unsort_mtx();
 
     mtx->apply(y, expected);
@@ -334,7 +301,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithSparselibUnsorted)
 
 TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithSparselib)
 {
-    set_up_apply_data<Mtx::sparselib>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::sparselib>();
 
     mtx->apply(alpha, y, beta, expected);
     dmtx->apply(dalpha, dy, dbeta, dresult);
@@ -345,7 +312,7 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithSparselib)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithMergePath)
 {
-    set_up_apply_data<Mtx::merge_path>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::merge_path>();
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -356,7 +323,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithMergePath)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithMergePathUnsorted)
 {
-    set_up_apply_data<Mtx::merge_path>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::merge_path>();
     unsort_mtx();
 
     mtx->apply(y, expected);
@@ -368,7 +335,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithMergePathUnsorted)
 
 TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithMergePath)
 {
-    set_up_apply_data<Mtx::merge_path>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::merge_path>();
 
     mtx->apply(alpha, y, beta, expected);
     dmtx->apply(dalpha, dy, dbeta, dresult);
@@ -379,7 +346,7 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithMergePath)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatical)
 {
-    set_up_apply_data<Mtx::automatical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::automatical>();
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -390,7 +357,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatical)
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomaticalUnsorted)
 {
-    set_up_apply_data<Mtx::automatical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::automatical>();
     unsort_mtx();
 
     mtx->apply(y, expected);
@@ -402,7 +369,7 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomaticalUnsorted)
 
 TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
 {
-    set_up_apply_data<Mtx::load_balance>(3);
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>(3);
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -413,7 +380,7 @@ TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
 
 TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
 {
-    set_up_apply_data<Mtx::load_balance>(3);
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>(3);
 
     mtx->apply(alpha, y, beta, expected);
     dmtx->apply(dalpha, dy, dbeta, dresult);
@@ -424,7 +391,7 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithLoadBalance)
 
 TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 {
-    set_up_apply_data<Mtx::merge_path>(3);
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::merge_path>(3);
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -435,7 +402,7 @@ TEST_F(Csr, SimpleApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 
 TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 {
-    set_up_apply_data<Mtx::merge_path>(3);
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::merge_path>(3);
 
     mtx->apply(alpha, y, beta, expected);
     dmtx->apply(dalpha, dy, dbeta, dresult);
@@ -444,31 +411,33 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 }
 
 
-TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
-{
-    auto automatical = std::make_shared<Mtx::automatical>(exec);
-#ifdef GKO_COMPILING_CUDA
-    auto row_len_limit = automatical->nvidia_row_len_limit;
-#elif defined(GKO_COMPILING_HIP)
-    auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
-                                  automatical->amd_row_len_limit);
-#else
-    auto row_len_limit = automatical->intel_row_len_limit;
-#endif
-    auto load_balance_mtx =
-        gen_mtx<Mtx>(1, row_len_limit + 1000, row_len_limit + 1);
-    auto classical_mtx = gen_mtx<Mtx>(50, 50, 1);
-    auto load_balance_mtx_d = gko::clone(exec, load_balance_mtx);
-    auto classical_mtx_d = gko::clone(exec, classical_mtx);
+// TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
+// {
+//     auto automatical =gko::matrix::csr::spmv_strategy::automatical;
+// #ifdef GKO_COMPILING_CUDA
+//     auto row_len_limit = automatical->nvidia_row_len_limit;
+// #elif defined(GKO_COMPILING_HIP)
+//     auto row_len_limit = std::max(automatical->nvidia_row_len_limit,
+//                                   automatical->amd_row_len_limit);
+// #else
+//     auto row_len_limit = automatical->intel_row_len_limit;
+// #endif
+//     auto load_balance_mtx =
+//         gen_mtx<Mtx>(1, row_len_limit + 1000, row_len_limit + 1);
+//     auto classical_mtx = gen_mtx<Mtx>(50, 50, 1);
+//     auto load_balance_mtx_d = gko::clone(exec, load_balance_mtx);
+//     auto classical_mtx_d = gko::clone(exec, classical_mtx);
 
-    load_balance_mtx_d->set_strategy(automatical);
-    classical_mtx_d->set_strategy(automatical);
+//     load_balance_mtx_d->set_strategy(automatical);
+//     classical_mtx_d->set_strategy(automatical);
 
-    EXPECT_EQ("load_balance", load_balance_mtx_d->get_strategy()->get_name());
-    EXPECT_EQ("classical", classical_mtx_d->get_strategy()->get_name());
-    ASSERT_NE(load_balance_mtx_d->get_strategy().get(),
-              classical_mtx_d->get_strategy().get());
-}
+//     EXPECT_EQ(load_balance_mtx_d->get_strategy(),
+//               gko::matrix::csr::spmv_strategy::load_balance);
+//     EXPECT_EQ(classical_mtx_d->get_strategy(),
+//               gko::matrix::csr::spmv_strategy::classical);
+//     ASSERT_NE(load_balance_mtx_d->get_strategy(),
+//               classical_mtx_d->get_strategy());
+// }
 
 
 #endif
@@ -476,7 +445,7 @@ TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
 
 TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = mtx->transpose();
     auto dtrans = dmtx->transpose();
 
@@ -491,7 +460,7 @@ TEST_F(Csr, AdvancedApplyToCsrMatrixIsEquivalentToRef)
 
 TEST_F(Csr, MultiplyAddIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = gko::as<Mtx>(mtx->transpose());
     auto dtrans = gko::as<Mtx>(dmtx->transpose());
 
@@ -506,7 +475,7 @@ TEST_F(Csr, MultiplyAddIsEquivalentToRef)
 
 TEST_F(Csr, MultiplyAddIsEquivalentToRefCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = gko::as<Mtx>(mtx->transpose());
 
     auto result = mtx->multiply_add(alpha, trans, beta, square_mtx);
@@ -521,7 +490,7 @@ TEST_F(Csr, MultiplyAddIsEquivalentToRefCrossExecutor)
 
 TEST_F(Csr, MultiplyAddReuseCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = gko::as<Mtx>(mtx->transpose());
 
     auto [dresult, _dreuse] =
@@ -537,7 +506,7 @@ TEST_F(Csr, MultiplyAddReuseCrossExecutor)
 
 TEST_F(Csr, MultiplyAddReuseUpdateCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = gko::as<Mtx>(mtx->transpose());
     auto [dresult, dreuse] =
         dmtx->multiply_add_reuse(alpha, trans, beta, square_mtx);
@@ -559,7 +528,7 @@ TEST_F(Csr, MultiplyAddReuseUpdateCrossExecutor)
 
 TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = mtx->transpose();
     auto dtrans = dmtx->transpose();
 
@@ -574,7 +543,7 @@ TEST_F(Csr, SimpleApplyToCsrMatrixIsEquivalentToRef)
 
 TEST_F(Csr, MultiplyIsEquivalentToRefCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = gko::as<Mtx>(mtx->transpose());
 
     auto result = mtx->multiply(trans);
@@ -589,7 +558,7 @@ TEST_F(Csr, MultiplyIsEquivalentToRefCrossExecutor)
 
 TEST_F(Csr, MultiplyWithSparseIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto mtx2 =
         gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 10);
     auto dmtx2 = gko::clone(exec, mtx2);
@@ -605,7 +574,7 @@ TEST_F(Csr, MultiplyWithSparseIsEquivalentToRef)
 
 TEST_F(Csr, MultiplySparseWithSparseIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto mtx1 = gen_mtx<Mtx>(mtx->get_size()[0], mtx->get_size()[1], 0, 10);
     auto mtx2 =
         gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 10);
@@ -623,7 +592,7 @@ TEST_F(Csr, MultiplySparseWithSparseIsEquivalentToRef)
 
 TEST_F(Csr, MultiplyWithEmptyIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto mtx2 =
         gen_mtx<Mtx>(mtx->get_size()[1], square_mtx->get_size()[1], 0, 0);
     auto dmtx2 = gko::clone(exec, mtx2);
@@ -639,7 +608,7 @@ TEST_F(Csr, MultiplyWithEmptyIsEquivalentToRef)
 
 TEST_F(Csr, MultiplyReuseCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = gko::as<Mtx>(mtx->transpose());
 
     auto [dresult, _dreuse] = dmtx->multiply_reuse(trans);
@@ -654,7 +623,7 @@ TEST_F(Csr, MultiplyReuseCrossExecutor)
 
 TEST_F(Csr, MultiplyReuseUpdateCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto trans = gko::as<Mtx>(mtx->transpose());
     auto [dresult, dreuse] = dmtx->multiply_reuse(trans);
     auto expected = mtx->multiply(trans);
@@ -672,7 +641,7 @@ TEST_F(Csr, MultiplyReuseUpdateCrossExecutor)
 
 TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto a = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto b = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto da = gko::clone(exec, a);
@@ -692,7 +661,7 @@ TEST_F(Csr, AdvancedApplyToIdentityMatrixIsEquivalentToRef)
 
 TEST_F(Csr, ScaleAddZeroIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto a = Mtx::create(ref);
     auto b = Mtx::create(ref);
     auto da = gko::clone(exec, a);
@@ -707,7 +676,7 @@ TEST_F(Csr, ScaleAddZeroIsEquivalentToRef)
 
 TEST_F(Csr, ScaleAddIsEquivalentToRefCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto a = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto b = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     auto da = gko::clone(exec, a);
@@ -724,7 +693,7 @@ TEST_F(Csr, ScaleAddIsEquivalentToRefCrossExecutor)
 
 TEST_F(Csr, ScaleAddReuseCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     mtx = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     mtx2 = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     dmtx = gko::clone(exec, mtx);
@@ -742,7 +711,7 @@ TEST_F(Csr, ScaleAddReuseCrossExecutor)
 
 TEST_F(Csr, ScaleAddReuseUpdateCrossExecutor)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     mtx = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     mtx2 = gen_mtx<Mtx>(mtx_size[0], mtx_size[1], 0);
     dmtx = gko::clone(exec, mtx);
@@ -765,7 +734,7 @@ TEST_F(Csr, ScaleAddReuseUpdateCrossExecutor)
 
 TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = gko::clone(exec, complex_b);
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
@@ -780,7 +749,7 @@ TEST_F(Csr, ApplyToComplexIsEquivalentToRef)
 
 TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto complex_b = gen_mtx<ComplexVec>(this->mtx_size[1], 3, 1);
     auto dcomplex_b = gko::clone(exec, complex_b);
     auto complex_x = gen_mtx<ComplexVec>(this->mtx_size[0], 3, 1);
@@ -795,7 +764,7 @@ TEST_F(Csr, AdvancedApplyToComplexIsEquivalentToRef)
 
 TEST_F(Csr, TransposeIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto trans = gko::as<Mtx>(mtx->transpose());
     auto dtrans = gko::as<Mtx>(dmtx->transpose());
@@ -821,7 +790,7 @@ TEST_F(Csr, Transpose64IsEquivalentToRef)
 
 TEST_F(Csr, TransposeReuseIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto [trans, reuse] = mtx->transpose_reuse();
     auto [dtrans, dreuse] = dmtx->transpose_reuse();
@@ -835,7 +804,7 @@ TEST_F(Csr, TransposeReuseIsEquivalentToRef)
 
 TEST_F(Csr, TransposeReuseUpdateIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto [trans, reuse] = mtx->transpose_reuse();
     auto [dtrans, dreuse] = dmtx->transpose_reuse();
     // test that the value permutation works: modify input values
@@ -854,7 +823,7 @@ TEST_F(Csr, TransposeReuse64IsEquivalentToRef)
 {
     SKIP_IF_SINGLE_MODE;
     using Mtx64 = gko::matrix::Csr<value_type, gko::int64>;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto mtx = gen_mtx<Mtx64>(123, 234, 0);
     auto dmtx = gko::clone(exec, mtx);
 
@@ -872,7 +841,7 @@ TEST_F(Csr, TransposeReuse64UpdateIsEquivalentToRef)
 {
     SKIP_IF_SINGLE_MODE;
     using Mtx64 = gko::matrix::Csr<value_type, gko::int64>;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto mtx = gen_mtx<Mtx64>(123, 234, 0);
     auto dmtx = gko::clone(exec, mtx);
     auto [trans, reuse] = mtx->transpose_reuse();
@@ -891,7 +860,7 @@ TEST_F(Csr, TransposeReuse64UpdateIsEquivalentToRef)
 
 TEST_F(Csr, ConjugateTransposeIsEquivalentToRef)
 {
-    set_up_apply_complex_data<ComplexMtx::classical>();
+    set_up_apply_complex_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto trans = gko::as<ComplexMtx>(complex_mtx->conj_transpose());
     auto dtrans = gko::as<ComplexMtx>(dcomplex_mtx->conj_transpose());
@@ -917,7 +886,7 @@ TEST_F(Csr, ConjugateTranspose64IsEquivalentToRef)
 
 TEST_F(Csr, ConvertToDenseIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
@@ -930,7 +899,7 @@ TEST_F(Csr, ConvertToDenseIsEquivalentToRef)
 
 TEST_F(Csr, MoveToDenseIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto dense_mtx = gko::matrix::Dense<value_type>::create(ref);
     auto ddense_mtx = gko::matrix::Dense<value_type>::create(exec);
 
@@ -943,7 +912,7 @@ TEST_F(Csr, MoveToDenseIsEquivalentToRef)
 
 TEST_F(Csr, ConvertToEllIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto ell_mtx = gko::matrix::Ell<value_type>::create(ref);
     auto dell_mtx = gko::matrix::Ell<value_type>::create(exec);
 
@@ -956,7 +925,7 @@ TEST_F(Csr, ConvertToEllIsEquivalentToRef)
 
 TEST_F(Csr, MoveToEllIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto ell_mtx = gko::matrix::Ell<value_type>::create(ref);
     auto dell_mtx = gko::matrix::Ell<value_type>::create(exec);
 
@@ -969,7 +938,7 @@ TEST_F(Csr, MoveToEllIsEquivalentToRef)
 
 TEST_F(Csr, ConvertToSparsityCsrIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(ref);
     auto d_sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(exec);
 
@@ -982,7 +951,7 @@ TEST_F(Csr, ConvertToSparsityCsrIsEquivalentToRef)
 
 TEST_F(Csr, MoveToSparsityCsrIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(ref);
     auto d_sparsity_mtx = gko::matrix::SparsityCsr<value_type>::create(exec);
 
@@ -995,7 +964,7 @@ TEST_F(Csr, MoveToSparsityCsrIsEquivalentToRef)
 
 TEST_F(Csr, ConvertToCooIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto coo_mtx = gko::matrix::Coo<value_type>::create(ref);
     auto dcoo_mtx = gko::matrix::Coo<value_type>::create(exec);
 
@@ -1008,7 +977,7 @@ TEST_F(Csr, ConvertToCooIsEquivalentToRef)
 
 TEST_F(Csr, MoveToCooIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto coo_mtx = gko::matrix::Coo<value_type>::create(ref);
     auto dcoo_mtx = gko::matrix::Coo<value_type>::create(exec);
 
@@ -1021,7 +990,7 @@ TEST_F(Csr, MoveToCooIsEquivalentToRef)
 
 TEST_F(Csr, ConvertToSellpIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto sellp_mtx = gko::matrix::Sellp<value_type>::create(ref);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
@@ -1034,7 +1003,7 @@ TEST_F(Csr, ConvertToSellpIsEquivalentToRef)
 
 TEST_F(Csr, MoveToSellpIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto sellp_mtx = gko::matrix::Sellp<value_type>::create(ref);
     auto dsellp_mtx = gko::matrix::Sellp<value_type>::create(exec);
 
@@ -1060,7 +1029,7 @@ TEST_F(Csr, ConvertsEmptyToSellp)
 TEST_F(Csr, ConvertToHybridIsEquivalentToRef)
 {
     using Hybrid_type = gko::matrix::Hybrid<value_type>;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto hybrid_mtx = Hybrid_type::create(
         ref, std::make_shared<Hybrid_type::column_limit>(2));
     auto dhybrid_mtx = Hybrid_type::create(
@@ -1076,7 +1045,7 @@ TEST_F(Csr, ConvertToHybridIsEquivalentToRef)
 TEST_F(Csr, MoveToHybridIsEquivalentToRef)
 {
     using Hybrid_type = gko::matrix::Hybrid<value_type>;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     auto hybrid_mtx = Hybrid_type::create(
         ref, std::make_shared<Hybrid_type::column_limit>(2));
     auto dhybrid_mtx = Hybrid_type::create(
@@ -1092,7 +1061,7 @@ TEST_F(Csr, MoveToHybridIsEquivalentToRef)
 TEST_F(Csr, IsGenericPermutable)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto mode :
          {permute_mode::none, permute_mode::rows, permute_mode::columns,
@@ -1112,7 +1081,7 @@ TEST_F(Csr, IsGenericPermutable)
 TEST_F(Csr, IsGenericReusePermutable)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto mode :
          {permute_mode::none, permute_mode::rows, permute_mode::columns,
@@ -1135,7 +1104,7 @@ TEST_F(Csr, IsGenericReusePermutable)
 TEST_F(Csr, IsGenericReusePermuteUpdatable)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto mode :
          {permute_mode::none, permute_mode::rows, permute_mode::columns,
@@ -1183,7 +1152,7 @@ TEST_F(Csr, IsColPermutableHypersparse)
 TEST_F(Csr, IsGenericPermutableRectangular)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto mode :
          {permute_mode::rows, permute_mode::columns, permute_mode::inverse_rows,
@@ -1205,7 +1174,7 @@ TEST_F(Csr, IsGenericPermutableRectangular)
 
 TEST_F(Csr, IsNonsymmPermutable)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto invert : {false, true}) {
         SCOPED_TRACE(invert);
@@ -1222,7 +1191,7 @@ TEST_F(Csr, IsNonsymmPermutable)
 TEST_F(Csr, IsNonsymmReusePermutable)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto invert : {false, true}) {
         SCOPED_TRACE(invert);
@@ -1243,7 +1212,7 @@ TEST_F(Csr, IsNonsymmReusePermutable)
 TEST_F(Csr, IsNonsymmReusePermuteUpdatable)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto invert : {false, true}) {
         SCOPED_TRACE(invert);
@@ -1269,7 +1238,7 @@ TEST_F(Csr, IsNonsymmReusePermuteUpdatable)
 TEST_F(Csr, IsGenericScalePermutable)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto mode :
          {permute_mode::none, permute_mode::rows, permute_mode::columns,
@@ -1311,7 +1280,7 @@ TEST_F(Csr, IsColScalePermutableHypersparse)
 TEST_F(Csr, IsGenericScalePermutableRectangular)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto mode :
          {permute_mode::rows, permute_mode::columns, permute_mode::inverse_rows,
@@ -1334,7 +1303,7 @@ TEST_F(Csr, IsGenericScalePermutableRectangular)
 TEST_F(Csr, IsNonsymmScalePermutable)
 {
     using gko::matrix::permute_mode;
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     for (auto invert : {false, true}) {
         SCOPED_TRACE(invert);
@@ -1352,7 +1321,7 @@ TEST_F(Csr, IsNonsymmScalePermutable)
 
 TEST_F(Csr, IsPermutable)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto permuted = gko::as<Mtx>(square_mtx->permute(rpermute_idxs.get()));
     auto dpermuted = gko::as<Mtx>(dsquare_mtx->permute(rpermute_idxs.get()));
@@ -1365,7 +1334,7 @@ TEST_F(Csr, IsPermutable)
 
 TEST_F(Csr, IsInversePermutable)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto permuted =
         gko::as<Mtx>(square_mtx->inverse_permute(rpermute_idxs.get()));
@@ -1380,7 +1349,7 @@ TEST_F(Csr, IsInversePermutable)
 
 TEST_F(Csr, IsRowPermutable)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto r_permute = gko::as<Mtx>(mtx->row_permute(rpermute_idxs.get()));
     auto dr_permute = gko::as<Mtx>(dmtx->row_permute(rpermute_idxs.get()));
@@ -1393,7 +1362,7 @@ TEST_F(Csr, IsRowPermutable)
 
 TEST_F(Csr, IsColPermutable)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto c_permute = gko::as<Mtx>(mtx->column_permute(cpermute_idxs.get()));
     auto dc_permute = gko::as<Mtx>(dmtx->column_permute(cpermute_idxs.get()));
@@ -1406,7 +1375,7 @@ TEST_F(Csr, IsColPermutable)
 
 TEST_F(Csr, IsInverseRowPermutable)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto inverse_r_permute =
         gko::as<Mtx>(mtx->inverse_row_permute(rpermute_idxs.get()));
@@ -1421,7 +1390,7 @@ TEST_F(Csr, IsInverseRowPermutable)
 
 TEST_F(Csr, IsInverseColPermutable)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto inverse_c_permute =
         gko::as<Mtx>(mtx->inverse_column_permute(cpermute_idxs.get()));
@@ -1436,7 +1405,7 @@ TEST_F(Csr, IsInverseColPermutable)
 
 TEST_F(Csr, RecognizeSortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     bool is_sorted_exec{};
     bool is_sorted_ref{};
 
@@ -1449,7 +1418,7 @@ TEST_F(Csr, RecognizeSortedMatrixIsEquivalentToRef)
 
 TEST_F(Csr, RecognizeUnsortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     unsort_mtx();
     bool is_sorted_exec{};
     bool is_sorted_ref{};
@@ -1463,7 +1432,7 @@ TEST_F(Csr, RecognizeUnsortedMatrixIsEquivalentToRef)
 
 TEST_F(Csr, SortSortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     ASSERT_TRUE(dmtx->is_sorted_by_column_index());
 
     mtx->sort_by_column_index();
@@ -1493,7 +1462,7 @@ TEST_F(Csr, SortSortedMatrixIsEquivalentToRef64)
 
 TEST_F(Csr, SortUnsortedMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     unsort_mtx();
     ASSERT_FALSE(dmtx->is_sorted_by_column_index());
 
@@ -1591,7 +1560,7 @@ TEST_F(Csr, SortUnsortedComplexMatrixIsEquivalentToRef64)
 
 TEST_F(Csr, ExtractDiagonalIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto diag = mtx->extract_diagonal();
     auto ddiag = dmtx->extract_diagonal();
@@ -1602,7 +1571,7 @@ TEST_F(Csr, ExtractDiagonalIsEquivalentToRef)
 
 TEST_F(Csr, InplaceAbsoluteMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     mtx->compute_absolute_inplace();
     dmtx->compute_absolute_inplace();
@@ -1613,7 +1582,7 @@ TEST_F(Csr, InplaceAbsoluteMatrixIsEquivalentToRef)
 
 TEST_F(Csr, OutplaceAbsoluteMatrixIsEquivalentToRef)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto abs_mtx = mtx->compute_absolute();
     auto dabs_mtx = dmtx->compute_absolute();
@@ -1624,7 +1593,7 @@ TEST_F(Csr, OutplaceAbsoluteMatrixIsEquivalentToRef)
 
 TEST_F(Csr, InplaceAbsoluteComplexMatrixIsEquivalentToRef)
 {
-    set_up_apply_complex_data<ComplexMtx::classical>();
+    set_up_apply_complex_data<gko::matrix::csr::spmv_strategy::classical>();
 
     complex_mtx->compute_absolute_inplace();
     dcomplex_mtx->compute_absolute_inplace();
@@ -1635,7 +1604,7 @@ TEST_F(Csr, InplaceAbsoluteComplexMatrixIsEquivalentToRef)
 
 TEST_F(Csr, OutplaceAbsoluteComplexMatrixIsEquivalentToRef)
 {
-    set_up_apply_complex_data<ComplexMtx::classical>();
+    set_up_apply_complex_data<gko::matrix::csr::spmv_strategy::classical>();
 
     auto abs_mtx = complex_mtx->compute_absolute();
     auto dabs_mtx = dcomplex_mtx->compute_absolute();
@@ -1836,7 +1805,7 @@ TEST_F(Csr, CanDetectWhenAllDiagonalEntriesArePresent)
 
 TEST_F(Csr, AddScaledIdentityToNonSquare)
 {
-    set_up_apply_data<Mtx::classical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::classical>();
     gko::utils::ensure_all_diagonal_entries(mtx.get());
     dmtx->copy_from(mtx);
 

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -171,16 +171,52 @@ TEST_F(Csr, StrategyAfterCopyIsEquivalentToRef)
     ASSERT_EQ(mtx->get_strategy(), dmtx->get_strategy());
 }
 
-// Reference and Omp does not have srow
-// TEST_F(Csr, SrowIsCorrectFromLoadBalance)
-// {
-//     set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>();
 
-//     if (std::dynamic_pointer_cast<const OmpExecutor>(exec)) {
-//         GTEST_SKIP();
-//     }
+TEST_F(Csr, SrowIsCorrectFromLoadBalance)
+{
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::load_balance>();
 
-// }
+    if (std::dynamic_pointer_cast<const gko::OmpExecutor>(exec)) {
+        GTEST_SKIP() << "Csr does not have load balance on OmpExecutor";
+    }
+    int warp_size = 0;
+    if (auto dexec = std::dynamic_pointer_cast<const gko::CudaExecutor>(exec)) {
+        warp_size = dexec->get_warp_size();
+    } else if (auto dexec =
+                   std::dynamic_pointer_cast<const gko::HipExecutor>(exec)) {
+        warp_size = dexec->get_warp_size();
+    } else if (auto dexec =
+                   std::dynamic_pointer_cast<const gko::DpcppExecutor>(exec)) {
+        warp_size = 32;
+    }
+    const auto srow_size = dmtx->get_num_srow_elements();
+    // group `warp_size` as a unit, num_lines means how many units we need to
+    // handle
+    const auto num_lines =
+        gko::ceildiv(dmtx->get_num_stored_elements(), warp_size);
+    ASSERT_GT(srow_size, 0);
+    // srow (starting rows) should try to distribute these unit
+    // first num_lines % srow_size has one more than avg
+    const auto avg = num_lines / srow_size;
+    index_type current = 0;
+    ASSERT_EQ(exec->copy_val_to_host(dmtx->get_const_srow()), 0);
+    for (int i = 1; i < srow_size; i++) {
+        current += (avg + (i < (num_lines % srow_size))) * warp_size;
+        auto srow_val = exec->copy_val_to_host(dmtx->get_const_srow() + i);
+        if (srow_val > 0) {
+            // the number of elements before this row should be less than the
+            // assgined number
+            ASSERT_LE(exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
+                                             srow_val - 1),
+                      current);
+        }
+        // the starting point should be in this row not the next row.
+        ASSERT_GE(current, exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
+                                                  srow_val));
+        ASSERT_LT(current, exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
+                                                  srow_val + 1));
+    }
+}
 
 TEST_F(Csr, SimpleApplyIsEquivalentToRefWithClassical)
 {

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -381,9 +381,9 @@ TEST_F(Csr, AdvancedApplyIsEquivalentToRefWithMergePath)
 }
 
 
-TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatical)
+TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatic)
 {
-    set_up_apply_data<gko::matrix::csr::spmv_strategy::automatical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::automatic>();
 
     mtx->apply(y, expected);
     dmtx->apply(dy, dresult);
@@ -392,9 +392,9 @@ TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomatical)
 }
 
 
-TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomaticalUnsorted)
+TEST_F(Csr, SimpleApplyIsEquivalentToRefWithAutomaticUnsorted)
 {
-    set_up_apply_data<gko::matrix::csr::spmv_strategy::automatical>();
+    set_up_apply_data<gko::matrix::csr::spmv_strategy::automatic>();
     unsort_mtx();
 
     mtx->apply(y, expected);
@@ -448,13 +448,13 @@ TEST_F(Csr, AdvancedApplyToDenseMatrixIsEquivalentToRefWithMergePath)
 }
 
 
-TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
+TEST_F(Csr, OneAutomaticWorksWithDifferentMatrices)
 {
     if (std::dynamic_pointer_cast<const gko::OmpExecutor>(exec)) {
-        GTEST_SKIP() << "Csr does not have load balance under automatical on "
+        GTEST_SKIP() << "Csr does not have load balance under automatic on "
                         "OmpExecutor";
     }
-    auto automatical = gko::matrix::csr::spmv_strategy::automatical;
+    auto automatic = gko::matrix::csr::spmv_strategy::automatic;
 #ifdef GKO_COMPILING_CUDA
     int64_t nnz_limit = 1e6;
     int64_t row_len_limit = 1024;
@@ -485,8 +485,8 @@ TEST_F(Csr, OneAutomaticalWorksWithDifferentMatrices)
     auto load_balance_mtx_d = gko::clone(exec, load_balance_mtx);
     auto classical_mtx_d = gko::clone(exec, classical_mtx);
 
-    load_balance_mtx_d->set_strategy(automatical);
-    classical_mtx_d->set_strategy(automatical);
+    load_balance_mtx_d->set_strategy(automatic);
+    classical_mtx_d->set_strategy(automatic);
 
     EXPECT_EQ(gko::matrix::csr::detail::get_actual_strategy(
                   exec, load_balance_mtx_d->get_strategy(),

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -23,6 +23,7 @@
 
 #include "core/components/prefix_sum_kernels.hpp"
 #include "core/matrix/csr_kernels.hpp"
+#include "core/matrix/csr_strategy.hpp"
 #include "core/test/utils.hpp"
 #include "core/test/utils/assertions.hpp"
 #include "core/test/utils/unsort_matrix.hpp"

--- a/test/matrix/csr_kernels2.cpp
+++ b/test/matrix/csr_kernels2.cpp
@@ -196,26 +196,22 @@ TEST_F(Csr, SrowIsCorrectFromLoadBalance)
     const auto num_lines =
         gko::ceildiv(dmtx->get_num_stored_elements(), warp_size);
     ASSERT_GT(srow_size, 0);
-    // srow (starting rows) should try to distribute these unit
-    // first num_lines % srow_size has one more than avg
-    const auto avg = num_lines / srow_size;
-    index_type current = 0;
     ASSERT_EQ(exec->copy_val_to_host(dmtx->get_const_srow()), 0);
     for (int i = 1; i < srow_size; i++) {
-        current += (avg + (i < (num_lines % srow_size))) * warp_size;
+        auto start = (i * num_lines / srow_size) * warp_size;
         auto srow_val = exec->copy_val_to_host(dmtx->get_const_srow() + i);
         if (srow_val > 0) {
             // the number of elements before this row should be less than the
             // assigned number
             ASSERT_LE(exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
                                              srow_val - 1),
-                      current);
+                      start);
         }
         // the starting point should be in this row not the next row.
-        ASSERT_GE(current, exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
-                                                  srow_val));
-        ASSERT_LT(current, exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
-                                                  srow_val + 1));
+        ASSERT_GE(start, exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
+                                                srow_val));
+        ASSERT_LT(start, exec->copy_val_to_host(dmtx->get_const_row_ptrs() +
+                                                srow_val + 1));
     }
 }
 

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -124,7 +124,7 @@ struct CsrWithDefaultStrategy : CsrBase {
         CsrBase::assert_empty_state(mtx);
         auto first_strategy = mtx->create_default()->get_strategy();
         auto second_strategy = mtx->get_strategy();
-        GKO_ASSERT_DYNAMIC_TYPE_EQ(first_strategy, second_strategy);
+        ASSERT_EQ(first_strategy, second_strategy);
     }
 };
 
@@ -138,20 +138,20 @@ struct CsrWithClassicalStrategy : CsrBase {
         std::shared_ptr<gko::Executor> exec, gko::dim<2> size)
     {
         return matrix_type::create(exec, size, 0,
-                                   std::make_shared<matrix_type::classical>());
+                                   gko::matrix::csr::spmv_strategy::classical);
     }
 
     static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
-        ASSERT_TRUE(dynamic_cast<const matrix_type::classical*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::classical);
     }
 
     static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
-        ASSERT_TRUE(dynamic_cast<const matrix_type::classical*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::classical);
     }
 };
 
@@ -160,20 +160,20 @@ struct CsrWithMergePathStrategy : CsrBase {
         std::shared_ptr<gko::Executor> exec, gko::dim<2> size)
     {
         return matrix_type::create(exec, size, 0,
-                                   std::make_shared<matrix_type::merge_path>());
+                                   gko::matrix::csr::spmv_strategy::merge_path);
     }
 
     static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
-        ASSERT_TRUE(dynamic_cast<const matrix_type::merge_path*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::merge_path);
     }
 
     static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
-        ASSERT_TRUE(dynamic_cast<const matrix_type::merge_path*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::merge_path);
     }
 };
 
@@ -190,20 +190,20 @@ struct CsrWithSparselibStrategy : CsrBase {
         std::shared_ptr<gko::Executor> exec, gko::dim<2> size)
     {
         return matrix_type::create(exec, size, 0,
-                                   std::make_shared<matrix_type::sparselib>());
+                                   gko::matrix::csr::spmv_strategy::sparselib);
     }
 
     static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
-        ASSERT_TRUE(dynamic_cast<const matrix_type::sparselib*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::sparselib);
     }
 
     static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
-        ASSERT_TRUE(dynamic_cast<const matrix_type::sparselib*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::sparselib);
     }
 };
 
@@ -211,22 +211,21 @@ struct CsrWithLoadBalanceStrategy : CsrBase {
     static std::unique_ptr<matrix_type> create(
         std::shared_ptr<gko::Executor> exec, gko::dim<2> size)
     {
-        return matrix_type::create(exec, size, 0,
-                                   std::make_shared<matrix_type::load_balance>(
-                                       gko::EXEC_TYPE::create(0, exec)));
+        return matrix_type::create(
+            exec, size, 0, gko::matrix::csr::spmv_strategy::load_balance);
     }
 
     static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
-        ASSERT_TRUE(dynamic_cast<const matrix_type::load_balance*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::load_balance);
     }
 
     static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
-        ASSERT_TRUE(dynamic_cast<const matrix_type::load_balance*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::load_balance);
     }
 };
 
@@ -234,22 +233,21 @@ struct CsrWithAutomaticalStrategy : CsrBase {
     static std::unique_ptr<matrix_type> create(
         std::shared_ptr<gko::Executor> exec, gko::dim<2> size)
     {
-        return matrix_type::create(exec, size, 0,
-                                   std::make_shared<matrix_type::automatical>(
-                                       gko::EXEC_TYPE::create(0, exec)));
+        return matrix_type::create(
+            exec, size, 0, gko::matrix::csr::spmv_strategy::automatical);
     }
 
     static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
-        ASSERT_TRUE(dynamic_cast<const matrix_type::automatical*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::automatical);
     }
 
     static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
-        ASSERT_TRUE(dynamic_cast<const matrix_type::automatical*>(
-            mtx->get_strategy().get()));
+        ASSERT_EQ(mtx->get_strategy(),
+                  gko::matrix::csr::spmv_strategy::automatical);
     }
 };
 

--- a/test/matrix/matrix.cpp
+++ b/test/matrix/matrix.cpp
@@ -229,25 +229,25 @@ struct CsrWithLoadBalanceStrategy : CsrBase {
     }
 };
 
-struct CsrWithAutomaticalStrategy : CsrBase {
+struct CsrWithAutomaticStrategy : CsrBase {
     static std::unique_ptr<matrix_type> create(
         std::shared_ptr<gko::Executor> exec, gko::dim<2> size)
     {
-        return matrix_type::create(
-            exec, size, 0, gko::matrix::csr::spmv_strategy::automatical);
+        return matrix_type::create(exec, size, 0,
+                                   gko::matrix::csr::spmv_strategy::automatic);
     }
 
     static void check_property(gko::ptr_param<const matrix_type> mtx)
     {
         ASSERT_EQ(mtx->get_strategy(),
-                  gko::matrix::csr::spmv_strategy::automatical);
+                  gko::matrix::csr::spmv_strategy::automatic);
     }
 
     static void assert_empty_state(gko::ptr_param<const matrix_type> mtx)
     {
         CsrBase::assert_empty_state(mtx);
         ASSERT_EQ(mtx->get_strategy(),
-                  gko::matrix::csr::spmv_strategy::automatical);
+                  gko::matrix::csr::spmv_strategy::automatic);
     }
 };
 
@@ -839,7 +839,7 @@ using MatrixTypes = ::testing::Types<
 #if defined(GKO_COMPILING_CUDA) || defined(GKO_COMPILING_HIP) || \
     defined(GKO_COMPILING_DPCPP)
     CsrWithSparselibStrategy, CsrWithLoadBalanceStrategy,
-    CsrWithAutomaticalStrategy,
+    CsrWithAutomaticStrategy,
 #endif
     Ell,
 #ifdef GKO_COMPILING_OMP

--- a/test/mpi/preconditioner/schwarz.cpp
+++ b/test/mpi/preconditioner/schwarz.cpp
@@ -86,7 +86,7 @@ protected:
         // precision on HIP and DPCPP because of atomic
         dist_mat = dist_mtx_type::create(
             exec, comm, csr::create(exec),
-            csr::create(exec, std::make_shared<typename csr::classical>()));
+            csr::create(exec, gko::matrix::csr::spmv_strategy::classical));
         dist_mat->read_distributed(mat_input, row_part);
         non_dist_mat = non_dist_matrix_type::create(exec);
         non_dist_mat->read(mat_input);

--- a/test/solver/lower_trs_kernels.cpp
+++ b/test/solver/lower_trs_kernels.cpp
@@ -339,7 +339,7 @@ TEST_F(LowerTrs, ApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyFullDenseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().on(ref);
     auto d_lower_trs_factory = solver_type::build().on(exec);
     auto solver = lower_trs_factory->generate(mtx);
@@ -355,7 +355,7 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyFullDenseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =
@@ -373,7 +373,7 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxUnitDiagIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyFullSparseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().on(ref);
     auto d_lower_trs_factory = solver_type::build().on(exec);
     auto solver = lower_trs_factory->generate(mtx);
@@ -389,7 +389,7 @@ TEST_F(LowerTrs, ClassicalApplyFullSparseMtxIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyFullSparseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =
@@ -407,7 +407,7 @@ TEST_F(LowerTrs, ClassicalApplyFullSparseMtxUnitDiagIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().on(ref);
     auto d_lower_trs_factory = solver_type::build().on(exec);
     auto solver = lower_trs_factory->generate(mtx_l);
@@ -423,7 +423,7 @@ TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =
@@ -441,7 +441,7 @@ TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().on(ref);
     auto d_lower_trs_factory = solver_type::build().on(exec);
     auto solver = lower_trs_factory->generate(mtx_l);
@@ -457,7 +457,7 @@ TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =
@@ -475,7 +475,7 @@ TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 4, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().with_num_rhs(4u).on(ref);
     auto d_lower_trs_factory = solver_type::build().with_num_rhs(4u).on(exec);
     auto solver = lower_trs_factory->generate(mtx);
@@ -491,7 +491,7 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 5, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_num_rhs(5u).with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =
@@ -509,7 +509,7 @@ TEST_F(LowerTrs, ClassicalApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 TEST_F(LowerTrs, ClassicalApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 6, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().with_num_rhs(6u).on(ref);
     auto d_lower_trs_factory = solver_type::build().with_num_rhs(6u).on(exec);
     auto solver = lower_trs_factory->generate(mtx);
@@ -526,7 +526,7 @@ TEST_F(LowerTrs,
        ClassicalApplyFullSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 7, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_num_rhs(7u).with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =
@@ -544,7 +544,7 @@ TEST_F(LowerTrs,
 TEST_F(LowerTrs, ClassicalApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 8, 50);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().with_num_rhs(8u).on(ref);
     auto d_lower_trs_factory = solver_type::build().with_num_rhs(8u).on(exec);
     auto solver = lower_trs_factory->generate(mtx_l);
@@ -561,7 +561,7 @@ TEST_F(LowerTrs,
        ClassicalApplyTriangularDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 9, 50);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_num_rhs(9u).with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =
@@ -579,7 +579,7 @@ TEST_F(LowerTrs,
 TEST_F(LowerTrs, ClassicalApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 10, 5);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory = solver_type::build().with_num_rhs(10u).on(ref);
     auto d_lower_trs_factory = solver_type::build().with_num_rhs(10u).on(exec);
     auto solver = lower_trs_factory->generate(mtx_l);
@@ -596,7 +596,7 @@ TEST_F(LowerTrs,
        ClassicalApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 11, 5);
-    dmtx_l->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_l->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto lower_trs_factory =
         solver_type::build().with_num_rhs(11u).with_unit_diagonal(true).on(ref);
     auto d_lower_trs_factory =

--- a/test/solver/upper_trs_kernels.cpp
+++ b/test/solver/upper_trs_kernels.cpp
@@ -340,7 +340,7 @@ TEST_F(UpperTrs, ApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyFullDenseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().on(ref);
     auto d_upper_trs_factory = solver_type::build().on(exec);
     auto solver = upper_trs_factory->generate(mtx);
@@ -356,7 +356,7 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyFullDenseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_upper_trs_factory =
@@ -374,7 +374,7 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxUnitDiagIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyFullSparseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().on(ref);
     auto d_upper_trs_factory = solver_type::build().on(exec);
     auto solver = upper_trs_factory->generate(mtx);
@@ -390,7 +390,7 @@ TEST_F(UpperTrs, ClassicalApplyFullSparseMtxIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyFullSparseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_upper_trs_factory =
@@ -408,7 +408,7 @@ TEST_F(UpperTrs, ClassicalApplyFullSparseMtxUnitDiagIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().on(ref);
     auto d_upper_trs_factory = solver_type::build().on(exec);
     auto solver = upper_trs_factory->generate(mtx_u);
@@ -424,7 +424,7 @@ TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 50);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_upper_trs_factory =
@@ -442,7 +442,7 @@ TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxUnitDiagIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().on(ref);
     auto d_upper_trs_factory = solver_type::build().on(exec);
     auto solver = upper_trs_factory->generate(mtx_u);
@@ -458,7 +458,7 @@ TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
 {
     initialize_data(50, 1, 5);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_unit_diagonal(true).on(ref);
     auto d_upper_trs_factory =
@@ -476,7 +476,7 @@ TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxUnitDiagIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 4, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().with_num_rhs(4u).on(ref);
     auto d_upper_trs_factory = solver_type::build().with_num_rhs(4u).on(exec);
     auto solver = upper_trs_factory->generate(mtx);
@@ -492,7 +492,7 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxMultipleRhsIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 5, 50);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_num_rhs(5u).with_unit_diagonal(true).on(ref);
     auto d_upper_trs_factory =
@@ -510,7 +510,7 @@ TEST_F(UpperTrs, ClassicalApplyFullDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 TEST_F(UpperTrs, ClassicalApplyFullSparseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 6, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().with_num_rhs(6u).on(ref);
     auto d_upper_trs_factory = solver_type::build().with_num_rhs(6u).on(exec);
     auto solver = upper_trs_factory->generate(mtx);
@@ -527,7 +527,7 @@ TEST_F(UpperTrs,
        ClassicalApplyFullSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 7, 5);
-    dmtx->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_num_rhs(7u).with_unit_diagonal(true).on(ref);
     auto d_upper_trs_factory =
@@ -545,7 +545,7 @@ TEST_F(UpperTrs,
 TEST_F(UpperTrs, ClassicalApplyTriangularDenseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 8, 50);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().with_num_rhs(8u).on(ref);
     auto d_upper_trs_factory = solver_type::build().with_num_rhs(8u).on(exec);
     auto solver = upper_trs_factory->generate(mtx_u);
@@ -562,7 +562,7 @@ TEST_F(UpperTrs,
        ClassicalApplyTriangularDenseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 9, 50);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_num_rhs(9u).with_unit_diagonal(true).on(ref);
     auto d_upper_trs_factory =
@@ -580,7 +580,7 @@ TEST_F(UpperTrs,
 TEST_F(UpperTrs, ClassicalApplyTriangularSparseMtxMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 10, 5);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory = solver_type::build().with_num_rhs(10u).on(ref);
     auto d_upper_trs_factory = solver_type::build().with_num_rhs(10u).on(exec);
     auto solver = upper_trs_factory->generate(mtx_u);
@@ -597,7 +597,7 @@ TEST_F(UpperTrs,
        ClassicalApplyTriangularSparseMtxUnitDiagMultipleRhsIsEquivalentToRef)
 {
     initialize_data(50, 11, 5);
-    dmtx_u->set_strategy(std::make_shared<mtx_type::classical>());
+    dmtx_u->set_strategy(gko::matrix::csr::spmv_strategy::classical);
     auto upper_trs_factory =
         solver_type::build().with_unit_diagonal(true).with_num_rhs(11u).on(ref);
     auto d_upper_trs_factory =

--- a/test/test_install/test_install.cpp
+++ b/test/test_install/test_install.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -68,7 +68,8 @@ void check_solver(std::shared_ptr<gko::Executor> exec,
                   gko::ptr_param<gko::matrix::Dense<>> x)
 {
     using Mtx = gko::matrix::Csr<>;
-    auto A = gko::share(Mtx::create(exec, std::make_shared<Mtx::classical>()));
+    auto A = gko::share(
+        Mtx::create(exec, gko::matrix::csr::spmv_strategy::classical));
 
     auto num_iters = 20u;
     double reduction_factor = 1e-7;
@@ -89,8 +90,8 @@ void check_solver(std::shared_ptr<gko::Executor> exec,
 #if defined(HAS_HIP) || defined(HAS_CUDA)
     // If we are on a device, we need to run a reference test to compare against
     auto exec_ref = exec->get_master();
-    auto A_ref =
-        gko::share(Mtx::create(exec_ref, std::make_shared<Mtx::classical>()));
+    auto A_ref = gko::share(
+        Mtx::create(exec_ref, gko::matrix::csr::spmv_strategy::classical));
     A_ref->read(A_raw);
     auto solver_gen_ref =
         Solver::build()
@@ -359,7 +360,8 @@ int main()
     // core/matrix/csr.hpp
     {
         using Mtx = gko::matrix::Csr<>;
-        auto test = Mtx::create(exec, std::make_shared<Mtx::classical>());
+        auto test =
+            Mtx::create(exec, gko::matrix::csr::spmv_strategy::classical);
     }
 
     // core/matrix/dense.hpp


### PR DESCRIPTION
This PR uses enum to handle csr strategy.

Interface Change:
- `std::make_shared<Csr::<strategy_type>>(...)` -> `gko::matrix::csr::spmv_strategy::<strategy_name>`
- no function from the strategy itself. such as `csr->get_strategy()->copy()`
- no manual setup for load_balance strategy (If you need it for specific gpu, please do it in ginkgo core. That will also be nice if you can report the performance difference and setup via PR)
- automatical -> automatic

note:
In the beginning, we use inheritance to support different arguments required by different strategy to avoid a big structure containing unused variable.
Also, it was designed to let user provide detailed setup for load balance.
However, load balance require some knowledge on the hardware and the algorithm implementation. Most people use our default setup for individual executor, so we think it is unnecessary complicated now.
We have made them header only, so we can not rely on the executor runtime information there, which also requires additional workaround there.

In this PR, we only use enum to represent the strategy. The implementation and no any additional strategy function (such as `this->get_strategy()->copy()` not working anymore). We will process the necessary information in the core not the header.

Related Issue: https://github.com/ginkgo-project/ginkgo/issues/320

TODO:
- [x] fix the automatical handling in the spmv selection
- [x] recover max_length_per_row setting
- [x] strategy naming? automatical -> auto (because automatical is not a actual word)
- [x] recover csr builder test
- [x] add new srow check test on gpu executor
- [x] add interface break note