### PR TITLE
fix missing thrust/tuple.h header in CCCL-3.3.3 (#2021)

### DIFF
--- a/common/cuda_hip/distributed/index_map_kernels.cpp
+++ b/common/cuda_hip/distributed/index_map_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -15,6 +15,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform_reduce.h>
+#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/common/cuda_hip/distributed/matrix_kernels.cpp
+++ b/common/cuda_hip/distributed/matrix_kernels.cpp
@@ -14,6 +14,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform_reduce.h>
+#include <thrust/tuple.h>
 #include <thrust/unique.h>
 
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/common/cuda_hip/distributed/partition_helpers_kernels.cpp
+++ b/common/cuda_hip/distributed/partition_helpers_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -8,6 +8,7 @@
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/sort.h>
+#include <thrust/tuple.h>
 
 #include "common/cuda_hip/base/thrust.hpp"
 

--- a/common/cuda_hip/distributed/partition_kernels.cpp
+++ b/common/cuda_hip/distributed/partition_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -12,6 +12,7 @@
 #include <thrust/scan.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+#include <thrust/tuple.h>
 
 #include "common/cuda_hip/base/thrust.hpp"
 #include "common/cuda_hip/components/atomic.hpp"

--- a/common/cuda_hip/factorization/lu_kernels.cpp
+++ b/common/cuda_hip/factorization/lu_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -10,6 +10,7 @@
 #include <thrust/copy.h>
 #include <thrust/iterator/transform_output_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
+#include <thrust/tuple.h>
 
 #include <ginkgo/core/matrix/csr.hpp>
 

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -15,6 +15,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/sort.h>
+#include <thrust/tuple.h>
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/fbcsr_kernels.template.cpp
@@ -14,6 +14,7 @@
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/pair.h>
 #include <thrust/sort.h>
+#include <thrust/tuple.h>
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/exception_helpers.hpp>

--- a/common/cuda_hip/reorder/rcm_kernels.cpp
+++ b/common/cuda_hip/reorder/rcm_kernels.cpp
@@ -15,6 +15,7 @@
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
+#include <thrust/tuple.h>
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/types.hpp>


### PR DESCRIPTION
This PR takes the file changes from #2021 such that we can perform our CI properly.

It fixes the missing header `thrust/tuple.h` in CCCL-3.3.3

Our CI from external contributor is not working currently due to the setting.