### PR TITLE
create msvc reference test and will bring the fix from #2009

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -1,0 +1,51 @@
+name: Windows-MSVC
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+      - 'release/**'
+    tags:
+      - '**'
+  pull_request:
+    types: [opened,synchronize]
+    paths-ignore:
+      - 'doc/**'
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled by `debug_enabled` keyword (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.head_ref && github.ref) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  windows:
+    strategy:
+      fail-fast: false
+    name: msvc
+    runs-on: [windows-latest]
+
+    steps:
+    - name: Checkout the latest code (shallow clone)
+      uses: actions/checkout@v4
+    - name: Debug over SSH (tmate)
+      uses: mxschmitt/action-tmate@v3.5
+      if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+      with:
+        limit-access-to-actor: true
+
+    - name: configure and test
+      run: |
+        $env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
+        Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+        refreshenv
+        mkdir build
+        cd build
+        cmake -DGINKGO_BUILD_OMP=OFF -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake --build . -j4 --config Release
+        ctest . -C Release

--- a/core/test/log/profiler_hook.cpp
+++ b/core/test/log/profiler_hook.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -25,6 +25,32 @@ const std::string dense_complex_double =
 const std::string dense_complex_double =
     "gko::matrix::Dense<std::complex<double> >";
 #endif
+
+
+// MSVC has class/struct in the type name, so we remove it to keep the same
+// output as the others.
+void normalize_type_names(std::vector<std::string>& str_vec)
+{
+#ifdef _MSC_VER
+    auto normalize = [](std::string s) {
+        const std::string class_str = "class ";
+        auto pos = s.find(class_str);
+        while (pos != std::string::npos) {
+            s.erase(pos, class_str.size());
+            pos = s.find(class_str);
+        }
+        const std::string struct_str = "struct ";
+        pos = s.find(struct_str);
+        while (pos != std::string::npos) {
+            s.erase(pos, struct_str.size());
+            pos = s.find(struct_str);
+        }
+        return s;
+    };
+    std::transform(str_vec.begin(), str_vec.end(), str_vec.begin(),
+                   [&](std::string s) { return normalize(s); });
+#endif
+}
 
 std::pair<gko::log::ProfilerHook::hook_function,
           gko::log::ProfilerHook::hook_function>
@@ -160,6 +186,7 @@ TEST(ProfilerHook, LogsPolymorphicObjectLinOp)
                                          false);
 
     exec->remove_logger(logger);
+    normalize_type_names(output);
     ASSERT_EQ(output, expected);
 }
 
@@ -207,6 +234,7 @@ TEST(ProfilerHook, LogsPolymorphicObjectLinOpApplyWithType)
     linop->apply(linop, outvec);
     linop->apply(alpha, invec, scalar, linop);
 
+    normalize_type_names(output);
     ASSERT_EQ(output, expected);
 }
 
@@ -245,6 +273,7 @@ TEST(ProfilerHook, LogsIteration)
     solver->apply(alpha, mtx, alpha, mtx);
 
     solver->remove_logger(logger);
+    normalize_type_names(output);
     ASSERT_EQ(output, expected);
 }
 

--- a/reference/test/base/batch_multi_vector_kernels.cpp
+++ b/reference/test/base/batch_multi_vector_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -29,52 +29,52 @@ protected:
     using Mtx = gko::batch::MultiVector<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
     using ComplexMtx = gko::to_complex<Mtx>;
-    MultiVector()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<Mtx>(
-              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
-               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
-              exec)),
-          mtx_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          mtx_1(gko::batch::initialize<Mtx>(
-              {{{1.0, -1.0, 2.2}, {-2.0, 2.0, -0.5}},
-               {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}},
-              exec)),
-          mtx_10(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -1.0, 2.2}), I<T>({-2.0, 2.0, -0.5})}, exec)),
-          mtx_11(gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}},
-                                           exec)),
-          mtx_2(gko::batch::initialize<Mtx>(
-              {{{1.0, 1.5}, {6.0, 1.0}, {-0.25, 1.0}},
-               {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}},
-              exec)),
-          mtx_20(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 1.5}), I<T>({6.0, 1.0}), I<T>({-0.25, 1.0})}, exec)),
-          mtx_21(gko::initialize<DenseMtx>(
-              {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}, exec)),
-          mtx_3(gko::batch::initialize<Mtx>(
-              {{I<T>({1.0, 1.5}), I<T>({6.0, 1.0})}, {{2.0, -2.0}, {1.0, 3.0}}},
-              exec)),
-          mtx_30(gko::initialize<DenseMtx>({I<T>({1.0, 1.5}), I<T>({6.0, 1.0})},
-                                           exec)),
-          mtx_31(gko::initialize<DenseMtx>(
-              {I<T>({2.0, -2.0}), I<T>({1.0, 3.0})}, exec)),
-          mtx_4(gko::batch::initialize<Mtx>(
-              {{{1.0, 1.5, 3.0}, {6.0, 1.0, 5.0}, {6.0, 1.0, 5.5}},
-               {{2.0, -2.0, 1.5}, {4.0, 3.0, 2.2}, {-1.25, 3.0, 0.5}}},
-              exec)),
-          mtx_5(gko::batch::initialize<Mtx>(
-              {{{1.0, 1.5}, {6.0, 1.0}, {7.0, -4.5}},
-               {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}},
-              exec)),
-          mtx_6(gko::batch::initialize<Mtx>(
-              {{{1.0, 0.0, 3.0}, {0.0, 3.0, 0.0}, {0.0, 1.0, 5.0}},
-               {{2.0, 0.0, 5.0}, {0.0, 1.0, 0.0}, {0.0, -1.0, 8.0}}},
-              exec))
-    {}
+    MultiVector() : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 = gko::batch::initialize<Mtx>(
+            {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
+             {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
+            exec);
+        mtx_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec);
+        mtx_1 =
+            gko::batch::initialize<Mtx>({{{1.0, -1.0, 2.2}, {-2.0, 2.0, -0.5}},
+                                         {{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}},
+                                        exec);
+        mtx_10 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, -1.0, 2.2}), I<T>({-2.0, 2.0, -0.5})}, exec);
+        mtx_11 =
+            gko::initialize<DenseMtx>({{1.0, 2.5, 3.0}, {1.0, 2.0, 3.0}}, exec);
+        mtx_2 = gko::batch::initialize<Mtx>(
+            {{{1.0, 1.5}, {6.0, 1.0}, {-0.25, 1.0}},
+             {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}},
+            exec);
+        mtx_20 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, 1.5}), I<T>({6.0, 1.0}), I<T>({-0.25, 1.0})}, exec);
+        mtx_21 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}, exec);
+        mtx_3 = gko::batch::initialize<Mtx>(
+            {{I<T>({1.0, 1.5}), I<T>({6.0, 1.0})}, {{2.0, -2.0}, {1.0, 3.0}}},
+            exec);
+        mtx_30 = gko::initialize<DenseMtx>({I<T>({1.0, 1.5}), I<T>({6.0, 1.0})},
+                                           exec);
+        mtx_31 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, -2.0}), I<T>({1.0, 3.0})}, exec);
+        mtx_4 = gko::batch::initialize<Mtx>(
+            {{{1.0, 1.5, 3.0}, {6.0, 1.0, 5.0}, {6.0, 1.0, 5.5}},
+             {{2.0, -2.0, 1.5}, {4.0, 3.0, 2.2}, {-1.25, 3.0, 0.5}}},
+            exec);
+        mtx_5 = gko::batch::initialize<Mtx>(
+            {{{1.0, 1.5}, {6.0, 1.0}, {7.0, -4.5}},
+             {I<T>({2.0, -2.0}), I<T>({1.0, 3.0}), I<T>({4.0, 3.0})}},
+            exec);
+        mtx_6 = gko::batch::initialize<Mtx>(
+            {{{1.0, 0.0, 3.0}, {0.0, 3.0, 0.0}, {0.0, 1.0, 5.0}},
+             {{2.0, 0.0, 5.0}, {0.0, 1.0, 0.0}, {0.0, -1.0, 8.0}}},
+            exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<Mtx> mtx_0;

--- a/reference/test/base/combination.cpp
+++ b/reference/test/base/combination.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -23,11 +23,13 @@ protected:
     Combination()
         : exec{gko::ReferenceExecutor::create()},
           coefficients{gko::initialize<Mtx>({1}, exec),
-                       gko::initialize<Mtx>({2}, exec)},
-          operators{
-              gko::initialize<Mtx>({I<T>({2.0, 3.0}), I<T>({1.0, 4.0})}, exec),
-              gko::initialize<Mtx>({I<T>({3.0, 2.0}), I<T>({2.0, 0.0})}, exec)}
-    {}
+                       gko::initialize<Mtx>({2}, exec)}
+    {
+        operators = {
+            gko::initialize<Mtx>({I<T>({2.0, 3.0}), I<T>({1.0, 4.0})}, exec),
+            gko::initialize<Mtx>({I<T>({3.0, 2.0}), I<T>({2.0, 0.0})}, exec)};
+    }
+
 
     std::shared_ptr<const gko::Executor> exec;
     std::vector<std::shared_ptr<gko::LinOp>> coefficients;

--- a/reference/test/base/composition.cpp
+++ b/reference/test/base/composition.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -50,23 +50,22 @@ protected:
     using Mtx = gko::matrix::Dense<T>;
     using value_type = T;
 
-    Composition()
-        : exec{gko::ReferenceExecutor::create()},
-          operators{
-              gko::initialize<Mtx>(I<T>({2.0, 1.0}), exec),
-              gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec),
-              gko::initialize<Mtx>(
-                  {I<T>({-1.0, 1.0, 2.0}), I<T>({5.0, -3.0, 0.0})}, exec),
-              gko::initialize<Mtx>(
-                  {I<T>({9.0, 4.0}), I<T>({6.0, -2.0}), I<T>({-3.0, 2.0})},
-                  exec),
-              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec),
-              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
-          identity{
-              gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)},
-          product{gko::initialize<Mtx>({I<T>({-9.0, -2.0}), I<T>({27.0, 26.0})},
-                                       exec)}
-    {}
+    Composition() : exec{gko::ReferenceExecutor::create()}
+    {
+        operators = {
+            gko::initialize<Mtx>(I<T>({2.0, 1.0}), exec),
+            gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec),
+            gko::initialize<Mtx>(
+                {I<T>({-1.0, 1.0, 2.0}), I<T>({5.0, -3.0, 0.0})}, exec),
+            gko::initialize<Mtx>(
+                {I<T>({9.0, 4.0}), I<T>({6.0, -2.0}), I<T>({-3.0, 2.0})}, exec),
+            gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec),
+            gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec)};
+        identity =
+            gko::initialize<Mtx>({I<T>({1.0, 0.0}), I<T>({0.0, 1.0})}, exec);
+        product = gko::initialize<Mtx>({I<T>({-9.0, -2.0}), I<T>({27.0, 26.0})},
+                                       exec);
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::vector<std::shared_ptr<gko::LinOp>> coefficients;

--- a/reference/test/base/perturbation.cpp
+++ b/reference/test/base/perturbation.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -23,9 +23,10 @@ protected:
     Perturbation()
         : exec{gko::ReferenceExecutor::create()},
           basis{gko::initialize<Mtx>({2.0, 1.0}, exec)},
-          projector{gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec)},
           scalar{gko::initialize<Mtx>({2.0}, exec)}
-    {}
+    {
+        projector = gko::initialize<Mtx>({I<T>({3.0, 2.0})}, exec);
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::shared_ptr<gko::LinOp> basis;

--- a/reference/test/matrix/batch_csr_kernels.cpp
+++ b/reference/test/matrix/batch_csr_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,39 +30,39 @@ protected:
     using BMVec = gko::batch::MultiVector<value_type>;
     using CsrMtx = gko::matrix::Csr<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
-    Csr()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<BMtx>(
-              {{{1.0, -1.0, 0.0}, {-2.0, 2.0, 3.0}},
-               {{1.0, -2.0, 0.0}, {1.0, -2.5, 4.0}}},
-              exec, 5)),
-          mtx_00(gko::initialize<CsrMtx>(
-              {I<T>({1.0, -1.0, 0.0}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<CsrMtx>(
-              {I<T>({1.0, -2.0, 0.0}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          b_0(gko::batch::initialize<BMVec>(
-              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})},
-               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})}},
-              exec)),
-          b_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          b_01(gko::initialize<DenseMtx>(
-              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          x_0(gko::batch::initialize<BMVec>(
-              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
-               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
-              exec)),
-          x_00(gko::initialize<DenseMtx>(
-              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
-          x_01(gko::initialize<DenseMtx>(
-              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
-    {}
+    Csr() : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 =
+            gko::batch::initialize<BMtx>({{{1.0, -1.0, 0.0}, {-2.0, 2.0, 3.0}},
+                                          {{1.0, -2.0, 0.0}, {1.0, -2.5, 4.0}}},
+                                         exec, 5);
+        mtx_00 = gko::initialize<CsrMtx>(
+            {I<T>({1.0, -1.0, 0.0}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<CsrMtx>(
+            {I<T>({1.0, -2.0, 0.0}), I<T>({1.0, -2.5, 4.0})}, exec);
+        b_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+              I<T>({1.0, 0.0, 2.0})},
+             {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+              I<T>({1.0, 0.0, 2.0})}},
+            exec);
+        b_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+             I<T>({1.0, 0.0, 2.0})},
+            exec);
+        b_01 = gko::initialize<DenseMtx>(
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+             I<T>({1.0, 0.0, 2.0})},
+            exec);
+        x_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+             {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+            exec);
+        x_00 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec);
+        x_01 = gko::initialize<DenseMtx>(
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<BMtx> mtx_0;

--- a/reference/test/matrix/batch_dense_kernels.cpp
+++ b/reference/test/matrix/batch_dense_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -28,39 +28,39 @@ protected:
     using BMtx = gko::batch::matrix::Dense<value_type>;
     using BMVec = gko::batch::MultiVector<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
-    Dense()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<BMtx>(
-              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
-               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
-              exec)),
-          mtx_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<DenseMtx>(
-              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          b_0(gko::batch::initialize<BMVec>(
-              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})},
-               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})}},
-              exec)),
-          b_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          b_01(gko::initialize<DenseMtx>(
-              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          x_0(gko::batch::initialize<BMVec>(
-              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
-               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
-              exec)),
-          x_00(gko::initialize<DenseMtx>(
-              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
-          x_01(gko::initialize<DenseMtx>(
-              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
-    {}
+    Dense() : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 = gko::batch::initialize<BMtx>(
+            {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
+             {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
+            exec);
+        mtx_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec);
+        b_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+              I<T>({1.0, 0.0, 2.0})},
+             {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+              I<T>({1.0, 0.0, 2.0})}},
+            exec);
+        b_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+             I<T>({1.0, 0.0, 2.0})},
+            exec);
+        b_01 = gko::initialize<DenseMtx>(
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+             I<T>({1.0, 0.0, 2.0})},
+            exec);
+        x_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+             {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+            exec);
+        x_00 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec);
+        x_01 = gko::initialize<DenseMtx>(
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<BMtx> mtx_0;

--- a/reference/test/matrix/batch_ell_kernels.cpp
+++ b/reference/test/matrix/batch_ell_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -30,39 +30,39 @@ protected:
     using BMVec = gko::batch::MultiVector<value_type>;
     using EllMtx = gko::matrix::Ell<value_type>;
     using DenseMtx = gko::matrix::Dense<value_type>;
-    Ell()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx_0(gko::batch::initialize<BMtx>(
-              {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
-               {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
-              exec)),
-          mtx_00(gko::initialize<EllMtx>(
-              {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec)),
-          mtx_01(gko::initialize<EllMtx>(
-              {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec)),
-          b_0(gko::batch::initialize<BMVec>(
-              {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})},
-               {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-                I<T>({1.0, 0.0, 2.0})}},
-              exec)),
-          b_00(gko::initialize<DenseMtx>(
-              {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          b_01(gko::initialize<DenseMtx>(
-              {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
-               I<T>({1.0, 0.0, 2.0})},
-              exec)),
-          x_0(gko::batch::initialize<BMVec>(
-              {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
-               {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
-              exec)),
-          x_00(gko::initialize<DenseMtx>(
-              {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec)),
-          x_01(gko::initialize<DenseMtx>(
-              {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec))
-    {}
+    Ell() : exec(gko::ReferenceExecutor::create())
+    {
+        mtx_0 = gko::batch::initialize<BMtx>(
+            {{I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})},
+             {{1.0, -2.0, -0.5}, {1.0, -2.5, 4.0}}},
+            exec);
+        mtx_00 = gko::initialize<EllMtx>(
+            {I<T>({1.0, -1.0, 1.5}), I<T>({-2.0, 2.0, 3.0})}, exec);
+        mtx_01 = gko::initialize<EllMtx>(
+            {I<T>({1.0, -2.0, -0.5}), I<T>({1.0, -2.5, 4.0})}, exec);
+        b_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+              I<T>({1.0, 0.0, 2.0})},
+             {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+              I<T>({1.0, 0.0, 2.0})}},
+            exec);
+        b_00 = gko::initialize<DenseMtx>(
+            {I<T>({1.0, 0.0, 1.0}), I<T>({2.0, 0.0, 1.0}),
+             I<T>({1.0, 0.0, 2.0})},
+            exec);
+        b_01 = gko::initialize<DenseMtx>(
+            {I<T>({-1.0, 1.0, 1.0}), I<T>({1.0, -1.0, 1.0}),
+             I<T>({1.0, 0.0, 2.0})},
+            exec);
+        x_0 = gko::batch::initialize<BMVec>(
+            {{I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})},
+             {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}},
+            exec);
+        x_00 = gko::initialize<DenseMtx>(
+            {I<T>({2.0, 0.0, 1.0}), I<T>({2.0, 0.0, 2.0})}, exec);
+        x_01 = gko::initialize<DenseMtx>(
+            {I<T>({-2.0, 1.0, 1.0}), I<T>({1.0, -1.0, -1.0})}, exec);
+    }
 
     std::shared_ptr<const gko::ReferenceExecutor> exec;
     std::unique_ptr<BMtx> mtx_0;

--- a/reference/test/matrix/dense_kernels.cpp
+++ b/reference/test/matrix/dense_kernels.cpp
@@ -40,23 +40,23 @@ protected:
     using MixedMtx = gko::matrix::Dense<gko::next_precision<value_type>>;
     using ComplexMtx = gko::to_complex<Mtx>;
     using RealMtx = gko::remove_complex<Mtx>;
-    Dense()
-        : exec(gko::ReferenceExecutor::create()),
-          mtx1(gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {1.5, 2.5, 3.5}},
-                                    exec)),
-          mtx2(gko::initialize<Mtx>({I<T>({1.0, -1.0}), I<T>({-2.0, 2.0})},
-                                    exec)),
-          mtx3(gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {0.5, 1.5, 2.5}},
-                                    exec)),
-          mtx4(gko::initialize<Mtx>(4, {{1.0, 3.0, 2.0}, {0.0, 5.0, 0.0}},
-                                    exec)),
-          mtx5(gko::initialize<Mtx>(
-              {{1.0, -1.0, -0.5}, {-2.0, 2.0, 4.5}, {2.1, 3.4, 1.2}}, exec)),
-          mtx6(gko::initialize<Mtx>({{1.0, 2.0, 0.0}, {0.0, 1.5, 0.0}}, exec)),
-          mtx7(gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 1.5, 0.0}}, exec)),
-          mtx8(gko::initialize<Mtx>(
-              {I<T>({1.0, -1.0}), I<T>({-2.0, 2.0}), I<T>({-3.0, 3.0})}, exec))
-    {}
+    Dense() : exec(gko::ReferenceExecutor::create())
+    {
+        mtx1 =
+            gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {1.5, 2.5, 3.5}}, exec);
+        mtx2 =
+            gko::initialize<Mtx>({I<T>({1.0, -1.0}), I<T>({-2.0, 2.0})}, exec);
+        mtx3 =
+            gko::initialize<Mtx>(4, {{1.0, 2.0, 3.0}, {0.5, 1.5, 2.5}}, exec);
+        mtx4 =
+            gko::initialize<Mtx>(4, {{1.0, 3.0, 2.0}, {0.0, 5.0, 0.0}}, exec);
+        mtx5 = gko::initialize<Mtx>(
+            {{1.0, -1.0, -0.5}, {-2.0, 2.0, 4.5}, {2.1, 3.4, 1.2}}, exec);
+        mtx6 = gko::initialize<Mtx>({{1.0, 2.0, 0.0}, {0.0, 1.5, 0.0}}, exec);
+        mtx7 = gko::initialize<Mtx>({{1.0, 2.0, 3.0}, {0.0, 1.5, 0.0}}, exec);
+        mtx8 = gko::initialize<Mtx>(
+            {I<T>({1.0, -1.0}), I<T>({-2.0, 2.0}), I<T>({-3.0, 3.0})}, exec);
+    }
 
     std::shared_ptr<const gko::Executor> exec;
     std::unique_ptr<Mtx> mtx1;

--- a/reference/test/multigrid/fixed_coarsening_kernels.cpp
+++ b/reference/test/multigrid/fixed_coarsening_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -49,29 +49,27 @@ protected:
                              std::make_shared<typename Mtx::classical>())),
           coarse_rows(exec, {0, 2, 3}),
           gen_coarse_rows(exec, 5),
-          coarse_b(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({3.0, 1.0}), I<VT>({0.0, -1.0})},
-              exec)),
-          fine_b(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
-               I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
-              exec)),
-          restrict_ans(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({3.0, -2.0})},
-              exec)),
-          prolong_applyans(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, 0.0}), I<VT>({3.0, 1.0}),
-               I<VT>({0.0, -1.0}), I<VT>({0.0, 0.0})},
-              exec)),
-          fine_x(gko::initialize<Vec>(
-              {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
-               I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
-              exec)),
           fixed_coarsening_factory(MgLevel::build()
                                        .with_coarse_rows(coarse_rows)
                                        .with_skip_sorting(true)
                                        .on(exec))
     {
+        coarse_b = gko::initialize<Vec>(
+            {I<VT>({2.0, -1.0}), I<VT>({3.0, 1.0}), I<VT>({0.0, -1.0})}, exec);
+        fine_b = gko::initialize<Vec>(
+            {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
+             I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
+            exec);
+        restrict_ans = gko::initialize<Vec>(
+            {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({3.0, -2.0})}, exec);
+        prolong_applyans = gko::initialize<Vec>(
+            {I<VT>({2.0, -1.0}), I<VT>({0.0, 0.0}), I<VT>({3.0, 1.0}),
+             I<VT>({0.0, -1.0}), I<VT>({0.0, 0.0})},
+            exec);
+        fine_x = gko::initialize<Vec>(
+            {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
+             I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
+            exec);
         this->create_mtx(mtx.get(), &gen_coarse_rows, coarse.get());
         mg_level = fixed_coarsening_factory->generate(mtx);
     }

--- a/reference/test/multigrid/pgm_kernels.cpp
+++ b/reference/test/multigrid/pgm_kernels.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -50,26 +50,6 @@ protected:
                           .with_max_unassigned_ratio(0.1)
                           .with_skip_sorting(true)
                           .on(exec)),
-          fine_b(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
-               I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
-              exec)),
-          coarse_b(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0})}, exec)),
-          restrict_ans((gko::initialize<Vec>(
-              {I<VT>({0.0, -1.0}), I<VT>({2.0, 0.0})}, exec))),
-          prolong_ans(gko::initialize<Vec>(
-              {I<VT>({0.0, -2.0}), I<VT>({1.0, -2.0}), I<VT>({1.0, -2.0}),
-               I<VT>({0.0, -1.0}), I<VT>({2.0, 1.0})},
-              exec)),
-          prolong_applyans(gko::initialize<Vec>(
-              {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0}),
-               I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0})},
-              exec)),
-          fine_x(gko::initialize<Vec>(
-              {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
-               I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
-              exec)),
           mtx(Mtx::create(exec, gko::dim<2>(5, 5), 15,
                           std::make_shared<typename Mtx::classical>())),
           weight(WeightMtx::create(
@@ -79,6 +59,26 @@ protected:
                              std::make_shared<typename Mtx::classical>())),
           agg(exec, 5)
     {
+        fine_b = gko::initialize<Vec>(
+            {I<VT>({2.0, -1.0}), I<VT>({-1.0, 2.0}), I<VT>({0.0, -1.0}),
+             I<VT>({3.0, -2.0}), I<VT>({-2.0, 1.0})},
+            exec);
+        coarse_b = gko::initialize<Vec>(
+            {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0})}, exec);
+        restrict_ans =
+            gko::initialize<Vec>({I<VT>({0.0, -1.0}), I<VT>({2.0, 0.0})}, exec);
+        prolong_ans = gko::initialize<Vec>(
+            {I<VT>({0.0, -2.0}), I<VT>({1.0, -2.0}), I<VT>({1.0, -2.0}),
+             I<VT>({0.0, -1.0}), I<VT>({2.0, 1.0})},
+            exec);
+        prolong_applyans = gko::initialize<Vec>(
+            {I<VT>({2.0, -1.0}), I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0}),
+             I<VT>({0.0, -1.0}), I<VT>({2.0, -1.0})},
+            exec);
+        fine_x = gko::initialize<Vec>(
+            {I<VT>({-2.0, -1.0}), I<VT>({1.0, -1.0}), I<VT>({-1.0, -1.0}),
+             I<VT>({0.0, 0.0}), I<VT>({0.0, 2.0})},
+            exec);
         this->create_mtx(mtx.get(), weight.get(), &agg, coarse.get());
         mg_level = pgm_factory->generate(mtx);
         mtx_diag = weight->extract_diagonal();


### PR DESCRIPTION
This PR creates msvc reference test by using Github free resource and will bring the fix from #2009 to run our CI properly.

For profiler log, in MSVC, `typeid().name` will return with class/struct, so we remove it to match the output

For moving the initialization from member initialize list to body, it is an issue introduced after x64 msvc v19.42 VS17.12 from compiler explorer example https://gcc.godbolt.org/z/rrxecEYco
I also created a corresponding report in https://developercommunity.visualstudio.com/t/MSVC-optimizer-frees-nested-initializer_/11088522

The issue is to use explicit `initializer_list` (alias `I<T>`) in another `initializer_list`, the internal `initializer_list` will be released before function finish. Also, it only happens when using it in the member initialize list. In this PR, we move it to workaround the issue.

We need to use `I<T>` in our test when having two value when T can be complex. without `I<T>`, `{val1, val2}` can also be complex number, so it is confusing.


TODO:
- [x] Add description for #2009
- [x] Reference test failed in the first commit and the fix indeeds works.

Error log:
- https://github.com/ginkgo-project/ginkgo/actions/runs/26741403295/job/78806082543 for MSVC failed test
- https://github.com/ginkgo-project/ginkgo/actions/runs/26795612316/job/78991147921 fix the test except for profiler log