### PR TITLE
Add index type template parameter to memory accessor

### DIFF
--- a/accessor/block_col_major.hpp
+++ b/accessor/block_col_major.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -32,7 +32,8 @@ namespace acc {
  * @tparam ValueType  type of values this accessor returns
  * @tparam Dimensionality  number of dimensions of this accessor
  */
-template <typename ValueType, std::size_t Dimensionality>
+template <typename ValueType, std::size_t Dimensionality,
+          typename IndexType = std::int64_t>
 class block_col_major {
 public:
     friend class range<block_col_major>;
@@ -57,12 +58,13 @@ public:
      */
     using data_type = value_type*;
 
-    using const_accessor = block_col_major<const ValueType, Dimensionality>;
+    using const_accessor =
+        block_col_major<const ValueType, Dimensionality, IndexType>;
     using stride_type = std::array<size_type, dimensionality - 1>;
     using length_type = std::array<size_type, dimensionality>;
 
 private:
-    using index_type = std::int64_t;
+    using index_type = IndexType;
 
 protected:
     /**

--- a/accessor/reduced_row_major.hpp
+++ b/accessor/reduced_row_major.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -47,15 +47,15 @@ namespace acc {
  * @note  This class only manages the accesses and not the memory itself.
  */
 template <std::size_t Dimensionality, typename ArithmeticType,
-          typename StorageType>
+          typename StorageType, typename IndexType = std::int64_t>
 class reduced_row_major {
 public:
     using arithmetic_type = std::remove_cv_t<ArithmeticType>;
     using storage_type = StorageType;
     static constexpr auto dimensionality = Dimensionality;
     static constexpr bool is_const{std::is_const<storage_type>::value};
-    using const_accessor =
-        reduced_row_major<dimensionality, arithmetic_type, const storage_type>;
+    using const_accessor = reduced_row_major<dimensionality, arithmetic_type,
+                                             const storage_type, IndexType>;
 
     static_assert(Dimensionality >= 1,
                   "Dimensionality must be a positive number!");
@@ -69,7 +69,7 @@ protected:
         reference_class::reduced_storage<arithmetic_type, storage_type>;
 
 private:
-    using index_type = std::int64_t;
+    using index_type = IndexType;
 
 protected:
     /**

--- a/accessor/row_major.hpp
+++ b/accessor/row_major.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -32,7 +32,8 @@ namespace acc {
  * @tparam ValueType  type of values this accessor returns
  * @tparam Dimensionality  number of dimensions of this accessor
  */
-template <typename ValueType, size_type Dimensionality>
+template <typename ValueType, size_type Dimensionality,
+          typename IndexType = std::int64_t>
 class row_major {
 public:
     friend class range<row_major>;
@@ -55,12 +56,13 @@ public:
      */
     using data_type = value_type*;
 
-    using const_accessor = row_major<const ValueType, Dimensionality>;
+    using const_accessor =
+        row_major<const ValueType, Dimensionality, IndexType>;
     using length_type = std::array<size_type, dimensionality>;
     using stride_type = std::array<size_type, dimensionality - 1>;
 
 private:
-    using index_type = std::int64_t;
+    using index_type = IndexType;
 
 protected:
     /**

--- a/accessor/scaled_reduced_row_major.hpp
+++ b/accessor/scaled_reduced_row_major.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -127,12 +127,13 @@ private:
  * @note  This class only manages the accesses and not the memory itself.
  */
 template <std::size_t Dimensionality, typename ArithmeticType,
-          typename StorageType, std::uint64_t ScalarMask>
+          typename StorageType, std::uint64_t ScalarMask,
+          typename IndexType = std::int64_t>
 class scaled_reduced_row_major
     : public detail::enable_write_scalar<
           Dimensionality,
           scaled_reduced_row_major<Dimensionality, ArithmeticType, StorageType,
-                                   ScalarMask>,
+                                   ScalarMask, IndexType>,
           ArithmeticType, std::is_const<StorageType>::value> {
 public:
     using arithmetic_type = std::remove_cv_t<ArithmeticType>;
@@ -145,7 +146,7 @@ public:
 
     using const_accessor =
         scaled_reduced_row_major<dimensionality, arithmetic_type,
-                                 const storage_type, ScalarMask>;
+                                 const storage_type, ScalarMask, IndexType>;
 
     static_assert(!is_complex<ArithmeticType>::value &&
                       !is_complex<StorageType>::value,
@@ -173,7 +174,7 @@ protected:
         reference_class::scaled_reduced_storage<arithmetic_type, StorageType>;
 
 private:
-    using index_type = std::int64_t;
+    using index_type = IndexType;
 
 protected:
     /**

--- a/common/cuda_hip/matrix/ell_kernels.cpp
+++ b/common/cuda_hip/matrix/ell_kernels.cpp
@@ -239,8 +239,8 @@ void abstract_spmv(
 {
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
-    using a_accessor =
-        acc::reduced_row_major<1, arithmetic_type, const MatrixValueType>;
+    using a_accessor = acc::reduced_row_major<1, arithmetic_type,
+                                              const MatrixValueType, IndexType>;
     using b_accessor =
         acc::reduced_row_major<2, arithmetic_type, const InputValueType>;
 

--- a/core/matrix/csr_accessor_helper.hpp
+++ b/core/matrix/csr_accessor_helper.hpp
@@ -82,7 +82,8 @@ auto build_const_rrm_accessor(matrix::view::dense<const ValueType> input,
 template <typename ArthType, typename ValueType, typename IndexType>
 auto build_rrm_accessor(matrix::Csr<ValueType, IndexType>* input)
 {
-    using accessor = gko::acc::reduced_row_major<1, ArthType, ValueType>;
+    using accessor =
+        gko::acc::reduced_row_major<1, ArthType, ValueType, IndexType>;
     return gko::acc::range<accessor>(
         std::array<acc::size_type, 1>{
             {static_cast<acc::size_type>(input->get_num_stored_elements())}},
@@ -93,7 +94,8 @@ auto build_rrm_accessor(matrix::Csr<ValueType, IndexType>* input)
 template <typename ArthType, typename ValueType, typename IndexType>
 auto build_const_rrm_accessor(const matrix::Csr<ValueType, IndexType>* input)
 {
-    using accessor = gko::acc::reduced_row_major<1, ArthType, const ValueType>;
+    using accessor =
+        gko::acc::reduced_row_major<1, ArthType, const ValueType, IndexType>;
     return gko::acc::range<accessor>(
         std::array<acc::size_type, 1>{
             {static_cast<acc::size_type>(input->get_num_stored_elements())}},

--- a/core/matrix/fbcsr.cpp
+++ b/core/matrix/fbcsr.cpp
@@ -319,11 +319,11 @@ void Fbcsr<ValueType, IndexType>::write(mat_data& data) const
     data = {tmp->get_size(), {}};
 
     const size_type nbnz = tmp->get_num_stored_blocks();
-    const acc::range<acc::block_col_major<const value_type, 3>> vblocks(
-        std::array<acc::size_type, 3>{static_cast<acc::size_type>(nbnz),
-                                      static_cast<acc::size_type>(bs_),
-                                      static_cast<acc::size_type>(bs_)},
-        tmp->values_.get_const_data());
+    const acc::range<acc::block_col_major<const value_type, 3, IndexType>>
+        vblocks(std::array<acc::size_type, 3>{static_cast<acc::size_type>(nbnz),
+                                              static_cast<acc::size_type>(bs_),
+                                              static_cast<acc::size_type>(bs_)},
+                tmp->values_.get_const_data());
 
     for (size_type brow = 0; brow < tmp->get_num_block_rows(); ++brow) {
         const auto start = tmp->row_ptrs_.get_const_data()[brow];

--- a/core/test/accessor/block_col_major.cpp
+++ b/core/test/accessor/block_col_major.cpp
@@ -1,29 +1,31 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "accessor/block_col_major.hpp"
 
 #include <array>
-#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 
 #include "accessor/index_span.hpp"
 #include "accessor/range.hpp"
+#include "core/test/accessor/utils.hpp"
 
 
 namespace {
 
 
+template <typename IndexType>
 class BlockColMajorAccessor3d : public ::testing::Test {
 protected:
     using span = gko::acc::index_span;
     static constexpr gko::acc::size_type dimensionality{3};
 
-    using blk_col_major_range =
-        gko::acc::range<gko::acc::block_col_major<int, dimensionality>>;
+    using blk_col_major_range = gko::acc::range<
+        gko::acc::block_col_major<int, dimensionality, IndexType>>;
 
     // clang-format off
     int data[2 * 3 * 4]{
@@ -57,45 +59,49 @@ protected:
 };
 
 
-TEST_F(BlockColMajorAccessor3d, ComputesCorrectStride)
+TYPED_TEST_SUITE(BlockColMajorAccessor3d, gko::acc::test::AltIndexTypes);
+
+
+TYPED_TEST(BlockColMajorAccessor3d, ComputesCorrectStride)
 {
-    auto range_stride = default_r.get_accessor().stride;
+    auto range_stride = this->default_r.get_accessor().stride;
     auto check_stride = std::array<gko::acc::size_type, 2>{{12, 3}};
 
     ASSERT_EQ(range_stride, check_stride);
 }
 
 
-TEST_F(BlockColMajorAccessor3d, CanAccessData)
+TYPED_TEST(BlockColMajorAccessor3d, CanAccessData)
 {
-    EXPECT_EQ(default_r(0, 0, 0), 1);
-    EXPECT_EQ(custom_r(0, 0, 0), 1);
-    EXPECT_EQ(default_r(0, 1, 0), 3);
-    EXPECT_EQ(custom_r(0, 1, 0), 3);
-    EXPECT_EQ(default_r(0, 1, 1), 4);
-    EXPECT_EQ(default_r(0, 1, 3), 12);
-    EXPECT_EQ(default_r(0, 2, 2), -3);
-    EXPECT_EQ(default_r(1, 2, 1), 30);
-    EXPECT_EQ(default_r(1, 2, 2), 31);
-    EXPECT_EQ(default_r(1, 2, 3), 32);
+    EXPECT_EQ(this->default_r(0, 0, 0), 1);
+    EXPECT_EQ(this->custom_r(0, 0, 0), 1);
+    EXPECT_EQ(this->default_r(0, 1, 0), 3);
+    EXPECT_EQ(this->custom_r(0, 1, 0), 3);
+    EXPECT_EQ(this->default_r(0, 1, 1), 4);
+    EXPECT_EQ(this->default_r(0, 1, 3), 12);
+    EXPECT_EQ(this->default_r(0, 2, 2), -3);
+    EXPECT_EQ(this->default_r(1, 2, 1), 30);
+    EXPECT_EQ(this->default_r(1, 2, 2), 31);
+    EXPECT_EQ(this->default_r(1, 2, 3), 32);
 }
 
 
-TEST_F(BlockColMajorAccessor3d, CanWriteData)
+TYPED_TEST(BlockColMajorAccessor3d, CanWriteData)
 {
-    default_r(0, 0, 0) = 4;
-    custom_r(1, 1, 1) = 100;
+    this->default_r(0, 0, 0) = 4;
+    this->custom_r(1, 1, 1) = 100;
 
-    EXPECT_EQ(default_r(0, 0, 0), 4);
-    EXPECT_EQ(custom_r(0, 0, 0), 4);
-    EXPECT_EQ(default_r(1, 1, 1), 100);
-    EXPECT_EQ(custom_r(1, 1, 1), 100);
+    EXPECT_EQ(this->default_r(0, 0, 0), 4);
+    EXPECT_EQ(this->custom_r(0, 0, 0), 4);
+    EXPECT_EQ(this->default_r(1, 1, 1), 100);
+    EXPECT_EQ(this->custom_r(1, 1, 1), 100);
 }
 
 
-TEST_F(BlockColMajorAccessor3d, CanCreateSubrange)
+TYPED_TEST(BlockColMajorAccessor3d, CanCreateSubrange)
 {
-    auto subr = custom_r(span{0u, 2u}, span{1u, 2u}, span{1u, 3u});
+    using span = typename TestFixture::span;
+    auto subr = this->custom_r(span{0u, 2u}, span{1u, 2u}, span{1u, 3u});
 
     EXPECT_EQ(subr(0, 0, 0), 4);
     EXPECT_EQ(subr(0, 0, 1), -2);
@@ -104,21 +110,37 @@ TEST_F(BlockColMajorAccessor3d, CanCreateSubrange)
 }
 
 
-TEST_F(BlockColMajorAccessor3d, CanCreateRowVector)
+TYPED_TEST(BlockColMajorAccessor3d, CanCreateRowVector)
 {
-    auto subr = default_r(1u, 2u, span{0u, 2u});
+    using span = typename TestFixture::span;
+    auto subr = this->default_r(1u, 2u, span{0u, 2u});
 
     EXPECT_EQ(subr(0, 0, 0), 29);
     EXPECT_EQ(subr(0, 0, 1), 30);
 }
 
 
-TEST_F(BlockColMajorAccessor3d, CanCreateColumnVector)
+TYPED_TEST(BlockColMajorAccessor3d, CanCreateColumnVector)
 {
-    auto subr = default_r(span{0u, 2u}, 1u, 3u);
+    using span = typename TestFixture::span;
+    auto subr = this->default_r(span{0u, 2u}, 1u, 3u);
 
     EXPECT_EQ(subr(0, 0, 0), 12);
     EXPECT_EQ(subr(1, 0, 0), 28);
+}
+
+
+TYPED_TEST(BlockColMajorAccessor3d, ComputeIndexReturnsIndexType)
+{
+    using size_array = std::array<gko::acc::size_type, 3>;
+    using stride_array = std::array<gko::acc::size_type, 2>;
+    using result_type =
+        decltype(gko::acc::helper::blk_col_major::compute_index<TypeParam>(
+            std::declval<size_array>(), std::declval<stride_array>(), 0, 0, 0));
+
+    static_assert(std::is_same<result_type, TypeParam>::value,
+                  "block_col_major index computation must return IndexType");
+    SUCCEED();
 }
 
 

--- a/core/test/accessor/reduced_row_major.cpp
+++ b/core/test/accessor/reduced_row_major.cpp
@@ -1,20 +1,19 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "accessor/reduced_row_major.hpp"
 
 #include <array>
-#include <cmath>
 #include <limits>
-#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 
-#include "accessor/index_span.hpp"
 #include "accessor/range.hpp"
 #include "accessor/utils.hpp"
+#include "core/test/accessor/utils.hpp"
 
 
 namespace {
@@ -24,6 +23,7 @@ namespace {
  * This test makes sure reduced_row_major works independent of Ginkgo and with
  * dimensionalities 1 and 2.
  */
+template <typename IndexType>
 class ReducedStorageXd : public ::testing::Test {
 protected:
     using ar_type = double;
@@ -32,12 +32,14 @@ protected:
     static constexpr ar_type delta{std::numeric_limits<st_type>::epsilon() *
                                    1e1};
 
-    using accessor1d = gko::acc::reduced_row_major<1, ar_type, st_type>;
-    using accessor2d = gko::acc::reduced_row_major<2, ar_type, st_type>;
+    using accessor1d =
+        gko::acc::reduced_row_major<1, ar_type, st_type, IndexType>;
+    using accessor2d =
+        gko::acc::reduced_row_major<2, ar_type, st_type, IndexType>;
     using const_accessor1d =
-        gko::acc::reduced_row_major<1, ar_type, const st_type>;
+        gko::acc::reduced_row_major<1, ar_type, const st_type, IndexType>;
     using const_accessor2d =
-        gko::acc::reduced_row_major<2, ar_type, const st_type>;
+        gko::acc::reduced_row_major<2, ar_type, const st_type, IndexType>;
     static_assert(std::is_same<const_accessor1d,
                                typename accessor1d::const_accessor>::value,
                   "Const accessors must be the same!");
@@ -84,30 +86,47 @@ protected:
 };
 
 
-TEST_F(ReducedStorageXd, CanRead)
+TYPED_TEST_SUITE(ReducedStorageXd, gko::acc::test::AltIndexTypes);
+
+
+TYPED_TEST(ReducedStorageXd, CanRead)
 {
-    EXPECT_EQ(cr1(1), this->c_st_ar(2.2));
-    EXPECT_EQ(cr2(0, 1), this->c_st_ar(2.2));
-    EXPECT_EQ(r1(1), this->c_st_ar(2.2));
-    EXPECT_EQ(r2(0, 1), this->c_st_ar(2.2));
+    EXPECT_EQ(this->cr1(1), this->c_st_ar(2.2));
+    EXPECT_EQ(this->cr2(0, 1), this->c_st_ar(2.2));
+    EXPECT_EQ(this->r1(1), this->c_st_ar(2.2));
+    EXPECT_EQ(this->r2(0, 1), this->c_st_ar(2.2));
 }
 
 
-TEST_F(ReducedStorageXd, CanWrite1)
+TYPED_TEST(ReducedStorageXd, CanWrite1)
 {
-    r1(2) = 0.25;
+    this->r1(2) = 0.25;
 
-    data_equal_except_for(2);
-    EXPECT_EQ(r1(2), 0.25);  // expect exact since easy to store
+    this->data_equal_except_for(2);
+    EXPECT_EQ(this->r1(2), 0.25);  // expect exact since easy to store
 }
 
 
-TEST_F(ReducedStorageXd, CanWrite2)
+TYPED_TEST(ReducedStorageXd, CanWrite2)
 {
-    r2(1, 1) = 0.75;
+    this->r2(1, 1) = 0.75;
 
-    data_equal_except_for(5);
-    EXPECT_EQ(r2(1, 1), 0.75);  // expect exact since easy to store
+    this->data_equal_except_for(5);
+    EXPECT_EQ(this->r2(1, 1), 0.75);  // expect exact since easy to store
+}
+
+
+TYPED_TEST(ReducedStorageXd, ComputeIndexReturnsIndexType)
+{
+    using size_array = std::array<gko::acc::size_type, 2>;
+    using stride_array = std::array<gko::acc::size_type, 1>;
+    using result_type =
+        decltype(gko::acc::helper::compute_row_major_index<TypeParam>(
+            std::declval<size_array>(), std::declval<stride_array>(), 0, 0));
+
+    static_assert(std::is_same<result_type, TypeParam>::value,
+                  "reduced_row_major index computation must return IndexType");
+    SUCCEED();
 }
 
 

--- a/core/test/accessor/row_major.cpp
+++ b/core/test/accessor/row_major.cpp
@@ -1,17 +1,18 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "accessor/row_major.hpp"
 
 #include <array>
-#include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 
 #include "accessor/index_span.hpp"
 #include "accessor/range.hpp"
+#include "core/test/accessor/utils.hpp"
 
 
 namespace {
@@ -197,6 +198,41 @@ TEST_F(RowMajorAccessor3d, CanAssignValues)
     default_r(1, 1, 1) = default_r(0, 0, 0);
 
     EXPECT_EQ(data[17], 1);
+}
+
+
+template <typename IndexType>
+class RowMajorIndexType : public RowMajorAccessor {};
+
+TYPED_TEST_SUITE(RowMajorIndexType, gko::acc::test::AltIndexTypes);
+
+TYPED_TEST(RowMajorIndexType, AddressMatchesDefaultIndexType)
+{
+    using alt = gko::acc::row_major<int, 2, TypeParam>;
+    gko::acc::range<alt> r_alt{typename TestFixture::dim_type{{3u, 2u}},
+                               this->data,
+                               typename TestFixture::stride_type{{3u}}};
+
+    EXPECT_EQ(this->r(0, 0), r_alt(0, 0));
+    EXPECT_EQ(this->r(1, 1), r_alt(1, 1));
+    EXPECT_EQ(this->r(2, 1), r_alt(2, 1));
+
+    r_alt(2, 0) = 42;
+    EXPECT_EQ(this->r(2, 0), 42);
+}
+
+
+TYPED_TEST(RowMajorIndexType, ComputeIndexReturnsIndexType)
+{
+    using size_array = std::array<gko::acc::size_type, 2>;
+    using stride_array = std::array<gko::acc::size_type, 1>;
+    using result_type =
+        decltype(gko::acc::helper::compute_row_major_index<TypeParam>(
+            std::declval<size_array>(), std::declval<stride_array>(), 0, 0));
+
+    static_assert(std::is_same<result_type, TypeParam>::value,
+                  "row_major index computation must return IndexType");
+    SUCCEED();
 }
 
 

--- a/core/test/accessor/scaled_reduced_row_major.cpp
+++ b/core/test/accessor/scaled_reduced_row_major.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -9,11 +9,13 @@
 #include <limits>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include <gtest/gtest.h>
 
 #include "accessor/index_span.hpp"
 #include "accessor/range.hpp"
+#include "core/test/accessor/utils.hpp"
 
 
 namespace {
@@ -362,14 +364,16 @@ protected:
     using size_type = gko::acc::size_type;
     static constexpr ar_type delta{0.1};
 
-    using accessor1d =
-        gko::acc::scaled_reduced_row_major<1, ar_type, st_type, 1>;
-    using accessor2d =
-        gko::acc::scaled_reduced_row_major<2, ar_type, st_type, 3>;
+    using accessor1d = gko::acc::scaled_reduced_row_major<1, ar_type, st_type,
+                                                          1, std::int32_t>;
+    using accessor2d = gko::acc::scaled_reduced_row_major<2, ar_type, st_type,
+                                                          3, std::int32_t>;
     using const_accessor1d =
-        gko::acc::scaled_reduced_row_major<1, ar_type, const st_type, 1>;
+        gko::acc::scaled_reduced_row_major<1, ar_type, const st_type, 1,
+                                           std::int32_t>;
     using const_accessor2d =
-        gko::acc::scaled_reduced_row_major<2, ar_type, const st_type, 3>;
+        gko::acc::scaled_reduced_row_major<2, ar_type, const st_type, 3,
+                                           std::int32_t>;
     static_assert(std::is_same<const_accessor1d,
                                typename accessor1d::const_accessor>::value,
                   "Const accessors must be the same!");
@@ -455,6 +459,49 @@ TEST_F(ScaledReducedStorageXd, CanWrite2)
     data_equal_except_for(5);
     scalar_equal_except_for(99);
     EXPECT_NEAR(r2(1, 1), 0.5, delta);
+}
+
+
+template <typename IndexType>
+class ScaledReducedStorageXdIndexType : public ScaledReducedStorageXd {};
+
+TYPED_TEST_SUITE(ScaledReducedStorageXdIndexType,
+                 gko::acc::test::AltIndexTypes);
+
+TYPED_TEST(ScaledReducedStorageXdIndexType, AddressMatchesDefaultIndexType)
+{
+    using ar_type = typename TestFixture::ar_type;
+    using st_type = typename TestFixture::st_type;
+
+    using ref_acc = gko::acc::scaled_reduced_row_major<2, ar_type, st_type, 3>;
+    using alt_acc =
+        gko::acc::scaled_reduced_row_major<2, ar_type, st_type, 3, TypeParam>;
+    gko::acc::range<ref_acc> ref{this->size_2d, this->data, this->stride1,
+                                 this->scalar, this->stride_sc};
+    gko::acc::range<alt_acc> alt{this->size_2d, this->data, this->stride1,
+                                 this->scalar, this->stride_sc};
+
+    EXPECT_EQ(ref(0, 0), alt(0, 0));
+    EXPECT_EQ(ref(0, 1), alt(0, 1));
+    EXPECT_EQ(ref(1, 1), alt(1, 1));
+
+    alt(0, 0) = ar_type{7.0};
+    EXPECT_EQ(ref(0, 0), alt(0, 0));
+}
+
+
+TYPED_TEST(ScaledReducedStorageXdIndexType, ComputeIndexReturnsIndexType)
+{
+    using size_array = std::array<gko::acc::size_type, 2>;
+    using stride_array = std::array<gko::acc::size_type, 1>;
+    using result_type =
+        decltype(gko::acc::helper::compute_row_major_index<TypeParam>(
+            std::declval<size_array>(), std::declval<stride_array>(), 0, 0));
+
+    static_assert(
+        std::is_same<result_type, TypeParam>::value,
+        "scaled_reduced_row_major index computation must return IndexType");
+    SUCCEED();
 }
 
 

--- a/core/test/accessor/utils.hpp
+++ b/core/test/accessor/utils.hpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_CORE_TEST_ACCESSOR_UTILS_HPP_
+#define GKO_CORE_TEST_ACCESSOR_UTILS_HPP_
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+
+namespace gko {
+namespace acc {
+namespace test {
+
+
+using AltIndexTypes =
+    ::testing::Types<std::int64_t, std::int32_t, std::uint32_t>;
+
+
+}  // namespace test
+}  // namespace acc
+}  // namespace gko
+
+#endif  // GKO_CORE_TEST_ACCESSOR_UTILS_HPP_

--- a/dpcpp/matrix/ell_kernels.dp.cpp
+++ b/dpcpp/matrix/ell_kernels.dp.cpp
@@ -312,7 +312,8 @@ void abstract_spmv(
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
     using a_accessor =
-        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType>;
+        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType,
+                                    IndexType>;
     using b_accessor =
         gko::acc::reduced_row_major<2, arithmetic_type, const InputValueType>;
 

--- a/omp/matrix/dense_kernels.cpp
+++ b/omp/matrix/dense_kernels.cpp
@@ -249,7 +249,7 @@ void convert_to_fbcsr(std::shared_ptr<const DefaultExecutor> exec,
     const auto nzbs = result->get_num_stored_blocks();
     const auto num_block_rows = num_rows / bs;
     const auto num_block_cols = num_cols / bs;
-    acc::range<acc::block_col_major<ValueType, 3>> blocks(
+    acc::range<acc::block_col_major<ValueType, 3, IndexType>> blocks(
         std::array<acc::size_type, 3>{static_cast<acc::size_type>(nzbs),
                                       static_cast<acc::size_type>(bs),
                                       static_cast<acc::size_type>(bs)},

--- a/omp/matrix/ell_kernels.cpp
+++ b/omp/matrix/ell_kernels.cpp
@@ -39,7 +39,8 @@ void spmv_small_rhs(std::shared_ptr<const OmpExecutor> exec,
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
     using a_accessor =
-        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType>;
+        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType,
+                                    IndexType>;
     using b_accessor =
         gko::acc::reduced_row_major<2, arithmetic_type, const InputValueType>;
 
@@ -88,7 +89,8 @@ void spmv_blocked(std::shared_ptr<const OmpExecutor> exec,
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
     using a_accessor =
-        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType>;
+        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType,
+                                    IndexType>;
     using b_accessor =
         gko::acc::reduced_row_major<2, arithmetic_type, const InputValueType>;
 

--- a/omp/matrix/fbcsr_kernels.cpp
+++ b/omp/matrix/fbcsr_kernels.cpp
@@ -49,8 +49,9 @@ void spmv(std::shared_ptr<const OmpExecutor> exec,
     const size_type nbnz = a->get_num_stored_blocks();
     auto row_ptrs = a->get_const_row_ptrs();
     auto col_idxs = a->get_const_col_idxs();
-    const acc::range<acc::block_col_major<const ValueType, 3>> avalues{
-        to_std_array<acc::size_type>(nbnz, bs, bs), a->get_const_values()};
+    const acc::range<acc::block_col_major<const ValueType, 3, IndexType>>
+        avalues{to_std_array<acc::size_type>(nbnz, bs, bs),
+                a->get_const_values()};
 
 #pragma omp parallel for
     for (IndexType ibrow = 0; ibrow < nbrows; ++ibrow) {
@@ -94,8 +95,9 @@ void advanced_spmv(std::shared_ptr<const OmpExecutor> exec,
     auto col_idxs = a->get_const_col_idxs();
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
-    const acc::range<acc::block_col_major<const ValueType, 3>> avalues{
-        to_std_array<acc::size_type>(nbnz, bs, bs), a->get_const_values()};
+    const acc::range<acc::block_col_major<const ValueType, 3, IndexType>>
+        avalues{to_std_array<acc::size_type>(nbnz, bs, bs),
+                a->get_const_values()};
 
 #pragma omp parallel for
     for (IndexType ibrow = 0; ibrow < nbrows; ++ibrow) {

--- a/reference/matrix/dense_kernels.cpp
+++ b/reference/matrix/dense_kernels.cpp
@@ -561,7 +561,7 @@ void convert_to_fbcsr(std::shared_ptr<const ReferenceExecutor> exec,
     const auto nzbs = result->get_num_stored_blocks();
     const auto num_block_rows = num_rows / bs;
     const auto num_block_cols = num_cols / bs;
-    acc::range<acc::block_col_major<ValueType, 3>> blocks(
+    acc::range<acc::block_col_major<ValueType, 3, IndexType>> blocks(
         std::array<acc::size_type, 3>{static_cast<acc::size_type>(nzbs),
                                       static_cast<acc::size_type>(bs),
                                       static_cast<acc::size_type>(bs)},

--- a/reference/matrix/ell_kernels.cpp
+++ b/reference/matrix/ell_kernels.cpp
@@ -34,7 +34,8 @@ void spmv(std::shared_ptr<const ReferenceExecutor> exec,
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
     using a_accessor =
-        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType>;
+        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType,
+                                    IndexType>;
     using b_accessor =
         gko::acc::reduced_row_major<2, arithmetic_type, const InputValueType>;
 
@@ -81,7 +82,8 @@ void advanced_spmv(std::shared_ptr<const ReferenceExecutor> exec,
     using arithmetic_type =
         highest_precision<InputValueType, OutputValueType, MatrixValueType>;
     using a_accessor =
-        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType>;
+        gko::acc::reduced_row_major<1, arithmetic_type, const MatrixValueType,
+                                    IndexType>;
     using b_accessor =
         gko::acc::reduced_row_major<2, arithmetic_type, const InputValueType>;
 

--- a/reference/matrix/fbcsr_kernels.cpp
+++ b/reference/matrix/fbcsr_kernels.cpp
@@ -50,8 +50,9 @@ void spmv(const std::shared_ptr<const ReferenceExecutor>,
     const size_type nbnz = a->get_num_stored_blocks();
     auto row_ptrs = a->get_const_row_ptrs();
     auto col_idxs = a->get_const_col_idxs();
-    const acc::range<acc::block_col_major<const ValueType, 3>> avalues{
-        to_std_array<acc::size_type>(nbnz, bs, bs), a->get_const_values()};
+    const acc::range<acc::block_col_major<const ValueType, 3, IndexType>>
+        avalues{to_std_array<acc::size_type>(nbnz, bs, bs),
+                a->get_const_values()};
 
     for (IndexType ibrow = 0; ibrow < nbrows; ++ibrow) {
         for (IndexType row = ibrow * bs; row < (ibrow + 1) * bs; ++row) {
@@ -94,8 +95,9 @@ void advanced_spmv(const std::shared_ptr<const ReferenceExecutor>,
     auto col_idxs = a->get_const_col_idxs();
     auto valpha = alpha(0, 0);
     auto vbeta = beta(0, 0);
-    const acc::range<acc::block_col_major<const ValueType, 3>> avalues{
-        to_std_array<acc::size_type>(nbnz, bs, bs), a->get_const_values()};
+    const acc::range<acc::block_col_major<const ValueType, 3, IndexType>>
+        avalues{to_std_array<acc::size_type>(nbnz, bs, bs),
+                a->get_const_values()};
 
     for (IndexType ibrow = 0; ibrow < nbrows; ++ibrow) {
         for (IndexType row = ibrow * bs; row < (ibrow + 1) * bs; ++row) {


### PR DESCRIPTION
Changes:
- Add an IndexType template parameter to every accessor
- Thread it through the concrete matrices that use them
