### PR TITLE
Workaround for LNK1189 too many symbol issue with CMake 4.1+ and MSVC

### DIFF
--- a/.github/workflows/windows-msvc.yml
+++ b/.github/workflows/windows-msvc.yml
@@ -27,9 +27,10 @@ jobs:
   windows:
     strategy:
       fail-fast: false
-    name: msvc
-    runs-on: [windows-latest]
-
+      matrix:
+        os: [windows-2022, windows-latest]
+    name: msvc/${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout the latest code (shallow clone)
       uses: actions/checkout@v4
@@ -46,6 +47,5 @@ jobs:
         refreshenv
         mkdir build
         cd build
-        cmake -DGINKGO_BUILD_OMP=OFF -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
+        cmake -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_REFERENCE=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF -DGINKGO_BUILD_TESTS=OFF -DGINKGO_ENABLE_HALF=OFF -DGINKGO_ENABLE_BFLOAT16=OFF ..
         cmake --build . -j4 --config Release
-        ctest . -C Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,11 @@ if(MSVC)
     # MSVC has macro for min/max, it leads C2589 issue with CUDA 13.2.
     # We disable it by -DNOMINMAX
     # similar issue: https://stackoverflow.com/questions/1825904/error-c2589-on-stdnumeric-limitsdoublemin
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNOMINMAX /bigobj /permissive-")
+    # After CMake 4.1, they do not add several flags for MSVC. (see Other Changes section in https://cmake.org/cmake/help/v4.1/release/4.1.html)
+    # `/Zc:inline` is required in Ginkgo to reduce the symbol significantly, so we add it back here.
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -DNOMINMAX /bigobj /permissive- /Zc:inline"
+    )
 endif()
 if(MINGW OR CYGWIN)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
We have LNK1189 too many symbols issues in latest windows github action runner.

After digging into the version changes, it has this issue in CMake 4.1+ with MSVC 2022/2026.

In "Other changes" section in the CMake 4.1 release note https://cmake.org/cmake/help/v4.1/release/4.1.html
> The [Visual Studio Generators](https://cmake.org/cmake/help/v4.1/manual/cmake-generators.7.html#visual-studio-generators) now suppress Visual Studio's default -Zc:forScope, -Zc:inline, and -Zc:wchar_t compiler flags, and -dynamicbase, -errorreport, -nxcompat, and -safeseh link flags, if they are not specified by the project or user. This makes builds more consistent with other generators, and with what projects and users actually specify.

We need to add `/Zc:inline` back to `CMAKE_CXX_FLAGS` when using MSVC to avoid the symbol explosion.

I check core\ginkgo_core.dir\Release\exports.def and it seems to give 3x counts without `/Zc:inline`. However, I am not fully sure it is the right place to check. If anyone knows how to measure it properly, it will be really helpful.