### PR TITLE
sonarcloud: do not analyze the test as source file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,6 @@ sonar.cfamily.threads=10
 
 sonar.sources=.
 sonar.tests=.
-sonar.exclusions="third_party/**, build/**"
-sonar.test.exclusions="benchmark/**, doc/**, examples/**"
-sonar.test.inclusions="*/test/**"
-sonar.coverage.exclusions="third_party/**, build/**, benchmark/**, doc/**, examples/**"
+sonar.exclusions="third_party/**, build/**, doc/**, assets/**, **/test/**"
+sonar.test.inclusions="**/test/**"
+sonar.coverage.exclusions="third_party/**, build/**, benchmark/**, doc/**, examples/**, assets/**, **/test/**"


### PR DESCRIPTION
we do not remove the test out of the source analysis previously.

for example, we have the following in the analysis step
test/matrix/matrix.cpp	36,502,247 ms -> ~10hours
test/solver/solver.cpp	16,431,614 ms -> ~4.5hours

It is compared against to the develop so we only have empty analysis on the webpage
It is the old setting https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/15378927117 (17h20m)
exclude test from source https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/15381742388 (5h40m)
It might have some ccache effect.


Some utils helper in test currently not in the source analysis.
It is doable under the current folder structure, but it will introduce many condition in the settings.
So, if we would like to put them in analysis, I will prefer rearranging the folder structure to make rule easier.