### PR TITLE
Combine serveral ConvertibleTo

### DIFF
--- a/core/matrix/coo.cpp
+++ b/core/matrix/coo.cpp
@@ -220,8 +220,9 @@ void Coo<ValueType, IndexType>::apply2_impl(const LinOp* alpha, const LinOp* b,
 
 
 template <typename ValueType, typename IndexType>
-void Coo<ValueType, IndexType>::convert_to(
-    Coo<next_precision<ValueType>, IndexType>* result) const
+template <typename ResultValueType>
+void Coo<ValueType, IndexType>::convert_to_impl(
+    Coo<ResultValueType, IndexType>* result) const
 {
     result->values_ = this->values_;
     result->row_idxs_ = this->row_idxs_;
@@ -231,53 +232,12 @@ void Coo<ValueType, IndexType>::convert_to(
 
 
 template <typename ValueType, typename IndexType>
-void Coo<ValueType, IndexType>::move_to(
-    Coo<next_precision<ValueType>, IndexType>* result)
+template <typename ResultValueType>
+void Coo<ValueType, IndexType>::move_to_impl(
+    Coo<ResultValueType, IndexType>* result)
 {
     this->convert_to(result);
 }
-
-
-#if GINKGO_ENABLE_HALF || GINKGO_ENABLE_BFLOAT16
-template <typename ValueType, typename IndexType>
-void Coo<ValueType, IndexType>::convert_to(
-    Coo<next_precision<ValueType, 2>, IndexType>* result) const
-{
-    result->values_ = this->values_;
-    result->row_idxs_ = this->row_idxs_;
-    result->col_idxs_ = this->col_idxs_;
-    result->set_size(this->get_size());
-}
-
-
-template <typename ValueType, typename IndexType>
-void Coo<ValueType, IndexType>::move_to(
-    Coo<next_precision<ValueType, 2>, IndexType>* result)
-{
-    this->convert_to(result);
-}
-#endif
-
-
-#if GINKGO_ENABLE_HALF && GINKGO_ENABLE_BFLOAT16
-template <typename ValueType, typename IndexType>
-void Coo<ValueType, IndexType>::convert_to(
-    Coo<next_precision<ValueType, 3>, IndexType>* result) const
-{
-    result->values_ = this->values_;
-    result->row_idxs_ = this->row_idxs_;
-    result->col_idxs_ = this->col_idxs_;
-    result->set_size(this->get_size());
-}
-
-
-template <typename ValueType, typename IndexType>
-void Coo<ValueType, IndexType>::move_to(
-    Coo<next_precision<ValueType, 3>, IndexType>* result)
-{
-    this->convert_to(result);
-}
-#endif
 
 
 template <typename ValueType, typename IndexType>

--- a/include/ginkgo/core/base/conversion.hpp
+++ b/include/ginkgo/core/base/conversion.hpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef GKO_PUBLIC_CORE_BASE_CONVERSION_HPP_
+#define GKO_PUBLIC_CORE_BASE_CONVERSION_HPP_
+
+
+#include <tuple>
+
+#include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/base/polymorphic_object.hpp>
+
+namespace gko {
+namespace detail {
+
+
+using precision_list = std::tuple<
+#if GINKGO_ENABLE_HALF
+    half,
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    bfloat16,
+#endif
+    float, double>;
+
+template <typename Removed, typename Tuple, typename Current>
+struct remove_type {};
+
+template <typename Removed, typename... Current>
+struct remove_type<Removed, std::tuple<>, std::tuple<Current...>> {
+    using type = std::tuple<Current...>;
+};
+
+template <typename Removed, typename V, typename... Rest, typename... Current>
+struct remove_type<Removed, std::tuple<V, Rest...>, std::tuple<Current...>> {
+    using type = typename remove_type<Removed, std::tuple<Rest...>,
+                                      std::tuple<Current..., V>>::type;
+};
+
+template <typename Removed, typename... Rest, typename... Current>
+struct remove_type<Removed, std::tuple<Removed, Rest...>,
+                   std::tuple<Current...>> {
+    using type = typename remove_type<Removed, std::tuple<Rest...>,
+                                      std::tuple<Current...>>::type;
+};
+
+template <typename T, typename List>
+using get_precision_list = typename remove_type<
+    T,
+    std::conditional_t<is_complex_impl<T>::value,
+                       typename to_complex_s<List>::type, List>,
+    std::tuple<>>::type;
+
+
+}  // namespace detail
+
+
+template <typename ConcreteType, typename ResultType>
+class EnableConvertibleTo : public ConvertibleTo<ResultType> {
+public:
+    void convert_to(ResultType* result) const override
+    {
+        self()->convert_to_impl(result);
+    }
+
+    void move_to(ResultType* result) override { self()->move_to_impl(result); }
+
+private:
+    GKO_ENABLE_SELF(ConcreteType);
+};
+
+
+template <typename Class, typename List>
+class EnableConvertibleToList {};
+
+template <template <typename, typename...> class Class, typename... List,
+          typename V, typename... Rest>
+class EnableConvertibleToList<Class<V, Rest...>, std::tuple<List...>>
+    : public EnableConvertibleTo<Class<V, Rest...>, Class<List, Rest...>>... {};
+
+
+}  // namespace gko
+
+#endif  // GKO_PUBLIC_CORE_BASE_CONVERSION_HPP_

--- a/include/ginkgo/core/matrix/coo.hpp
+++ b/include/ginkgo/core/matrix/coo.hpp
@@ -7,6 +7,7 @@
 
 
 #include <ginkgo/core/base/array.hpp>
+#include <ginkgo/core/base/conversion.hpp>
 #include <ginkgo/core/base/lin_op.hpp>
 #include <ginkgo/core/matrix/device_views.hpp>
 
@@ -50,13 +51,10 @@ class Hybrid;
 template <typename ValueType = default_precision, typename IndexType = int32>
 class Coo : public LinOp,
             public EnableCloneable<Coo<ValueType, IndexType>>,
-            public ConvertibleTo<Coo<next_precision<ValueType>, IndexType>>,
-#if GINKGO_ENABLE_HALF || GINKGO_ENABLE_BFLOAT16
-            public ConvertibleTo<Coo<next_precision<ValueType, 2>, IndexType>>,
-#endif
-#if GINKGO_ENABLE_HALF && GINKGO_ENABLE_BFLOAT16
-            public ConvertibleTo<Coo<next_precision<ValueType, 3>, IndexType>>,
-#endif
+            public EnableConvertibleToList<
+                Coo<ValueType, IndexType>,
+                gko::detail::get_precision_list<ValueType,
+                                                gko::detail::precision_list>>,
             public ConvertibleTo<Csr<ValueType, IndexType>>,
             public ConvertibleTo<Dense<ValueType>>,
             public DiagonalExtractable<ValueType>,
@@ -94,36 +92,14 @@ public:
     using const_device_view =
         matrix::view::coo<const value_type, const index_type>;
 
-    friend class Coo<previous_precision<ValueType>, IndexType>;
+    template <typename FriendValueType, typename FriendIndexType>
+    friend class Coo;
 
-    void convert_to(
-        Coo<next_precision<ValueType>, IndexType>* result) const override;
+    template <typename ResultValueType>
+    void convert_to_impl(Coo<ResultValueType, IndexType>* result) const;
 
-    void move_to(Coo<next_precision<ValueType>, IndexType>* result) override;
-
-#if GINKGO_ENABLE_HALF || GINKGO_ENABLE_BFLOAT16
-    friend class Coo<previous_precision<ValueType, 2>, IndexType>;
-    using ConvertibleTo<
-        Coo<next_precision<ValueType, 2>, IndexType>>::convert_to;
-    using ConvertibleTo<Coo<next_precision<ValueType, 2>, IndexType>>::move_to;
-
-    void convert_to(
-        Coo<next_precision<ValueType, 2>, IndexType>* result) const override;
-
-    void move_to(Coo<next_precision<ValueType, 2>, IndexType>* result) override;
-#endif
-
-#if GINKGO_ENABLE_HALF && GINKGO_ENABLE_BFLOAT16
-    friend class Coo<previous_precision<ValueType, 3>, IndexType>;
-    using ConvertibleTo<
-        Coo<next_precision<ValueType, 3>, IndexType>>::convert_to;
-    using ConvertibleTo<Coo<next_precision<ValueType, 3>, IndexType>>::move_to;
-
-    void convert_to(
-        Coo<next_precision<ValueType, 3>, IndexType>* result) const override;
-
-    void move_to(Coo<next_precision<ValueType, 3>, IndexType>* result) override;
-#endif
+    template <typename ResultValueType>
+    void move_to_impl(Coo<ResultValueType, IndexType>* result);
 
     void convert_to(Csr<ValueType, IndexType>* other) const override;
 


### PR DESCRIPTION
We have ConvertibleTo and usually for each precision we support.
Previously, we use the `next_precision` and macro condition to support them properly.
Alternatively, we can merge them together and use template such that it inherit from all `ConvertibleTo<Class<Precision, Rest...>>`

Also, we can use mixin such that it use the template implementation automatically. (EnableConvertibleTo)
However, the mixin using the template member function does not implicit instantiate the function.

Some direction in my mind
- only combine the inheritance: we will still have convert_to(next_precision) with macro
- use mixin with template: need to have macro for instantiation
  - alternatively, use runtime dispatch in internal function, such that they are implicitly instantiated (I somehow like this way, but I also feel making some unused internal function is a bit weird)
- use mixin with variant/runtime dispatch: similar to the above but merge runtime dispatch without template. However, it makes the result type to common type (or variant) and then cast back to the result type.
- any idea?