### PR TITLE
Writable to matrix data

### DIFF
--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -478,6 +478,7 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void Matrix<ValueType, LocalIndexType, GlobalIndexType>::write(
     matrix_data<value_type, global_index_type>& data) const
 {
+    GKO_ASSERT_IS_SQUARE_MATRIX(this);
     auto local_data = matrix_data<value_type, local_index_type>{};
     auto non_local_data = matrix_data<value_type, local_index_type>{};
     as<WritableToMatrixData<ValueType, LocalIndexType>>(this->local_mtx_)

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -479,18 +479,17 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::write(
     matrix_data<value_type, global_index_type>& data) const
 {
     GKO_ASSERT_IS_SQUARE_MATRIX(this);
-    auto local_data = matrix_data<value_type, local_index_type>{};
-    auto non_local_data = matrix_data<value_type, local_index_type>{};
-    as<WritableToMatrixData<ValueType, LocalIndexType>>(this->local_mtx_)
-        ->write(local_data);
-    as<WritableToMatrixData<ValueType, LocalIndexType>>(this->non_local_mtx_)
-        ->write(non_local_data);
+    auto diag_data = matrix_data<value_type, local_index_type>{};
+    auto off_diag_data = matrix_data<value_type, local_index_type>{};
+    as<WritableToMatrixData<ValueType, LocalIndexType>>(this->diag_mtx_)
+        ->write(diag_data);
+    as<WritableToMatrixData<ValueType, LocalIndexType>>(this->off_diag_mtx_)
+        ->write(off_diag_data);
 
     data = {this->get_size(), {}};
     auto exec = this->get_executor();
-    append_global_matrix_data(exec, local_data, imap_, index_space::local,
-                              data);
-    append_global_matrix_data(exec, non_local_data, imap_,
+    append_global_matrix_data(exec, diag_data, imap_, index_space::local, data);
+    append_global_matrix_data(exec, off_diag_data, imap_,
                               index_space::non_local, data);
     data.sort_row_major();
 }

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -34,6 +34,47 @@ GKO_REGISTER_OPERATION(separate_diag_off_diag,
 }  // namespace matrix
 
 
+namespace {
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+void append_global_matrix_data(
+    std::shared_ptr<const Executor> exec,
+    const matrix_data<ValueType, LocalIndexType>& local_data,
+    const index_map<LocalIndexType, GlobalIndexType>& row_map,
+    const index_map<LocalIndexType, GlobalIndexType>& col_map,
+    index_space col_space, matrix_data<ValueType, GlobalIndexType>& result)
+{
+    if (local_data.nonzeros.empty()) {
+        return;
+    }
+
+    auto device_data =
+        device_matrix_data<ValueType, LocalIndexType>::create_from_host(
+            exec, local_data);
+    const auto nnz = device_data.get_num_stored_elements();
+    auto local_row_idxs =
+        make_array_view(exec, nnz, device_data.get_row_idxs());
+    auto local_col_idxs =
+        make_array_view(exec, nnz, device_data.get_col_idxs());
+    auto global_row_idxs =
+        row_map.map_to_global(local_row_idxs, index_space::local);
+    auto global_col_idxs = col_map.map_to_global(local_col_idxs, col_space);
+    auto values = make_array_view(exec, nnz, device_data.get_values());
+    auto global_data =
+        device_matrix_data<ValueType, GlobalIndexType>{
+            exec, result.size, std::move(global_row_idxs),
+            std::move(global_col_idxs), std::move(values)}
+            .copy_to_host();
+
+    result.nonzeros.insert(result.nonzeros.end(), global_data.nonzeros.begin(),
+                           global_data.nonzeros.end());
+}
+
+
+}  // namespace
+
+
 template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
     std::shared_ptr<const Executor> exec, mpi::communicator comm)
@@ -73,6 +114,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       DistributedBase{comm},
       row_gatherer_{RowGatherer<LocalIndexType>::create(
           exec, mpi::detail::create_default_collective_communicator(comm))},
+      row_map_{exec},
       imap_{exec},
       one_scalar_{exec, 1.0},
       off_diag_mtx_(::gko::matrix::Coo<ValueType, LocalIndexType>::create(
@@ -94,6 +136,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
           mpi::detail::create_default_collective_communicator(comm)
               ->create_with_same_type(comm, &imap),
           imap)),
+      row_map_(imap),
       imap_(std::move(imap)),
       one_scalar_{exec, 1.0}
 {
@@ -265,6 +308,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
     as<Cloneable>(result->off_diag_mtx_)
         ->move_from(as<Cloneable>(this->off_diag_mtx_.get()));
     result->row_gatherer_->move_from(this->row_gatherer_);
+    result->row_map_ = std::move(this->row_map_);
     result->imap_ = std::move(this->imap_);
     result->set_size(this->get_size());
     this->set_size({});
@@ -285,6 +329,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::convert_to(
     as<Cloneable>(result->off_diag_mtx_)
         ->copy_from(as<Cloneable>(this->off_diag_mtx_.get()));
     result->row_gatherer_->copy_from(this->row_gatherer_);
+    result->row_map_ = this->row_map_;
     result->imap_ = this->imap_;
     result->set_size(this->get_size());
 }
@@ -302,6 +347,7 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
     as<Cloneable>(result->off_diag_mtx_)
         ->move_from(as<Cloneable>(this->off_diag_mtx_.get()));
     result->row_gatherer_->move_from(this->row_gatherer_);
+    result->row_map_ = std::move(this->row_map_);
     result->imap_ = std::move(this->imap_);
     result->set_size(this->get_size());
     this->set_size({});
@@ -344,6 +390,8 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
     auto global_num_cols = col_partition->get_size();
     dim<2> global_dim{global_num_rows, global_num_cols};
     this->set_size(global_dim);
+    row_map_ = index_map<local_index_type, global_index_type>(
+        exec, row_partition, comm.rank(), array<global_index_type>{exec});
 
     // temporary storage for the output
     array<local_index_type> diag_row_idxs{exec};
@@ -431,6 +479,27 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
     assembly_mode assembly_type)
 {
     return this->read_distributed(data, partition, partition, assembly_type);
+}
+
+
+template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
+void Matrix<ValueType, LocalIndexType, GlobalIndexType>::write(
+    matrix_data<value_type, global_index_type>& data) const
+{
+    auto local_data = matrix_data<value_type, local_index_type>{};
+    auto non_local_data = matrix_data<value_type, local_index_type>{};
+    as<WritableToMatrixData<ValueType, LocalIndexType>>(this->local_mtx_)
+        ->write(local_data);
+    as<WritableToMatrixData<ValueType, LocalIndexType>>(this->non_local_mtx_)
+        ->write(non_local_data);
+
+    data = {this->get_size(), {}};
+    auto exec = this->get_executor();
+    append_global_matrix_data(exec, local_data, row_map_, imap_,
+                              index_space::local, data);
+    append_global_matrix_data(exec, non_local_data, row_map_, imap_,
+                              index_space::non_local, data);
+    data.sort_row_major();
 }
 
 
@@ -686,6 +755,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(const Matrix& other)
       DistributedBase{other.get_communicator()},
       row_gatherer_{RowGatherer<LocalIndexType>::create(
           other.get_executor(), other.get_communicator())},
+      row_map_(other.get_executor()),
       imap_(other.get_executor()),
       one_scalar_(other.get_executor(), 1.0)
 {
@@ -700,6 +770,7 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       DistributedBase{other.get_communicator()},
       row_gatherer_{RowGatherer<LocalIndexType>::create(
           other.get_executor(), other.get_communicator())},
+      row_map_(other.get_executor()),
       imap_(other.get_executor()),
       one_scalar_(other.get_executor(), 1.0)
 {

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -119,6 +119,11 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
           exec, dim<2>{diag_linop->get_size()[0], 0}))
 {
     this->set_size(size);
+    auto partition =
+        share(build_partition_from_local_size<LocalIndexType, GlobalIndexType>(
+            exec, comm, diag_linop->get_size()[0]));
+    imap_ = index_map<local_index_type, global_index_type>(
+        exec, partition, comm.rank(), array<global_index_type>{exec});
     diag_mtx_ = std::move(diag_linop);
 }
 

--- a/core/distributed/matrix.cpp
+++ b/core/distributed/matrix.cpp
@@ -41,8 +41,7 @@ template <typename ValueType, typename LocalIndexType, typename GlobalIndexType>
 void append_global_matrix_data(
     std::shared_ptr<const Executor> exec,
     const matrix_data<ValueType, LocalIndexType>& local_data,
-    const index_map<LocalIndexType, GlobalIndexType>& row_map,
-    const index_map<LocalIndexType, GlobalIndexType>& col_map,
+    const index_map<LocalIndexType, GlobalIndexType>& imap,
     index_space col_space, matrix_data<ValueType, GlobalIndexType>& result)
 {
     if (local_data.nonzeros.empty()) {
@@ -58,8 +57,8 @@ void append_global_matrix_data(
     auto local_col_idxs =
         make_array_view(exec, nnz, device_data.get_col_idxs());
     auto global_row_idxs =
-        row_map.map_to_global(local_row_idxs, index_space::local);
-    auto global_col_idxs = col_map.map_to_global(local_col_idxs, col_space);
+        imap.map_to_global(local_row_idxs, index_space::local);
+    auto global_col_idxs = imap.map_to_global(local_col_idxs, col_space);
     auto values = make_array_view(exec, nnz, device_data.get_values());
     auto global_data =
         device_matrix_data<ValueType, GlobalIndexType>{
@@ -114,7 +113,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       DistributedBase{comm},
       row_gatherer_{RowGatherer<LocalIndexType>::create(
           exec, mpi::detail::create_default_collective_communicator(comm))},
-      row_map_{exec},
       imap_{exec},
       one_scalar_{exec, 1.0},
       off_diag_mtx_(::gko::matrix::Coo<ValueType, LocalIndexType>::create(
@@ -136,7 +134,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
           mpi::detail::create_default_collective_communicator(comm)
               ->create_with_same_type(comm, &imap),
           imap)),
-      row_map_(imap),
       imap_(std::move(imap)),
       one_scalar_{exec, 1.0}
 {
@@ -308,7 +305,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
     as<Cloneable>(result->off_diag_mtx_)
         ->move_from(as<Cloneable>(this->off_diag_mtx_.get()));
     result->row_gatherer_->move_from(this->row_gatherer_);
-    result->row_map_ = std::move(this->row_map_);
     result->imap_ = std::move(this->imap_);
     result->set_size(this->get_size());
     this->set_size({});
@@ -329,7 +325,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::convert_to(
     as<Cloneable>(result->off_diag_mtx_)
         ->copy_from(as<Cloneable>(this->off_diag_mtx_.get()));
     result->row_gatherer_->copy_from(this->row_gatherer_);
-    result->row_map_ = this->row_map_;
     result->imap_ = this->imap_;
     result->set_size(this->get_size());
 }
@@ -347,7 +342,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::move_to(
     as<Cloneable>(result->off_diag_mtx_)
         ->move_from(as<Cloneable>(this->off_diag_mtx_.get()));
     result->row_gatherer_->move_from(this->row_gatherer_);
-    result->row_map_ = std::move(this->row_map_);
     result->imap_ = std::move(this->imap_);
     result->set_size(this->get_size());
     this->set_size({});
@@ -390,8 +384,6 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::read_distributed(
     auto global_num_cols = col_partition->get_size();
     dim<2> global_dim{global_num_rows, global_num_cols};
     this->set_size(global_dim);
-    row_map_ = index_map<local_index_type, global_index_type>(
-        exec, row_partition, comm.rank(), array<global_index_type>{exec});
 
     // temporary storage for the output
     array<local_index_type> diag_row_idxs{exec};
@@ -495,9 +487,9 @@ void Matrix<ValueType, LocalIndexType, GlobalIndexType>::write(
 
     data = {this->get_size(), {}};
     auto exec = this->get_executor();
-    append_global_matrix_data(exec, local_data, row_map_, imap_,
-                              index_space::local, data);
-    append_global_matrix_data(exec, non_local_data, row_map_, imap_,
+    append_global_matrix_data(exec, local_data, imap_, index_space::local,
+                              data);
+    append_global_matrix_data(exec, non_local_data, imap_,
                               index_space::non_local, data);
     data.sort_row_major();
 }
@@ -755,7 +747,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(const Matrix& other)
       DistributedBase{other.get_communicator()},
       row_gatherer_{RowGatherer<LocalIndexType>::create(
           other.get_executor(), other.get_communicator())},
-      row_map_(other.get_executor()),
       imap_(other.get_executor()),
       one_scalar_(other.get_executor(), 1.0)
 {
@@ -770,7 +761,6 @@ Matrix<ValueType, LocalIndexType, GlobalIndexType>::Matrix(
       DistributedBase{other.get_communicator()},
       row_gatherer_{RowGatherer<LocalIndexType>::create(
           other.get_executor(), other.get_communicator())},
-      row_map_(other.get_executor()),
       imap_(other.get_executor()),
       one_scalar_(other.get_executor(), 1.0)
 {

--- a/core/test/mpi/distributed/CMakeLists.txt
+++ b/core/test/mpi/distributed/CMakeLists.txt
@@ -1,5 +1,5 @@
 ginkgo_create_test(helpers MPI_SIZE 1 LABELS distributed)
-ginkgo_create_test(matrix MPI_SIZE 1 LABELS distributed)
+ginkgo_create_test(matrix MPI_SIZE 3 LABELS distributed)
 ginkgo_create_test(collective_communicator MPI_SIZE 6 LABELS distributed)
 ginkgo_create_test(row_gatherer MPI_SIZE 6 LABELS distributed)
 ginkgo_create_test(vector_cache MPI_SIZE 3 LABELS distributed)

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -71,7 +71,7 @@ protected:
           comm(gko::experimental::mpi::communicator(MPI_COMM_WORLD))
     {}
 
-    void SetUp() override {}
+    void SetUp() override { ASSERT_EQ(this->comm.size(), 3); }
 
     template <typename F>
     void forall_matrix_types(F&& f)
@@ -425,30 +425,43 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithNonUniformPartition)
     auto local = local_mtx_type::create(this->ref);
     auto non_local = local_mtx_type::create(this->ref);
     gko::matrix_data<value_type, local_index_type> local_data{local_dim, {}};
+    gko::matrix_data<value_type, local_index_type> non_local_data{
+        gko::dim<2>{local_dim[0], 1}, {}};
     gko::matrix_data<value_type, global_index_type> expected{gko::dim<2>{6, 6},
                                                              {}};
+    auto remote_cols = gko::array<global_index_type>{this->ref};
     if (rank == 0) {
         local_data.nonzeros = {{0, 0, value_type{1.0f}},
                                {1, 0, value_type{2.0f}}};
+        non_local_data.nonzeros = {{0, 0, value_type{3.0f}}};
+        remote_cols =
+            gko::array<global_index_type>{this->ref, {global_index_type{4}}};
         expected.nonzeros = {{1, 1, value_type{1.0f}},
+                             {1, 4, value_type{3.0f}},
                              {3, 1, value_type{2.0f}}};
     } else if (rank == 1) {
         local_data.nonzeros = {{0, 0, value_type{1.0f}}};
-        expected.nonzeros = {{4, 4, value_type{1.0f}}};
+        non_local_data.nonzeros = {{0, 0, value_type{2.0f}}};
+        remote_cols =
+            gko::array<global_index_type>{this->ref, {global_index_type{0}}};
+        expected.nonzeros = {{4, 0, value_type{2.0f}},
+                             {4, 4, value_type{1.0f}}};
     } else {
         local_data.nonzeros = {{0, 0, value_type{1.0f}},
                                {1, 0, value_type{2.0f}},
                                {2, 1, value_type{3.0f}}};
+        non_local_data.nonzeros = {{0, 0, value_type{4.0f}}};
+        remote_cols =
+            gko::array<global_index_type>{this->ref, {global_index_type{1}}};
         expected.nonzeros = {{0, 0, value_type{1.0f}},
+                             {0, 1, value_type{4.0f}},
                              {2, 0, value_type{2.0f}},
                              {5, 2, value_type{3.0f}}};
     }
     local->read(local_data);
-    non_local->read(gko::matrix_data<value_type, local_index_type>{
-        gko::dim<2>{local_dim[0], 0}, {}});
+    non_local->read(non_local_data);
     expected.sort_row_major();
 
-    auto remote_cols = gko::array<global_index_type>{this->ref};
     auto imap = map_type{this->ref, partition, rank, remote_cols};
     auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
                                         std::move(local), std::move(non_local));
@@ -550,6 +563,36 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataFromLocalOnlyConstructor)
     for (gko::size_type i = 0; i < expected.nonzeros.size(); ++i) {
         EXPECT_EQ(written.nonzeros[i], expected.nonzeros[i]);
     }
+}
+
+
+TYPED_TEST(MatrixBuilder, ThrowsWhenWritingRectangularMatrixData)
+{
+    using value_type = typename TestFixture::value_type;
+    using local_index_type = typename TestFixture::local_index_type;
+    using global_index_type = typename TestFixture::global_index_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
+    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using writable_type =
+        gko::WritableToMatrixData<value_type, global_index_type>;
+    const auto local_size =
+        static_cast<local_index_type>(this->comm.rank() + 1);
+    const auto global_size = static_cast<global_index_type>(
+        ((1 + this->comm.size()) * this->comm.size()) / 2);
+    auto local = local_mtx_type::create(this->ref);
+    local->read(gko::matrix_data<value_type, local_index_type>{
+        gko::dim<2>{static_cast<gko::size_type>(local_size),
+                    static_cast<gko::size_type>(local_size)},
+        {{0, 0, value_type{1.0f}}}});
+    auto matrix = dist_mtx_type::create(
+        this->ref, this->comm,
+        gko::dim<2>{static_cast<gko::size_type>(global_size),
+                    static_cast<gko::size_type>(global_size + 1)},
+        std::move(local));
+    gko::matrix_data<value_type, global_index_type> written;
+
+    ASSERT_THROW(gko::as<writable_type>(matrix.get())->write(written),
+                 gko::DimensionMismatch);
 }
 
 

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -341,4 +341,73 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpDiagAndOffDiag)
 }
 
 
+TYPED_TEST(MatrixBuilder, WritesMatrixDataWithGlobalIndices)
+{
+    using value_type = typename TestFixture::value_type;
+    using local_index_type = typename TestFixture::local_index_type;
+    using global_index_type = typename TestFixture::global_index_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
+    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using partition_type =
+        gko::experimental::distributed::Partition<local_index_type,
+                                                  global_index_type>;
+    using map_type =
+        gko::experimental::distributed::index_map<local_index_type,
+                                                  global_index_type>;
+    using writable_type =
+        gko::WritableToMatrixData<value_type, global_index_type>;
+
+    if (this->comm.size() < 2) {
+        GTEST_SKIP() << "This test needs non-local columns.";
+    }
+
+    const auto rank = this->comm.rank();
+    const auto next_rank = (rank + 1) % this->comm.size();
+    const auto global_size =
+        static_cast<global_index_type>(2 * this->comm.size());
+    auto partition = gko::share(partition_type::build_from_global_size_uniform(
+        this->ref, this->comm.size(), global_size));
+    auto local = local_mtx_type::create(this->ref);
+    auto non_local = local_mtx_type::create(this->ref);
+    auto value = [](int value) {
+        return value_type{static_cast<gko::remove_complex<value_type>>(value)};
+    };
+    const auto global_row = static_cast<global_index_type>(2 * rank);
+    const auto remote_col = static_cast<global_index_type>(2 * next_rank);
+
+    local->read(gko::matrix_data<value_type, local_index_type>{
+        gko::dim<2>{2, 2}, {{0, 0, value(1)}, {1, 1, value(2)}}});
+    non_local->read(gko::matrix_data<value_type, local_index_type>{
+        gko::dim<2>{2, 2}, {{0, 0, value(3)}, {1, 1, value(4)}}});
+    auto remote_cols = gko::array<global_index_type>{
+        this->ref,
+        {remote_col, static_cast<global_index_type>(remote_col + 1)}};
+    auto imap = map_type{this->ref, partition, rank, remote_cols};
+
+    auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
+                                        std::move(local), std::move(non_local));
+    auto writable = dynamic_cast<writable_type*>(matrix.get());
+    ASSERT_NE(writable, nullptr);
+    gko::matrix_data<value_type, global_index_type> written;
+    writable->write(written);
+
+    gko::matrix_data<value_type, global_index_type> expected{
+        gko::dim<2>{static_cast<gko::size_type>(global_size),
+                    static_cast<gko::size_type>(global_size)},
+        {{global_row, global_row, value(1)},
+         {static_cast<global_index_type>(global_row + 1),
+          static_cast<global_index_type>(global_row + 1), value(2)},
+         {global_row, remote_col, value(3)},
+         {static_cast<global_index_type>(global_row + 1),
+          static_cast<global_index_type>(remote_col + 1), value(4)}}};
+    expected.sort_row_major();
+
+    ASSERT_EQ(written.size, expected.size);
+    ASSERT_EQ(written.nonzeros.size(), expected.nonzeros.size());
+    for (gko::size_type i = 0; i < expected.nonzeros.size(); ++i) {
+        EXPECT_EQ(written.nonzeros[i], expected.nonzeros[i]);
+    }
+}
+
+
 }  // namespace

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -357,6 +357,7 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithGlobalIndices)
     using writable_type =
         gko::WritableToMatrixData<value_type, global_index_type>;
     const auto rank = this->comm.rank();
+    const auto next_rank = (rank + 1) % this->comm.size();
     const auto global_size =
         static_cast<global_index_type>(2 * this->comm.size());
     auto partition = gko::share(partition_type::build_from_global_size_uniform(
@@ -364,42 +365,185 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithGlobalIndices)
     auto local = local_mtx_type::create(this->ref);
     auto non_local = local_mtx_type::create(this->ref);
     const auto global_row = static_cast<global_index_type>(2 * rank);
+    const auto remote_col = static_cast<global_index_type>(2 * next_rank);
     local->read(gko::matrix_data<value_type, local_index_type>{
         gko::dim<2>{2, 2},
         {{0, 0, value_type{1.0f}}, {1, 1, value_type{2.0f}}}});
-    non_local->read(
-        gko::matrix_data<value_type, local_index_type>{gko::dim<2>{2, 0}, {}});
-    auto remote_cols = gko::array<global_index_type>{this->ref};
+    non_local->read(gko::matrix_data<value_type, local_index_type>{
+        gko::dim<2>{2, 2},
+        {{0, 0, value_type{3.0f}}, {1, 1, value_type{4.0f}}}});
+    auto remote_cols = gko::array<global_index_type>{
+        this->ref,
+        {remote_col, static_cast<global_index_type>(remote_col + 1)}};
     gko::matrix_data<value_type, global_index_type> expected{
         gko::dim<2>{static_cast<gko::size_type>(global_size),
                     static_cast<gko::size_type>(global_size)},
         {{global_row, global_row, value_type{1.0f}},
          {static_cast<global_index_type>(global_row + 1),
-          static_cast<global_index_type>(global_row + 1), value_type{2.0f}}}};
-    if (this->comm.size() > 1) {
-        const auto next_rank = (rank + 1) % this->comm.size();
-        const auto remote_col = static_cast<global_index_type>(2 * next_rank);
-        non_local->read(gko::matrix_data<value_type, local_index_type>{
-            gko::dim<2>{2, 2},
-            {{0, 0, value_type{3.0f}}, {1, 1, value_type{4.0f}}}});
-        remote_cols = gko::array<global_index_type>{
-            this->ref,
-            {remote_col, static_cast<global_index_type>(remote_col + 1)}};
-        expected.nonzeros.emplace_back(global_row, remote_col,
-                                       value_type{3.0f});
-        expected.nonzeros.emplace_back(
-            static_cast<global_index_type>(global_row + 1),
-            static_cast<global_index_type>(remote_col + 1), value_type{4.0f});
-    }
+          static_cast<global_index_type>(global_row + 1), value_type{2.0f}},
+         {global_row, remote_col, value_type{3.0f}},
+         {static_cast<global_index_type>(global_row + 1),
+          static_cast<global_index_type>(remote_col + 1), value_type{4.0f}}}};
     expected.sort_row_major();
 
     auto imap = map_type{this->ref, partition, rank, remote_cols};
     auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
                                         std::move(local), std::move(non_local));
-    auto writable = dynamic_cast<writable_type*>(matrix.get());
-    ASSERT_NE(writable, nullptr);
     gko::matrix_data<value_type, global_index_type> written;
-    writable->write(written);
+    gko::as<writable_type>(matrix.get())->write(written);
+
+    ASSERT_EQ(written.size, expected.size);
+    ASSERT_EQ(written.nonzeros.size(), expected.nonzeros.size());
+    for (gko::size_type i = 0; i < expected.nonzeros.size(); ++i) {
+        EXPECT_EQ(written.nonzeros[i], expected.nonzeros[i]);
+    }
+}
+
+
+TYPED_TEST(MatrixBuilder, WritesMatrixDataWithNonUniformPartition)
+{
+    using value_type = typename TestFixture::value_type;
+    using local_index_type = typename TestFixture::local_index_type;
+    using global_index_type = typename TestFixture::global_index_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
+    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using partition_type =
+        gko::experimental::distributed::Partition<local_index_type,
+                                                  global_index_type>;
+    using map_type =
+        gko::experimental::distributed::index_map<local_index_type,
+                                                  global_index_type>;
+    using writable_type =
+        gko::WritableToMatrixData<value_type, global_index_type>;
+    const auto rank = this->comm.rank();
+    auto mapping = gko::array<comm_index_type>{this->ref, {2, 0, 2, 0, 1, 2}};
+    auto partition =
+        gko::share(partition_type::build_from_mapping(this->ref, mapping, 3));
+    auto local_size = partition->get_part_size(rank);
+    auto local_dim = gko::dim<2>{static_cast<gko::size_type>(local_size),
+                                 static_cast<gko::size_type>(local_size)};
+    auto local = local_mtx_type::create(this->ref);
+    auto non_local = local_mtx_type::create(this->ref);
+    gko::matrix_data<value_type, local_index_type> local_data{local_dim, {}};
+    gko::matrix_data<value_type, global_index_type> expected{gko::dim<2>{6, 6},
+                                                             {}};
+    if (rank == 0) {
+        local_data.nonzeros = {{0, 0, value_type{1.0f}},
+                               {1, 0, value_type{2.0f}}};
+        expected.nonzeros = {{1, 1, value_type{1.0f}},
+                             {3, 1, value_type{2.0f}}};
+    } else if (rank == 1) {
+        local_data.nonzeros = {{0, 0, value_type{1.0f}}};
+        expected.nonzeros = {{4, 4, value_type{1.0f}}};
+    } else {
+        local_data.nonzeros = {{0, 0, value_type{1.0f}},
+                               {1, 0, value_type{2.0f}},
+                               {2, 1, value_type{3.0f}}};
+        expected.nonzeros = {{0, 0, value_type{1.0f}},
+                             {2, 0, value_type{2.0f}},
+                             {5, 2, value_type{3.0f}}};
+    }
+    local->read(local_data);
+    non_local->read(gko::matrix_data<value_type, local_index_type>{
+        gko::dim<2>{local_dim[0], 0}, {}});
+    expected.sort_row_major();
+
+    auto remote_cols = gko::array<global_index_type>{this->ref};
+    auto imap = map_type{this->ref, partition, rank, remote_cols};
+    auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
+                                        std::move(local), std::move(non_local));
+    gko::matrix_data<value_type, global_index_type> written;
+    gko::as<writable_type>(matrix.get())->write(written);
+
+    ASSERT_EQ(written.size, expected.size);
+    ASSERT_EQ(written.nonzeros.size(), expected.nonzeros.size());
+    for (gko::size_type i = 0; i < expected.nonzeros.size(); ++i) {
+        EXPECT_EQ(written.nonzeros[i], expected.nonzeros[i]);
+    }
+}
+
+
+TYPED_TEST(MatrixBuilder, WritesEmptyMatrixDataWithGlobalSize)
+{
+    using value_type = typename TestFixture::value_type;
+    using local_index_type = typename TestFixture::local_index_type;
+    using global_index_type = typename TestFixture::global_index_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
+    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using partition_type =
+        gko::experimental::distributed::Partition<local_index_type,
+                                                  global_index_type>;
+    using map_type =
+        gko::experimental::distributed::index_map<local_index_type,
+                                                  global_index_type>;
+    using writable_type =
+        gko::WritableToMatrixData<value_type, global_index_type>;
+    const auto rank = this->comm.rank();
+    const auto global_size =
+        static_cast<global_index_type>(2 * this->comm.size());
+    auto partition = gko::share(partition_type::build_from_global_size_uniform(
+        this->ref, this->comm.size(), global_size));
+    auto local = local_mtx_type::create(this->ref);
+    auto non_local = local_mtx_type::create(this->ref);
+    local->read(
+        gko::matrix_data<value_type, local_index_type>{gko::dim<2>{2, 2}, {}});
+    non_local->read(
+        gko::matrix_data<value_type, local_index_type>{gko::dim<2>{2, 0}, {}});
+    auto remote_cols = gko::array<global_index_type>{this->ref};
+    auto imap = map_type{this->ref, partition, rank, remote_cols};
+    auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
+                                        std::move(local), std::move(non_local));
+    gko::matrix_data<value_type, global_index_type> written;
+
+    gko::as<writable_type>(matrix.get())->write(written);
+
+    ASSERT_EQ(written.size,
+              (gko::dim<2>{static_cast<gko::size_type>(global_size),
+                           static_cast<gko::size_type>(global_size)}));
+    ASSERT_TRUE(written.nonzeros.empty());
+}
+
+
+TYPED_TEST(MatrixBuilder, WritesMatrixDataFromLocalOnlyConstructor)
+{
+    using value_type = typename TestFixture::value_type;
+    using local_index_type = typename TestFixture::local_index_type;
+    using global_index_type = typename TestFixture::global_index_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
+    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using writable_type =
+        gko::WritableToMatrixData<value_type, global_index_type>;
+    const auto rank = this->comm.rank();
+    const auto local_size = static_cast<local_index_type>(rank + 1);
+    const auto global_size = static_cast<global_index_type>(
+        ((1 + this->comm.size()) * this->comm.size()) / 2);
+    const auto global_start =
+        static_cast<global_index_type>((rank * (rank + 1)) / 2);
+    auto local_dim = gko::dim<2>{static_cast<gko::size_type>(local_size),
+                                 static_cast<gko::size_type>(local_size)};
+    auto local = local_mtx_type::create(this->ref);
+    gko::matrix_data<value_type, local_index_type> local_data{
+        local_dim, {{0, 0, value_type{1.0f}}}};
+    gko::matrix_data<value_type, global_index_type> expected{
+        gko::dim<2>{static_cast<gko::size_type>(global_size),
+                    static_cast<gko::size_type>(global_size)},
+        {{global_start, global_start, value_type{1.0f}}}};
+    if (local_size > 1) {
+        local_data.nonzeros.emplace_back(
+            static_cast<local_index_type>(local_size - 1), 0, value_type{2.0f});
+        expected.nonzeros.emplace_back(
+            static_cast<global_index_type>(global_start + local_size - 1),
+            global_start, value_type{2.0f});
+    }
+    local->read(local_data);
+    auto matrix = dist_mtx_type::create(
+        this->ref, this->comm,
+        gko::dim<2>{static_cast<gko::size_type>(global_size),
+                    static_cast<gko::size_type>(global_size)},
+        std::move(local));
+    gko::matrix_data<value_type, global_index_type> written;
+
+    gko::as<writable_type>(matrix.get())->write(written);
 
     ASSERT_EQ(written.size, expected.size);
     ASSERT_EQ(written.nonzeros.size(), expected.nonzeros.size());

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -356,51 +356,50 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithGlobalIndices)
                                                   global_index_type>;
     using writable_type =
         gko::WritableToMatrixData<value_type, global_index_type>;
-
-    if (this->comm.size() < 2) {
-        GTEST_SKIP() << "This test needs non-local columns.";
-    }
-
     const auto rank = this->comm.rank();
-    const auto next_rank = (rank + 1) % this->comm.size();
     const auto global_size =
         static_cast<global_index_type>(2 * this->comm.size());
     auto partition = gko::share(partition_type::build_from_global_size_uniform(
         this->ref, this->comm.size(), global_size));
     auto local = local_mtx_type::create(this->ref);
     auto non_local = local_mtx_type::create(this->ref);
-    auto value = [](int value) {
-        return value_type{static_cast<gko::remove_complex<value_type>>(value)};
-    };
     const auto global_row = static_cast<global_index_type>(2 * rank);
-    const auto remote_col = static_cast<global_index_type>(2 * next_rank);
-
     local->read(gko::matrix_data<value_type, local_index_type>{
-        gko::dim<2>{2, 2}, {{0, 0, value(1)}, {1, 1, value(2)}}});
-    non_local->read(gko::matrix_data<value_type, local_index_type>{
-        gko::dim<2>{2, 2}, {{0, 0, value(3)}, {1, 1, value(4)}}});
-    auto remote_cols = gko::array<global_index_type>{
-        this->ref,
-        {remote_col, static_cast<global_index_type>(remote_col + 1)}};
-    auto imap = map_type{this->ref, partition, rank, remote_cols};
+        gko::dim<2>{2, 2},
+        {{0, 0, value_type{1.0f}}, {1, 1, value_type{2.0f}}}});
+    non_local->read(
+        gko::matrix_data<value_type, local_index_type>{gko::dim<2>{2, 0}, {}});
+    auto remote_cols = gko::array<global_index_type>{this->ref};
+    gko::matrix_data<value_type, global_index_type> expected{
+        gko::dim<2>{static_cast<gko::size_type>(global_size),
+                    static_cast<gko::size_type>(global_size)},
+        {{global_row, global_row, value_type{1.0f}},
+         {static_cast<global_index_type>(global_row + 1),
+          static_cast<global_index_type>(global_row + 1), value_type{2.0f}}}};
+    if (this->comm.size() > 1) {
+        const auto next_rank = (rank + 1) % this->comm.size();
+        const auto remote_col = static_cast<global_index_type>(2 * next_rank);
+        non_local->read(gko::matrix_data<value_type, local_index_type>{
+            gko::dim<2>{2, 2},
+            {{0, 0, value_type{3.0f}}, {1, 1, value_type{4.0f}}}});
+        remote_cols = gko::array<global_index_type>{
+            this->ref,
+            {remote_col, static_cast<global_index_type>(remote_col + 1)}};
+        expected.nonzeros.emplace_back(global_row, remote_col,
+                                       value_type{3.0f});
+        expected.nonzeros.emplace_back(
+            static_cast<global_index_type>(global_row + 1),
+            static_cast<global_index_type>(remote_col + 1), value_type{4.0f});
+    }
+    expected.sort_row_major();
 
+    auto imap = map_type{this->ref, partition, rank, remote_cols};
     auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
                                         std::move(local), std::move(non_local));
     auto writable = dynamic_cast<writable_type*>(matrix.get());
     ASSERT_NE(writable, nullptr);
     gko::matrix_data<value_type, global_index_type> written;
     writable->write(written);
-
-    gko::matrix_data<value_type, global_index_type> expected{
-        gko::dim<2>{static_cast<gko::size_type>(global_size),
-                    static_cast<gko::size_type>(global_size)},
-        {{global_row, global_row, value(1)},
-         {static_cast<global_index_type>(global_row + 1),
-          static_cast<global_index_type>(global_row + 1), value(2)},
-         {global_row, remote_col, value(3)},
-         {static_cast<global_index_type>(global_row + 1),
-          static_cast<global_index_type>(remote_col + 1), value(4)}}};
-    expected.sort_row_major();
 
     ASSERT_EQ(written.size, expected.size);
     ASSERT_EQ(written.nonzeros.size(), expected.nonzeros.size());

--- a/core/test/mpi/distributed/matrix.cpp
+++ b/core/test/mpi/distributed/matrix.cpp
@@ -186,7 +186,7 @@ TYPED_TEST(MatrixBuilder, BuildWithLocal)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::local_index_type;
-    using dist_mat_type = typename TestFixture::dist_mtx_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
     this->forall_matrix_types([this](auto with_matrix_type,
                                      auto expected_type_ptr,
                                      auto additional_test) {
@@ -194,7 +194,7 @@ TYPED_TEST(MatrixBuilder, BuildWithLocal)
             decltype(expected_type_ptr.get())>::type;
 
         auto mat =
-            dist_mat_type ::create(this->ref, this->comm, with_matrix_type);
+            dist_mtx_type::create(this->ref, this->comm, with_matrix_type);
 
         ASSERT_NO_THROW(gko::as<expected_type>(mat->get_diag_matrix()));
         additional_test(mat->get_diag_matrix());
@@ -209,7 +209,7 @@ TYPED_TEST(MatrixBuilder, BuildWithDiagAndOffDiag)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::local_index_type;
-    using dist_mat_type = typename TestFixture::dist_mtx_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
     this->forall_matrix_types([this](auto with_diag_matrix_type,
                                      auto expected_diag_type_ptr,
                                      auto additional_diag_test) {
@@ -221,9 +221,9 @@ TYPED_TEST(MatrixBuilder, BuildWithDiagAndOffDiag)
             using expected_off_diag_type = typename std::remove_pointer<
                 decltype(expected_off_diag_type_ptr.get())>::type;
 
-            auto mat = dist_mat_type ::create(this->ref, this->comm,
-                                              with_diag_matrix_type,
-                                              with_off_diag_matrix_type);
+            auto mat = dist_mtx_type::create(this->ref, this->comm,
+                                             with_diag_matrix_type,
+                                             with_off_diag_matrix_type);
 
             ASSERT_NO_THROW(
                 gko::as<expected_diag_type>(mat->get_diag_matrix()));
@@ -242,10 +242,10 @@ TYPED_TEST(MatrixBuilder, BuildWithCustomLinOp)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::local_index_type;
-    using dist_mat_type = typename TestFixture::dist_mtx_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
     using custom_type = CustomLinOp<value_type, index_type>;
 
-    auto mat = dist_mat_type::create(this->ref, this->comm,
+    auto mat = dist_mtx_type::create(this->ref, this->comm,
                                      gko::with_matrix_type<CustomLinOp>());
 
     ASSERT_NO_THROW(gko::as<custom_type>(mat->get_diag_matrix()));
@@ -289,7 +289,7 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpLocal)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::local_index_type;
-    using dist_mat_type = typename TestFixture::dist_mtx_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
     this->forall_matrix_types([this](auto with_matrix_type,
                                      auto expected_type_ptr,
                                      auto additional_test) {
@@ -297,7 +297,7 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpLocal)
             decltype(expected_type_ptr.get())>::type;
 
         auto mat =
-            dist_mat_type ::create(this->ref, this->comm, expected_type_ptr);
+            dist_mtx_type::create(this->ref, this->comm, expected_type_ptr);
 
         ASSERT_NO_THROW(gko::as<expected_type>(mat->get_diag_matrix()));
         additional_test(mat->get_diag_matrix());
@@ -312,7 +312,7 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpDiagAndOffDiag)
 {
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::local_index_type;
-    using dist_mat_type = typename TestFixture::dist_mtx_type;
+    using dist_mtx_type = typename TestFixture::dist_mtx_type;
     this->forall_matrix_types([this](auto with_diag_matrix_type,
                                      auto expected_diag_type_ptr,
                                      auto additional_diag_test) {
@@ -324,9 +324,9 @@ TYPED_TEST(MatrixBuilder, BuildFromLinOpDiagAndOffDiag)
             using expected_off_diag_type = typename std::remove_pointer<
                 decltype(expected_off_diag_type_ptr.get())>::type;
 
-            auto mat = dist_mat_type ::create(this->ref, this->comm,
-                                              expected_diag_type_ptr,
-                                              expected_off_diag_type_ptr);
+            auto mat = dist_mtx_type::create(this->ref, this->comm,
+                                             expected_diag_type_ptr,
+                                             expected_off_diag_type_ptr);
 
             ASSERT_NO_THROW(
                 gko::as<expected_diag_type>(mat->get_diag_matrix()));
@@ -347,7 +347,7 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithGlobalIndices)
     using local_index_type = typename TestFixture::local_index_type;
     using global_index_type = typename TestFixture::global_index_type;
     using dist_mtx_type = typename TestFixture::dist_mtx_type;
-    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using mtx_type = gko::matrix::Csr<value_type, local_index_type>;
     using partition_type =
         gko::experimental::distributed::Partition<local_index_type,
                                                   global_index_type>;
@@ -362,14 +362,14 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithGlobalIndices)
         static_cast<global_index_type>(2 * this->comm.size());
     auto partition = gko::share(partition_type::build_from_global_size_uniform(
         this->ref, this->comm.size(), global_size));
-    auto local = local_mtx_type::create(this->ref);
-    auto non_local = local_mtx_type::create(this->ref);
+    auto diag = mtx_type::create(this->ref);
+    auto off_diag = mtx_type::create(this->ref);
     const auto global_row = static_cast<global_index_type>(2 * rank);
     const auto remote_col = static_cast<global_index_type>(2 * next_rank);
-    local->read(gko::matrix_data<value_type, local_index_type>{
+    diag->read(gko::matrix_data<value_type, local_index_type>{
         gko::dim<2>{2, 2},
         {{0, 0, value_type{1.0f}}, {1, 1, value_type{2.0f}}}});
-    non_local->read(gko::matrix_data<value_type, local_index_type>{
+    off_diag->read(gko::matrix_data<value_type, local_index_type>{
         gko::dim<2>{2, 2},
         {{0, 0, value_type{3.0f}}, {1, 1, value_type{4.0f}}}});
     auto remote_cols = gko::array<global_index_type>{
@@ -388,7 +388,7 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithGlobalIndices)
 
     auto imap = map_type{this->ref, partition, rank, remote_cols};
     auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
-                                        std::move(local), std::move(non_local));
+                                        std::move(diag), std::move(off_diag));
     gko::matrix_data<value_type, global_index_type> written;
     gko::as<writable_type>(matrix.get())->write(written);
 
@@ -406,7 +406,7 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithNonUniformPartition)
     using local_index_type = typename TestFixture::local_index_type;
     using global_index_type = typename TestFixture::global_index_type;
     using dist_mtx_type = typename TestFixture::dist_mtx_type;
-    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using mtx_type = gko::matrix::Csr<value_type, local_index_type>;
     using partition_type =
         gko::experimental::distributed::Partition<local_index_type,
                                                   global_index_type>;
@@ -422,35 +422,35 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithNonUniformPartition)
     auto local_size = partition->get_part_size(rank);
     auto local_dim = gko::dim<2>{static_cast<gko::size_type>(local_size),
                                  static_cast<gko::size_type>(local_size)};
-    auto local = local_mtx_type::create(this->ref);
-    auto non_local = local_mtx_type::create(this->ref);
-    gko::matrix_data<value_type, local_index_type> local_data{local_dim, {}};
-    gko::matrix_data<value_type, local_index_type> non_local_data{
+    auto diag = mtx_type::create(this->ref);
+    auto off_diag = mtx_type::create(this->ref);
+    gko::matrix_data<value_type, local_index_type> diag_data{local_dim, {}};
+    gko::matrix_data<value_type, local_index_type> off_diag_data{
         gko::dim<2>{local_dim[0], 1}, {}};
     gko::matrix_data<value_type, global_index_type> expected{gko::dim<2>{6, 6},
                                                              {}};
     auto remote_cols = gko::array<global_index_type>{this->ref};
     if (rank == 0) {
-        local_data.nonzeros = {{0, 0, value_type{1.0f}},
-                               {1, 0, value_type{2.0f}}};
-        non_local_data.nonzeros = {{0, 0, value_type{3.0f}}};
+        diag_data.nonzeros = {{0, 0, value_type{1.0f}},
+                              {1, 0, value_type{2.0f}}};
+        off_diag_data.nonzeros = {{0, 0, value_type{3.0f}}};
         remote_cols =
             gko::array<global_index_type>{this->ref, {global_index_type{4}}};
         expected.nonzeros = {{1, 1, value_type{1.0f}},
                              {1, 4, value_type{3.0f}},
                              {3, 1, value_type{2.0f}}};
     } else if (rank == 1) {
-        local_data.nonzeros = {{0, 0, value_type{1.0f}}};
-        non_local_data.nonzeros = {{0, 0, value_type{2.0f}}};
+        diag_data.nonzeros = {{0, 0, value_type{1.0f}}};
+        off_diag_data.nonzeros = {{0, 0, value_type{2.0f}}};
         remote_cols =
             gko::array<global_index_type>{this->ref, {global_index_type{0}}};
         expected.nonzeros = {{4, 0, value_type{2.0f}},
                              {4, 4, value_type{1.0f}}};
     } else {
-        local_data.nonzeros = {{0, 0, value_type{1.0f}},
-                               {1, 0, value_type{2.0f}},
-                               {2, 1, value_type{3.0f}}};
-        non_local_data.nonzeros = {{0, 0, value_type{4.0f}}};
+        diag_data.nonzeros = {{0, 0, value_type{1.0f}},
+                              {1, 0, value_type{2.0f}},
+                              {2, 1, value_type{3.0f}}};
+        off_diag_data.nonzeros = {{0, 0, value_type{4.0f}}};
         remote_cols =
             gko::array<global_index_type>{this->ref, {global_index_type{1}}};
         expected.nonzeros = {{0, 0, value_type{1.0f}},
@@ -458,13 +458,13 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataWithNonUniformPartition)
                              {2, 0, value_type{2.0f}},
                              {5, 2, value_type{3.0f}}};
     }
-    local->read(local_data);
-    non_local->read(non_local_data);
+    diag->read(diag_data);
+    off_diag->read(off_diag_data);
     expected.sort_row_major();
 
     auto imap = map_type{this->ref, partition, rank, remote_cols};
     auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
-                                        std::move(local), std::move(non_local));
+                                        std::move(diag), std::move(off_diag));
     gko::matrix_data<value_type, global_index_type> written;
     gko::as<writable_type>(matrix.get())->write(written);
 
@@ -482,7 +482,7 @@ TYPED_TEST(MatrixBuilder, WritesEmptyMatrixDataWithGlobalSize)
     using local_index_type = typename TestFixture::local_index_type;
     using global_index_type = typename TestFixture::global_index_type;
     using dist_mtx_type = typename TestFixture::dist_mtx_type;
-    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using mtx_type = gko::matrix::Csr<value_type, local_index_type>;
     using partition_type =
         gko::experimental::distributed::Partition<local_index_type,
                                                   global_index_type>;
@@ -496,16 +496,16 @@ TYPED_TEST(MatrixBuilder, WritesEmptyMatrixDataWithGlobalSize)
         static_cast<global_index_type>(2 * this->comm.size());
     auto partition = gko::share(partition_type::build_from_global_size_uniform(
         this->ref, this->comm.size(), global_size));
-    auto local = local_mtx_type::create(this->ref);
-    auto non_local = local_mtx_type::create(this->ref);
-    local->read(
+    auto diag = mtx_type::create(this->ref);
+    auto off_diag = mtx_type::create(this->ref);
+    diag->read(
         gko::matrix_data<value_type, local_index_type>{gko::dim<2>{2, 2}, {}});
-    non_local->read(
+    off_diag->read(
         gko::matrix_data<value_type, local_index_type>{gko::dim<2>{2, 0}, {}});
     auto remote_cols = gko::array<global_index_type>{this->ref};
     auto imap = map_type{this->ref, partition, rank, remote_cols};
     auto matrix = dist_mtx_type::create(this->ref, this->comm, std::move(imap),
-                                        std::move(local), std::move(non_local));
+                                        std::move(diag), std::move(off_diag));
     gko::matrix_data<value_type, global_index_type> written;
 
     gko::as<writable_type>(matrix.get())->write(written);
@@ -517,13 +517,13 @@ TYPED_TEST(MatrixBuilder, WritesEmptyMatrixDataWithGlobalSize)
 }
 
 
-TYPED_TEST(MatrixBuilder, WritesMatrixDataFromLocalOnlyConstructor)
+TYPED_TEST(MatrixBuilder, WritesMatrixDataFromDiagOnlyConstructor)
 {
     using value_type = typename TestFixture::value_type;
     using local_index_type = typename TestFixture::local_index_type;
     using global_index_type = typename TestFixture::global_index_type;
     using dist_mtx_type = typename TestFixture::dist_mtx_type;
-    using local_mtx_type = gko::matrix::Csr<value_type, local_index_type>;
+    using mtx_type = gko::matrix::Csr<value_type, local_index_type>;
     using writable_type =
         gko::WritableToMatrixData<value_type, global_index_type>;
     const auto rank = this->comm.rank();
@@ -534,26 +534,26 @@ TYPED_TEST(MatrixBuilder, WritesMatrixDataFromLocalOnlyConstructor)
         static_cast<global_index_type>((rank * (rank + 1)) / 2);
     auto local_dim = gko::dim<2>{static_cast<gko::size_type>(local_size),
                                  static_cast<gko::size_type>(local_size)};
-    auto local = local_mtx_type::create(this->ref);
-    gko::matrix_data<value_type, local_index_type> local_data{
+    auto diag = mtx_type::create(this->ref);
+    gko::matrix_data<value_type, local_index_type> diag_data{
         local_dim, {{0, 0, value_type{1.0f}}}};
     gko::matrix_data<value_type, global_index_type> expected{
         gko::dim<2>{static_cast<gko::size_type>(global_size),
                     static_cast<gko::size_type>(global_size)},
         {{global_start, global_start, value_type{1.0f}}}};
     if (local_size > 1) {
-        local_data.nonzeros.emplace_back(
+        diag_data.nonzeros.emplace_back(
             static_cast<local_index_type>(local_size - 1), 0, value_type{2.0f});
         expected.nonzeros.emplace_back(
             static_cast<global_index_type>(global_start + local_size - 1),
             global_start, value_type{2.0f});
     }
-    local->read(local_data);
+    diag->read(diag_data);
     auto matrix = dist_mtx_type::create(
         this->ref, this->comm,
         gko::dim<2>{static_cast<gko::size_type>(global_size),
                     static_cast<gko::size_type>(global_size)},
-        std::move(local));
+        std::move(diag));
     gko::matrix_data<value_type, global_index_type> written;
 
     gko::as<writable_type>(matrix.get())->write(written);
@@ -579,8 +579,8 @@ TYPED_TEST(MatrixBuilder, ThrowsWhenWritingRectangularMatrixData)
         static_cast<local_index_type>(this->comm.rank() + 1);
     const auto global_size = static_cast<global_index_type>(
         ((1 + this->comm.size()) * this->comm.size()) / 2);
-    auto local = local_mtx_type::create(this->ref);
-    local->read(gko::matrix_data<value_type, local_index_type>{
+    auto diag = local_mtx_type::create(this->ref);
+    diag->read(gko::matrix_data<value_type, local_index_type>{
         gko::dim<2>{static_cast<gko::size_type>(local_size),
                     static_cast<gko::size_type>(local_size)},
         {{0, 0, value_type{1.0f}}}});
@@ -588,7 +588,7 @@ TYPED_TEST(MatrixBuilder, ThrowsWhenWritingRectangularMatrixData)
         this->ref, this->comm,
         gko::dim<2>{static_cast<gko::size_type>(global_size),
                     static_cast<gko::size_type>(global_size + 1)},
-        std::move(local));
+        std::move(diag));
     gko::matrix_data<value_type, global_index_type> written;
 
     ASSERT_THROW(gko::as<writable_type>(matrix.get())->write(written),

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -418,7 +418,10 @@ public:
      * Writes the locally stored matrix data into a matrix_data structure using
      * global row and column indices.
      *
-     * @param data  the matrix_data structure
+     * @param data  the output matrix_data
+     * e
+     * @note this currently assume the row index mapping is equal to the column
+     * index mapping
      */
     void write(matrix_data<value_type, global_index_type>& data) const override;
 
@@ -753,7 +756,6 @@ protected:
 
 private:
     std::shared_ptr<RowGatherer<LocalIndexType>> row_gatherer_;
-    index_map<local_index_type, global_index_type> row_map_;
     index_map<local_index_type, global_index_type> imap_;
     gko::detail::ScalarCache one_scalar_;
     detail::GenericVectorCache recv_buffer_;

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -273,6 +273,7 @@ class Matrix
       public ConvertibleTo<Matrix<next_precision<ValueType, 3>, LocalIndexType,
                                   GlobalIndexType>>,
 #endif
+      public WritableToMatrixData<ValueType, GlobalIndexType>,
       public DistributedBase {
     friend class EnableCloneable<Matrix>;
     friend class Matrix<previous_precision<ValueType>, LocalIndexType,
@@ -412,6 +413,14 @@ public:
         std::shared_ptr<const Partition<local_index_type, global_index_type>>
             col_partition,
         assembly_mode assembly_type = assembly_mode::local_only);
+
+    /**
+     * Writes the locally stored matrix data into a matrix_data structure using
+     * global row and column indices.
+     *
+     * @param data  the matrix_data structure
+     */
+    void write(matrix_data<value_type, global_index_type>& data) const override;
 
     /**
      * Get read access to the stored diagonal matrix block.
@@ -744,6 +753,7 @@ protected:
 
 private:
     std::shared_ptr<RowGatherer<LocalIndexType>> row_gatherer_;
+    index_map<local_index_type, global_index_type> row_map_;
     index_map<local_index_type, global_index_type> imap_;
     gko::detail::ScalarCache one_scalar_;
     detail::GenericVectorCache recv_buffer_;

--- a/include/ginkgo/core/distributed/matrix.hpp
+++ b/include/ginkgo/core/distributed/matrix.hpp
@@ -419,9 +419,9 @@ public:
      * global row and column indices.
      *
      * @param data  the output matrix_data
-     * e
+     *
      * @note this currently assume the row index mapping is equal to the column
-     * index mapping
+     *       index mapping
      */
     void write(matrix_data<value_type, global_index_type>& data) const override;
 


### PR DESCRIPTION
Add WritableToMatrixData support to distributed::Matrix by writing local and non-local blocks to matrix_data and mapping stored indices to global indices with the existing index_map. This version assumes row and column mappings are identical.

This is moved from the old PR: https://github.com/ginkgo-project/ginkgo/pull/2033
