### PR TITLE
1888/precision handling

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(
         base/mpi.cpp
         base/mtx_io.cpp
         base/perturbation.cpp
+        base/precision.cpp
         base/segmented_array.cpp
         base/timer.cpp
         base/version.cpp

--- a/core/base/precision.cpp
+++ b/core/base/precision.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "ginkgo/core/base/precision.hpp"
+
+#include <ginkgo/core/base/exception_helpers.hpp>
+
+
+namespace gko {
+
+
+precision as_real(precision p)
+{
+    if (is_real(p)) {
+        return p;
+    }
+    switch (p) {
+    case precision::complex_fp32:
+        return precision::fp32;
+    case precision::complex_fp64:
+        return precision::fp64;
+#if GINKGO_ENABLE_HALF
+    case precision::complex_fp16:
+        return precision::fp16;
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    case precision::complex_bf16:
+        return precision::bf16;
+#endif
+    default:
+        GKO_INVALID_STATE("Unsupported precision");
+    }
+}
+
+
+precision as_complex(precision p)
+{
+    if (is_complex(p)) {
+        return p;
+    }
+    switch (p) {
+    case precision::fp32:
+        return precision::complex_fp32;
+    case precision::fp64:
+        return precision::complex_fp64;
+#if GINKGO_ENABLE_HALF
+    case precision::fp16:
+        return precision::complex_fp16;
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    case precision::bf16:
+        return precision::complex_bf16;
+#endif
+    default:
+        GKO_INVALID_STATE("Unsupported precision");
+    }
+}
+
+
+std::string to_string(precision p)
+{
+    switch (p) {
+    case precision::fp32:
+        return "fp32";
+    case precision::complex_fp32:
+        return "complex_fp32";
+    case precision::fp64:
+        return "fp64";
+    case precision::complex_fp64:
+        return "complex_fp64";
+#if GINKGO_ENABLE_HALF
+    case precision::fp16:
+        return "fp16";
+    case precision::complex_fp16:
+        return "complex_fp16";
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    case precision::bf16:
+        return "bf16";
+    case precision::complex_bf16:
+        return "complex_bf16";
+#endif
+    case precision::any:
+        return "any";
+    case precision::none:
+        return "none";
+    default:
+        GKO_INVALID_STATE("Unsupported precision");
+    }
+}
+
+
+std::variant<
+#if GINKGO_ENABLE_HALF
+    half, std::complex<half>,
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    bfloat16, std::complex<bfloat16>,
+#endif
+    float, std::complex<float>, double, std::complex<double>>
+precision_to_variant(precision p)
+{
+    switch (p) {
+#if GINKGO_ENABLE_HALF
+    case precision::fp16:
+        return half{};
+    case precision::complex_fp16:
+        return std::complex<half>{};
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    case precision::bf16:
+        return bfloat16{};
+    case precision::complex_bf16:
+        return std::complex<bfloat16>{};
+#endif
+    case precision::fp32:
+        return float{};
+    case precision::complex_fp32:
+        return std::complex<float>{};
+    case precision::fp64:
+        return double{};
+    case precision::complex_fp64:
+        return std::complex<double>{};
+    default:
+        GKO_INVALID_STATE("Unsupported precision");
+    }
+}
+
+
+}  // namespace gko

--- a/core/test/base/CMakeLists.txt
+++ b/core/test/base/CMakeLists.txt
@@ -32,5 +32,6 @@ ginkgo_create_test(sanitizers ADDITIONAL_LIBRARIES Threads::Threads)
 ginkgo_create_test(segmented_array LABELS distributed)
 ginkgo_create_test(segmented_range)
 ginkgo_create_test(types)
+ginkgo_create_test(precision)
 ginkgo_create_test(utils)
 ginkgo_create_test(version EXECUTABLE_NAME version_test) # version collides with C++ stdlib header

--- a/core/test/base/precision.cpp
+++ b/core/test/base/precision.cpp
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "ginkgo/core/base/precision.hpp"
+
+#include <gtest/gtest.h>
+
+#include <ginkgo/core/base/math.hpp>
+
+namespace {
+namespace gko_test {
+
+
+auto precisions = {
+    gko::precision::none, gko::precision::any,
+    gko::precision::fp32, gko::precision::complex_fp32,
+    gko::precision::fp64, gko::precision::complex_fp64,
+#if GINKGO_ENABLE_BFLOAT16
+    gko::precision::bf16, gko::precision::complex_bf16,
+#endif
+#if GINKGO_ENABLE_HALF
+    gko::precision::fp16, gko::precision::complex_fp16,
+#endif
+};
+
+
+TEST(Precision, EnumOpsEqual)
+{
+    auto any_p = gko::precision::any;
+
+    for (auto p1 : precisions) {
+        auto same_p = p1;
+
+        EXPECT_EQ(p1, same_p);
+        EXPECT_EQ(same_p, p1);
+        EXPECT_EQ(p1, any_p);
+        EXPECT_EQ(any_p, p1);
+    }
+}
+
+
+TEST(Precision, EnumOpsNotEqual)
+{
+    for (auto p1 : precisions) {
+        for (auto p2 : precisions) {
+            if (p1 == p2) {
+                continue;
+            }
+
+            EXPECT_NE(p1, p2);
+            EXPECT_NE(p2, p1);
+        }
+    }
+}
+
+
+TEST(Precision, TypeToPrecision)
+{
+    EXPECT_EQ(gko::precision_v<float>, gko::precision::fp32);
+    EXPECT_EQ(gko::precision_v<std::complex<float>>,
+              gko::precision::complex_fp32);
+    EXPECT_EQ(gko::precision_v<double>, gko::precision::fp64);
+    EXPECT_EQ(gko::precision_v<std::complex<double>>,
+              gko::precision::complex_fp64);
+#if GINKGO_ENABLE_BFLOAT16
+    EXPECT_EQ(gko::precision_v<gko::bfloat16>, gko::precision::bf16);
+    EXPECT_EQ(gko::precision_v<std::complex<gko::bfloat16>>,
+              gko::precision::complex_bf16);
+#endif
+#if GINKGO_ENABLE_HALF
+    EXPECT_EQ(gko::precision_v<gko::half>, gko::precision::fp16);
+    EXPECT_EQ(gko::precision_v<std::complex<gko::half>>,
+              gko::precision::complex_fp16);
+#endif
+}
+
+
+template <typename T>
+void test_is_complex()
+{
+    EXPECT_EQ(gko::is_complex<T>(), gko::is_complex(gko::precision_v<T>));
+}
+
+TEST(Precision, IsComplex)
+{
+    test_is_complex<float>();
+    test_is_complex<double>();
+    test_is_complex<std::complex<float>>();
+    test_is_complex<std::complex<double>>();
+#if GINKGO_ENABLE_HALF
+    test_is_complex<gko::half>();
+    test_is_complex<std::complex<gko::half>>();
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    test_is_complex<gko::bfloat16>();
+    test_is_complex<std::complex<gko::bfloat16>>();
+#endif
+}
+
+
+template <typename T>
+void test_is_real()
+{
+    EXPECT_EQ(!gko::is_complex<T>(), gko::is_real(gko::precision_v<T>));
+}
+
+TEST(Precision, IsReal)
+{
+    test_is_real<float>();
+    test_is_real<double>();
+    test_is_real<std::complex<float>>();
+    test_is_real<std::complex<double>>();
+#if GINKGO_ENABLE_HALF
+    test_is_real<gko::half>();
+    test_is_real<std::complex<gko::half>>();
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    test_is_real<gko::bfloat16>();
+    test_is_real<std::complex<gko::bfloat16>>();
+#endif
+}
+
+TEST(Precision, AsReal)
+{
+    EXPECT_EQ(gko::as_real(gko::precision::fp32), gko::precision::fp32);
+    EXPECT_EQ(gko::as_real(gko::precision::fp64), gko::precision::fp64);
+    EXPECT_EQ(gko::as_real(gko::precision::complex_fp32), gko::precision::fp32);
+    EXPECT_EQ(gko::as_real(gko::precision::complex_fp64), gko::precision::fp64);
+#if GINKGO_ENABLE_BFLOAT16
+    EXPECT_EQ(gko::as_real(gko::precision::bf16), gko::precision::bf16);
+    EXPECT_EQ(gko::as_real(gko::precision::complex_bf16), gko::precision::bf16);
+#endif
+#if GINKGO_ENABLE_HALF
+    EXPECT_EQ(gko::as_real(gko::precision::fp16), gko::precision::fp16);
+    EXPECT_EQ(gko::as_real(gko::precision::complex_fp16), gko::precision::fp16);
+#endif
+    EXPECT_EQ(gko::as_real(gko::precision::any), gko::precision::any);
+    EXPECT_THROW(gko::as_real(gko::precision::none), gko::InvalidStateError);
+}
+
+TEST(Precision, AsComplex)
+{
+    EXPECT_EQ(gko::as_complex(gko::precision::fp32),
+              gko::precision::complex_fp32);
+    EXPECT_EQ(gko::as_complex(gko::precision::fp64),
+              gko::precision::complex_fp64);
+    EXPECT_EQ(gko::as_complex(gko::precision::complex_fp32),
+              gko::precision::complex_fp32);
+    EXPECT_EQ(gko::as_complex(gko::precision::complex_fp64),
+              gko::precision::complex_fp64);
+#if GINKGO_ENABLE_BFLOAT16
+    EXPECT_EQ(gko::as_complex(gko::precision::bf16),
+              gko::precision::complex_bf16);
+    EXPECT_EQ(gko::as_complex(gko::precision::complex_bf16),
+              gko::precision::complex_bf16);
+#endif
+#if GINKGO_ENABLE_HALF
+    EXPECT_EQ(gko::as_complex(gko::precision::fp16),
+              gko::precision::complex_fp16);
+    EXPECT_EQ(gko::as_complex(gko::precision::complex_fp16),
+              gko::precision::complex_fp16);
+#endif
+    EXPECT_EQ(gko::as_real(gko::precision::any), gko::precision::any);
+    EXPECT_THROW(gko::as_complex(gko::precision::none), gko::InvalidStateError);
+}
+
+TEST(Precision, PrecisionToVariant)
+{
+    EXPECT_TRUE(std::holds_alternative<float>(
+        gko::precision_to_variant(gko::precision::fp32)));
+    EXPECT_TRUE(std::holds_alternative<double>(
+        gko::precision_to_variant(gko::precision::fp64)));
+    EXPECT_TRUE(std::holds_alternative<std::complex<float>>(
+        gko::precision_to_variant(gko::precision::complex_fp32)));
+    EXPECT_TRUE(std::holds_alternative<std::complex<double>>(
+        gko::precision_to_variant(gko::precision::complex_fp64)));
+#if GINKGO_ENABLE_HALF
+    EXPECT_TRUE(std::holds_alternative<gko::half>(
+        gko::precision_to_variant(gko::precision::fp16)));
+    EXPECT_TRUE(std::holds_alternative<std::complex<gko::half>>(
+        gko::precision_to_variant(gko::precision::complex_fp16)));
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    EXPECT_TRUE(std::holds_alternative<gko::bfloat16>(
+        gko::precision_to_variant(gko::precision::bf16)));
+    EXPECT_TRUE(std::holds_alternative<std::complex<gko::bfloat16>>(
+        gko::precision_to_variant(gko::precision::complex_bf16)));
+#endif
+    EXPECT_THROW(gko::precision_to_variant(gko::precision::none),
+                 gko::InvalidStateError);
+    EXPECT_THROW(gko::precision_to_variant(gko::precision::any),
+                 gko::InvalidStateError);
+}
+
+
+}  // namespace gko_test
+}  // namespace

--- a/include/ginkgo/core/base/exception.hpp
+++ b/include/ginkgo/core/base/exception.hpp
@@ -13,6 +13,8 @@
 #include <ginkgo/core/base/name_demangling.hpp>
 #include <ginkgo/core/base/types.hpp>
 
+#include "precision.hpp"
+
 
 namespace gko {
 
@@ -686,6 +688,30 @@ public:
         : Error(file, line,
                 "Invariant violated in " +
                     name_demangling::get_type_name(type) + ": " + invariant)
+    {}
+};
+
+
+/**
+ * Exception thrown if an object with mismatched precision is used
+ */
+class PrecisionError : public Error {
+public:
+    /**
+     *
+     * @param file  The name of the offending source file
+     * @param line  The source code line number where the error occurred
+     * @param func  The function name where the error occurred
+     * @param expected  The string value of the expected precision
+     * @param op  The offending operator
+     * @param p  The string value of the precision of the operator
+     */
+    PrecisionError(const std::string& file, int line, const std::string& func,
+                   precision expected, const std::string& op, precision p)
+        : Error(file, line,
+                func + ": expected precision " + to_string(expected) +
+                    " but object " + op + " has precision " + to_string(p) +
+                    ".")
     {}
 };
 

--- a/include/ginkgo/core/base/exception_helpers.hpp
+++ b/include/ginkgo/core/base/exception_helpers.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -12,6 +12,7 @@
 #include <ginkgo/core/base/dim.hpp>
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/name_demangling.hpp>
+#include <ginkgo/core/base/precision.hpp>
 #include <ginkgo/core/base/utils_helper.hpp>
 
 
@@ -117,6 +118,15 @@ inline dim<2> get_size(const T& op)
 }
 
 inline dim<2> get_size(const dim<2>& size) { return size; }
+
+
+template <typename T>
+precision get_precision(T&& op)
+{
+    return op->get_precision();
+}
+
+inline precision get_precision(precision p) { return p; }
 
 
 template <typename T>
@@ -284,6 +294,21 @@ inline size_type get_num_batch_items(const T& obj)
             ::gko::detail::get_size(_op2)[0],                               \
             ::gko::detail::get_size(_op2)[1], "expected equal dimensions"); \
     }
+
+
+/**
+ * Asserts that _op has the expected precision _expected.
+ *
+ * @throw PrecisionError  if _op has a precision other than _expected.
+ */
+#define GKO_ASSERT_PRECISION(_expected, _op)                                  \
+    if (::gko::detail::get_precision(_expected) !=                            \
+        ::gko::detail::get_precision(_op)) {                                  \
+        throw ::gko::PrecisionError(__FILE__, __LINE__, __func__,             \
+                                    ::gko::detail::get_precision(_expected),  \
+                                    #_op, ::gko::detail::get_precision(_op)); \
+    }                                                                         \
+    static_assert(true, "Require ;")
 
 
 /**

--- a/include/ginkgo/core/base/precision.hpp
+++ b/include/ginkgo/core/base/precision.hpp
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: 2026 The Ginkgo authors
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <complex>
+#include <variant>
+
+#include <ginkgo/config.hpp>
+#include <ginkgo/core/base/types.hpp>
+
+namespace gko {
+
+
+/**
+ * A enum to specify the precision of stored data.
+ */
+enum struct precision {
+    none,  //!< no precision information is available, incompatible with all
+           //!< other precisions
+    any,   //!< compatible with all other precisions, including none
+    fp32,
+    complex_fp32,
+    fp64,
+    complex_fp64,
+#if GINKGO_ENABLE_HALF
+    fp16,
+    complex_fp16,
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    bf16,
+    complex_bf16,
+#endif
+};
+
+
+// Returns the string representation of a precision
+std::string to_string(precision p);
+
+
+// Equality comparison operator.
+// The precision::any is equal to any other precision, including none.
+constexpr bool operator==(precision a, precision b)
+{
+    auto int_a = static_cast<int>(a);
+    auto int_b = static_cast<int>(b);
+    if (int_a == static_cast<int>(precision::any) ||
+        int_b == static_cast<int>(precision::any)) {
+        return true;
+    }
+    return int_a == int_b;
+}
+
+
+constexpr bool operator!=(precision a, precision b) { return !(a == b); }
+
+
+/**
+ * Map from compile time type to runtime precision.
+ *
+ * @tparam T  Value type to map to a precision
+ */
+template <typename T>
+inline precision precision_v;
+
+template <>
+inline constexpr precision precision_v<float> = precision::fp32;
+template <>
+inline constexpr precision precision_v<std::complex<float>> =
+    precision::complex_fp32;
+template <>
+inline constexpr precision precision_v<double> = precision::fp64;
+template <>
+inline constexpr precision precision_v<std::complex<double>> =
+    precision::complex_fp64;
+#if GINKGO_ENABLE_HALF
+template <>
+inline constexpr precision precision_v<half> = precision::fp16;
+template <>
+inline constexpr precision precision_v<std::complex<half>> =
+    precision::complex_fp16;
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+template <>
+inline constexpr precision precision_v<bfloat16> = precision::bf16;
+template <>
+inline constexpr precision precision_v<std::complex<bfloat16>> =
+    precision::complex_bf16;
+#endif
+
+
+// True if the precision is complex or any
+constexpr bool is_complex(precision p)
+{
+    return
+#if GINKGO_ENABLE_HALF
+        p == precision::complex_fp16 ||
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+        p == precision::complex_bf16 ||
+#endif
+        p == precision::complex_fp32 || p == precision::complex_fp64;
+}
+
+
+// True if the precision is real or any
+constexpr bool is_real(precision p)
+{
+    return
+#if GINKGO_ENABLE_HALF
+        p == precision::fp16 ||
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+        p == precision::bf16 ||
+#endif
+        p == precision::fp32 || p == precision::fp64;
+}
+
+
+/**
+ * Maps a precision to its corresponding real precision.
+ *
+ * For example as_real(complex_fp32) == fp32.
+ * For a real precision or any this is the identity.
+ *
+ * @throws InvalidStateError if the precision is none
+ *
+ * @param p  precision to map to a real precision
+ * @return The real precision corresponding to p
+ */
+precision as_real(precision p);
+
+
+/**
+ * Maps a precision to its corresponding complex precision.
+ *
+ * For example as_complex(fp32) == complex_fp32.
+ * For a complex precision or any this is the identity.
+ *
+ * @throws InvalidStateError if the precision is none
+ *
+ * @param p  precision to map to a complex precision
+ * @return The complex precision corresponding to p
+ */
+precision as_complex(precision p);
+
+
+/**
+ * Create a variant from a precision.
+ *
+ * This allows to map the runtime precision back to a compile time precision
+ * when needed.
+ * For example, for a precision fp32, the result variant will hold float as
+ * its alternatives.
+ *
+ * @param p The precision to map to the variant
+ * @return A variant which value corresponds to the type matching the precision.
+ */
+std::variant<
+#if GINKGO_ENABLE_HALF
+    half, std::complex<half>,
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    bfloat16, std::complex<bfloat16>,
+#endif
+    float, std::complex<float>, double, std::complex<double>>
+precision_to_variant(precision p);
+
+
+}  // namespace gko


### PR DESCRIPTION
This PR adds runtime precision handling to LinOp. A new enum is created to provide the precision at runtime. The precision enum has values for all supported value types (depending on the cmake configuration). Additionally, it has the two values `none` and `any`. `none` is used to denote missing precision information or an invalid state. The `any` value can be used for mixed-precision applications.

The precision is stored in the `LinOp` class. Each existing linop sets the correct precision. There are helper variables to map a compile time type to a runtime enum value.

The opposite map is available by creating a variant from the enum.