### PR TITLE
Add a restart ratio parameter for GMRES

### DIFF
--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -416,41 +416,45 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
     // With one rhs the loop has already been left if it stopped, so the
     // synchronizing copy of its status is not needed.
     const bool need_host_stop_status = use_restart_tol && num_rhs > 1;
+    // ||r_i||, the residual norm when the current cycle started, and the
+    // current ||r_i - A d_i||, both kept on the host.
+    std::unique_ptr<NormVector> cycle_start_norm;
     std::unique_ptr<NormVector> host_residual_norm;
-    std::vector<remove_complex<ValueType>> cycle_start_norm;
     array<stopping_status> host_stop_status(exec->get_master());
     if (use_restart_tol) {
+        cycle_start_norm =
+            NormVector::create(exec->get_master(), dim<2>{1, num_rhs});
         host_residual_norm =
             NormVector::create(exec->get_master(), dim<2>{1, num_rhs});
-        cycle_start_norm.resize(num_rhs, zero<remove_complex<ValueType>>());
         if (need_host_stop_status) {
             host_stop_status.resize_and_reset(num_rhs);
         }
     }
-    auto record_cycle_start = [&] {
+    auto record_cycle_start = [&](const NormVector* res_norm) {
         if (use_restart_tol) {
-            host_residual_norm->copy_from(residual_norm);
-            for (size_type i = 0; i < num_rhs; ++i) {
-                cycle_start_norm[i] = host_residual_norm->at(0, i);
-            }
+            cycle_start_norm->copy_from(res_norm);
         }
     };
-    // ||r_i - A d_i|| <= restart_tol * ||r_i|| for every unstopped rhs.
-    auto cycle_tolerance_met = [&] {
+    // Returns true if ||r_i - A d_i|| <= restart_tol * ||r_i|| for every rhs
+    // that has not stopped, where r_i is the residual at the start of the
+    // cycle and d_i the correction the cycle has built so far.
+    auto cycle_tolerance_met = [&](const NormVector* res_norm,
+                                   const array<stopping_status>& stop) {
         if (!use_restart_tol) {
             return false;
         }
-        host_residual_norm->copy_from(residual_norm);
+        host_residual_norm->copy_from(res_norm);
         if (need_host_stop_status) {
-            host_stop_status = stop_status;
+            host_stop_status = stop;
         }
         for (size_type i = 0; i < num_rhs; ++i) {
             if (need_host_stop_status &&
                 host_stop_status.get_const_data()[i].has_stopped()) {
                 continue;
             }
+            // Negated so a non-finite norm does not count as meeting it.
             if (!(host_residual_norm->at(0, i) <=
-                  restart_tol * cycle_start_norm[i])) {
+                  restart_tol * cycle_start_norm->at(0, i))) {
                 return false;
             }
         }
@@ -480,7 +484,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         residual_norm_collection->get_device_view(),
         gko::detail::get_local(krylov_bases)->get_device_view(),
         final_iter_nums.get_data()));
-    record_cycle_start();
+    record_cycle_start(residual_norm);
 
     auto stop_criterion = this->get_stop_criterion_factory()->generate(
         this->get_system_matrix(),
@@ -489,7 +493,6 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     int total_iter = -1;
     size_type restart_iter = 0;
-    bool perform_reset = false;
 
     /* Memory movement summary for average iteration with krylov_dim d:
      * (5/2d+21/2+14/d)n * values + (1+1/d) * matrix/preconditioner storage
@@ -525,9 +528,9 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             break;
         }
 
-        if (restart_iter == krylov_dim || perform_reset) {
+        if (restart_iter == krylov_dim ||
+            cycle_tolerance_met(residual_norm, stop_status)) {
             // Restart
-            perform_reset = false;
             // Solve upper triangular.
             // y = hessenberg \ residual_norm_collection
             exec->run(gmres::make_solve_krylov(
@@ -564,7 +567,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 gko::detail::get_local(krylov_bases)->get_device_view(),
                 final_iter_nums.get_data()));
             restart_iter = 0;
-            record_cycle_start();
+            record_cycle_start(residual_norm);
         }
         auto this_krylov = krylov_bases->create_submatrix(
             local_span{local_num_rows * restart_iter,
@@ -660,11 +663,6 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             final_iter_nums.get_data(), stop_status.get_const_data()));
 
         restart_iter++;
-
-        // The restart is then taken at the top of the next iteration.
-        if (restart_iter < krylov_dim && cycle_tolerance_met()) {
-            perform_reset = true;
-        }
     }
 
     auto hessenberg_small = hessenberg->create_submatrix(

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -5,6 +5,7 @@
 #include "ginkgo/core/solver/gmres.hpp"
 
 #include <string>
+#include <vector>
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/exception.hpp>
@@ -72,6 +73,10 @@ typename Gmres<ValueType>::parameters_type Gmres<ValueType>::parse(
     if (auto& obj = config_check.get("krylov_dim")) {
         params.with_krylov_dim(gko::config::get_value<size_type>(obj));
     }
+    if (auto& obj = config_check.get("restart_tol")) {
+        params.with_restart_tol(
+            gko::config::get_value<remove_complex<ValueType>>(obj));
+    }
     if (auto& obj = config_check.get("flexible")) {
         params.with_flexible(gko::config::get_value<bool>(obj));
     }
@@ -102,6 +107,7 @@ std::unique_ptr<LinOp> Gmres<ValueType>::transpose() const
             share(as<Transposable>(this->get_preconditioner())->transpose()))
         .with_criteria(this->get_stop_criterion_factory())
         .with_krylov_dim(this->get_krylov_dim())
+        .with_restart_tol(this->get_restart_tol())
         .with_flexible(this->get_parameters().flexible)
         .on(this->get_executor())
         ->generate(
@@ -117,6 +123,7 @@ std::unique_ptr<LinOp> Gmres<ValueType>::conj_transpose() const
             as<Transposable>(this->get_preconditioner())->conj_transpose()))
         .with_criteria(this->get_stop_criterion_factory())
         .with_krylov_dim(this->get_krylov_dim())
+        .with_restart_tol(this->get_restart_tol())
         .with_flexible(this->get_parameters().flexible)
         .on(this->get_executor())
         ->generate(share(
@@ -402,6 +409,54 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
     auto& final_iter_nums = this->template create_workspace_array<size_type>(
         ws::final_iter_nums, num_rhs);
 
+    // Tolerance-based restart, disabled by restart_tol == 0.
+    const auto restart_tol = this->get_restart_tol();
+    const bool use_restart_tol =
+        restart_tol > zero<remove_complex<ValueType>>();
+    // With one rhs the loop has already been left if it stopped, so the
+    // synchronizing copy of its status is not needed.
+    const bool need_host_stop_status = use_restart_tol && num_rhs > 1;
+    std::unique_ptr<NormVector> host_residual_norm;
+    std::vector<remove_complex<ValueType>> cycle_start_norm;
+    array<stopping_status> host_stop_status(exec->get_master());
+    if (use_restart_tol) {
+        host_residual_norm =
+            NormVector::create(exec->get_master(), dim<2>{1, num_rhs});
+        cycle_start_norm.resize(num_rhs, zero<remove_complex<ValueType>>());
+        if (need_host_stop_status) {
+            host_stop_status.resize_and_reset(num_rhs);
+        }
+    }
+    auto record_cycle_start = [&] {
+        if (use_restart_tol) {
+            host_residual_norm->copy_from(residual_norm);
+            for (size_type i = 0; i < num_rhs; ++i) {
+                cycle_start_norm[i] = host_residual_norm->at(0, i);
+            }
+        }
+    };
+    // ||r_i - A d_i|| <= restart_tol * ||r_i|| for every unstopped rhs.
+    auto cycle_tolerance_met = [&] {
+        if (!use_restart_tol) {
+            return false;
+        }
+        host_residual_norm->copy_from(residual_norm);
+        if (need_host_stop_status) {
+            host_stop_status = stop_status;
+        }
+        for (size_type i = 0; i < num_rhs; ++i) {
+            if (need_host_stop_status &&
+                host_stop_status.get_const_data()[i].has_stopped()) {
+                continue;
+            }
+            if (!(host_residual_norm->at(0, i) <=
+                  restart_tol * cycle_start_norm[i])) {
+                return false;
+            }
+        }
+        return true;
+    };
+
     // Initialization
     // residual = dense_b
     // givens_sin = givens_cos = 0
@@ -425,6 +480,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         residual_norm_collection->get_device_view(),
         gko::detail::get_local(krylov_bases)->get_device_view(),
         final_iter_nums.get_data()));
+    record_cycle_start();
 
     auto stop_criterion = this->get_stop_criterion_factory()->generate(
         this->get_system_matrix(),
@@ -433,6 +489,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
 
     int total_iter = -1;
     size_type restart_iter = 0;
+    bool perform_reset = false;
 
     /* Memory movement summary for average iteration with krylov_dim d:
      * (5/2d+21/2+14/d)n * values + (1+1/d) * matrix/preconditioner storage
@@ -468,8 +525,9 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             break;
         }
 
-        if (restart_iter == krylov_dim) {
+        if (restart_iter == krylov_dim || perform_reset) {
             // Restart
+            perform_reset = false;
             // Solve upper triangular.
             // y = hessenberg \ residual_norm_collection
             exec->run(gmres::make_solve_krylov(
@@ -506,6 +564,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 gko::detail::get_local(krylov_bases)->get_device_view(),
                 final_iter_nums.get_data()));
             restart_iter = 0;
+            record_cycle_start();
         }
         auto this_krylov = krylov_bases->create_submatrix(
             local_span{local_num_rows * restart_iter,
@@ -601,6 +660,11 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             final_iter_nums.get_data(), stop_status.get_const_data()));
 
         restart_iter++;
+
+        // The restart is then taken at the top of the next iteration.
+        if (restart_iter < krylov_dim && cycle_tolerance_met()) {
+            perform_reset = true;
+        }
     }
 
     auto hessenberg_small = hessenberg->create_submatrix(

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -73,8 +73,8 @@ typename Gmres<ValueType>::parameters_type Gmres<ValueType>::parse(
     if (auto& obj = config_check.get("krylov_dim")) {
         params.with_krylov_dim(gko::config::get_value<size_type>(obj));
     }
-    if (auto& obj = config_check.get("restart_tol")) {
-        params.with_restart_tol(
+    if (auto& obj = config_check.get("restart_ratio")) {
+        params.with_restart_ratio(
             gko::config::get_value<remove_complex<ValueType>>(obj));
     }
     if (auto& obj = config_check.get("flexible")) {
@@ -107,7 +107,7 @@ std::unique_ptr<LinOp> Gmres<ValueType>::transpose() const
             share(as<Transposable>(this->get_preconditioner())->transpose()))
         .with_criteria(this->get_stop_criterion_factory())
         .with_krylov_dim(this->get_krylov_dim())
-        .with_restart_tol(this->get_restart_tol())
+        .with_restart_ratio(this->get_restart_ratio())
         .with_flexible(this->get_parameters().flexible)
         .on(this->get_executor())
         ->generate(
@@ -123,7 +123,7 @@ std::unique_ptr<LinOp> Gmres<ValueType>::conj_transpose() const
             as<Transposable>(this->get_preconditioner())->conj_transpose()))
         .with_criteria(this->get_stop_criterion_factory())
         .with_krylov_dim(this->get_krylov_dim())
-        .with_restart_tol(this->get_restart_tol())
+        .with_restart_ratio(this->get_restart_ratio())
         .with_flexible(this->get_parameters().flexible)
         .on(this->get_executor())
         ->generate(share(
@@ -409,19 +409,19 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
     auto& final_iter_nums = this->template create_workspace_array<size_type>(
         ws::final_iter_nums, num_rhs);
 
-    // Tolerance-based restart, disabled by restart_tol == 0.
-    const auto restart_tol = this->get_restart_tol();
-    const bool use_restart_tol =
-        restart_tol > zero<remove_complex<ValueType>>();
+    // Ratio-based restart, disabled by restart_ratio == 0.
+    const auto restart_ratio = this->get_restart_ratio();
+    const bool use_restart_ratio =
+        restart_ratio > zero<remove_complex<ValueType>>();
     // With one rhs the loop has already been left if it stopped, so the
     // synchronizing copy of its status is not needed.
-    const bool need_host_stop_status = use_restart_tol && num_rhs > 1;
+    const bool need_host_stop_status = use_restart_ratio && num_rhs > 1;
     // ||r_i||, the residual norm when the current cycle started, and the
     // current ||r_i - A d_i||, both kept on the host.
     std::unique_ptr<NormVector> cycle_start_norm;
     std::unique_ptr<NormVector> host_residual_norm;
     array<stopping_status> host_stop_status(exec->get_master());
-    if (use_restart_tol) {
+    if (use_restart_ratio) {
         cycle_start_norm =
             NormVector::create(exec->get_master(), dim<2>{1, num_rhs});
         host_residual_norm =
@@ -431,16 +431,16 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         }
     }
     auto record_cycle_start = [&](const NormVector* res_norm) {
-        if (use_restart_tol) {
+        if (use_restart_ratio) {
             cycle_start_norm->copy_from(res_norm);
         }
     };
-    // Returns true if ||r_i - A d_i|| <= restart_tol * ||r_i|| for every rhs
+    // Returns true if ||r_i - A d_i|| <= restart_ratio * ||r_i|| for every rhs
     // that has not stopped, where r_i is the residual at the start of the
     // cycle and d_i the correction the cycle has built so far.
-    auto cycle_tolerance_met = [&](const NormVector* res_norm,
-                                   const array<stopping_status>& stop) {
-        if (!use_restart_tol) {
+    auto cycle_ratio_met = [&](const NormVector* res_norm,
+                               const array<stopping_status>& stop) {
+        if (!use_restart_ratio) {
             return false;
         }
         host_residual_norm->copy_from(res_norm);
@@ -454,7 +454,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
             }
             // Negated so a non-finite norm does not count as meeting it.
             if (!(host_residual_norm->at(0, i) <=
-                  restart_tol * cycle_start_norm->at(0, i))) {
+                  restart_ratio * cycle_start_norm->at(0, i))) {
                 return false;
             }
         }
@@ -529,7 +529,7 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
         }
 
         if (restart_iter == krylov_dim ||
-            cycle_tolerance_met(residual_norm, stop_status)) {
+            cycle_ratio_met(residual_norm, stop_status)) {
             // Restart
             // Solve upper triangular.
             // y = hessenberg \ residual_norm_collection

--- a/core/solver/gmres.cpp
+++ b/core/solver/gmres.cpp
@@ -5,7 +5,6 @@
 #include "ginkgo/core/solver/gmres.hpp"
 
 #include <string>
-#include <vector>
 
 #include <ginkgo/core/base/array.hpp>
 #include <ginkgo/core/base/exception.hpp>
@@ -452,9 +451,8 @@ void Gmres<ValueType>::apply_dense_impl(const VectorType* dense_b,
                 host_stop_status.get_const_data()[i].has_stopped()) {
                 continue;
             }
-            // Negated so a non-finite norm does not count as meeting it.
-            if (!(host_residual_norm->at(0, i) <=
-                  restart_ratio * cycle_start_norm->at(0, i))) {
+            if (host_residual_norm->at(0, i) >
+                restart_ratio * cycle_start_norm->at(0, i)) {
                 return false;
             }
         }

--- a/core/test/config/solver.cpp
+++ b/core/test/config/solver.cpp
@@ -300,6 +300,8 @@ struct Gmres
                                                    exec);
         config_map["krylov_dim"] = pnode{3};
         param.with_krylov_dim(3u);
+        config_map["restart_tol"] = pnode{0.9};
+        param.with_restart_tol(decltype(param.restart_tol){0.9});
         config_map["flexible"] = pnode{true};
         param.with_flexible(true);
         config_map["ortho_method"] = pnode{"cgs"};
@@ -314,6 +316,7 @@ struct Gmres
 
         solver_config_test::template validate<from_reg>(result, answer);
         ASSERT_EQ(res_param.krylov_dim, ans_param.krylov_dim);
+        ASSERT_EQ(res_param.restart_tol, ans_param.restart_tol);
         ASSERT_EQ(res_param.flexible, ans_param.flexible);
         ASSERT_EQ(res_param.ortho_method, ans_param.ortho_method);
     }

--- a/core/test/config/solver.cpp
+++ b/core/test/config/solver.cpp
@@ -300,8 +300,8 @@ struct Gmres
                                                    exec);
         config_map["krylov_dim"] = pnode{3};
         param.with_krylov_dim(3u);
-        config_map["restart_tol"] = pnode{0.9};
-        param.with_restart_tol(decltype(param.restart_tol){0.9});
+        config_map["restart_ratio"] = pnode{0.9};
+        param.with_restart_ratio(decltype(param.restart_ratio){0.9});
         config_map["flexible"] = pnode{true};
         param.with_flexible(true);
         config_map["ortho_method"] = pnode{"cgs"};
@@ -316,7 +316,7 @@ struct Gmres
 
         solver_config_test::template validate<from_reg>(result, answer);
         ASSERT_EQ(res_param.krylov_dim, ans_param.krylov_dim);
-        ASSERT_EQ(res_param.restart_tol, ans_param.restart_tol);
+        ASSERT_EQ(res_param.restart_ratio, ans_param.restart_ratio);
         ASSERT_EQ(res_param.flexible, ans_param.flexible);
         ASSERT_EQ(res_param.ortho_method, ans_param.ortho_method);
     }

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -171,7 +171,7 @@ TYPED_TEST(Gmres, CanSetKrylovDimAgain)
 }
 
 
-TYPED_TEST(Gmres, RestartTolIsZeroByDefault)
+TYPED_TEST(Gmres, RestartRatioIsZeroByDefault)
 {
     using Solver = typename TestFixture::Solver;
     using value_type = typename TestFixture::value_type;
@@ -182,54 +182,54 @@ TYPED_TEST(Gmres, RestartTolIsZeroByDefault)
             .on(this->exec);
     auto solver = gmres_factory->generate(this->mtx);
 
-    ASSERT_EQ(solver->get_restart_tol(), real_type{0});
+    ASSERT_EQ(solver->get_restart_ratio(), real_type{0});
 }
 
 
-TYPED_TEST(Gmres, CanSetRestartTol)
+TYPED_TEST(Gmres, CanSetRestartRatio)
 {
     using Solver = typename TestFixture::Solver;
     using value_type = typename TestFixture::value_type;
     using real_type = gko::remove_complex<value_type>;
-    const real_type new_restart_tol{0.9};
+    const real_type new_restart_ratio{0.9};
 
     auto gmres_factory =
         Solver::build()
-            .with_restart_tol(new_restart_tol)
+            .with_restart_ratio(new_restart_ratio)
             .with_criteria(gko::stop::Iteration::build().with_max_iters(4u))
             .on(this->exec);
     auto solver = gmres_factory->generate(this->mtx);
 
-    ASSERT_EQ(solver->get_restart_tol(), new_restart_tol);
+    ASSERT_EQ(solver->get_restart_ratio(), new_restart_ratio);
 }
 
 
-TYPED_TEST(Gmres, CanSetRestartTolAgain)
+TYPED_TEST(Gmres, CanSetRestartRatioAgain)
 {
     using Solver = typename TestFixture::Solver;
     using value_type = typename TestFixture::value_type;
     using real_type = gko::remove_complex<value_type>;
-    const real_type new_restart_tol{0.95};
+    const real_type new_restart_ratio{0.95};
     auto gmres_factory =
         Solver::build()
             .with_criteria(gko::stop::Iteration::build().with_max_iters(4u))
             .on(this->exec);
     auto solver = gmres_factory->generate(this->mtx);
 
-    solver->set_restart_tol(new_restart_tol);
+    solver->set_restart_ratio(new_restart_ratio);
 
-    ASSERT_EQ(solver->get_restart_tol(), new_restart_tol);
+    ASSERT_EQ(solver->get_restart_ratio(), new_restart_ratio);
 }
 
 
-TYPED_TEST(Gmres, RejectsRestartTolOutsideUnitInterval)
+TYPED_TEST(Gmres, RejectsRestartRatioOutsideUnitInterval)
 {
     using Solver = typename TestFixture::Solver;
     using value_type = typename TestFixture::value_type;
     using real_type = gko::remove_complex<value_type>;
     auto build_with = [this](real_type tol) {
         return Solver::build()
-            .with_restart_tol(tol)
+            .with_restart_ratio(tol)
             .with_criteria(gko::stop::Iteration::build().with_max_iters(4u))
             .on(this->exec);
     };

--- a/core/test/solver/gmres.cpp
+++ b/core/test/solver/gmres.cpp
@@ -171,6 +171,78 @@ TYPED_TEST(Gmres, CanSetKrylovDimAgain)
 }
 
 
+TYPED_TEST(Gmres, RestartTolIsZeroByDefault)
+{
+    using Solver = typename TestFixture::Solver;
+    using value_type = typename TestFixture::value_type;
+    using real_type = gko::remove_complex<value_type>;
+    auto gmres_factory =
+        Solver::build()
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(4u))
+            .on(this->exec);
+    auto solver = gmres_factory->generate(this->mtx);
+
+    ASSERT_EQ(solver->get_restart_tol(), real_type{0});
+}
+
+
+TYPED_TEST(Gmres, CanSetRestartTol)
+{
+    using Solver = typename TestFixture::Solver;
+    using value_type = typename TestFixture::value_type;
+    using real_type = gko::remove_complex<value_type>;
+    const real_type new_restart_tol{0.9};
+
+    auto gmres_factory =
+        Solver::build()
+            .with_restart_tol(new_restart_tol)
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(4u))
+            .on(this->exec);
+    auto solver = gmres_factory->generate(this->mtx);
+
+    ASSERT_EQ(solver->get_restart_tol(), new_restart_tol);
+}
+
+
+TYPED_TEST(Gmres, CanSetRestartTolAgain)
+{
+    using Solver = typename TestFixture::Solver;
+    using value_type = typename TestFixture::value_type;
+    using real_type = gko::remove_complex<value_type>;
+    const real_type new_restart_tol{0.95};
+    auto gmres_factory =
+        Solver::build()
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(4u))
+            .on(this->exec);
+    auto solver = gmres_factory->generate(this->mtx);
+
+    solver->set_restart_tol(new_restart_tol);
+
+    ASSERT_EQ(solver->get_restart_tol(), new_restart_tol);
+}
+
+
+TYPED_TEST(Gmres, RejectsRestartTolOutsideUnitInterval)
+{
+    using Solver = typename TestFixture::Solver;
+    using value_type = typename TestFixture::value_type;
+    using real_type = gko::remove_complex<value_type>;
+    auto build_with = [this](real_type tol) {
+        return Solver::build()
+            .with_restart_tol(tol)
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(4u))
+            .on(this->exec);
+    };
+
+    ASSERT_THROW(build_with(real_type{1.0})->generate(this->mtx),
+                 gko::InvalidStateError);
+    ASSERT_THROW(build_with(real_type{2.0})->generate(this->mtx),
+                 gko::InvalidStateError);
+    ASSERT_THROW(build_with(-real_type{0.5})->generate(this->mtx),
+                 gko::InvalidStateError);
+}
+
+
 TYPED_TEST(Gmres, CanSetPreconditionerInFactory)
 {
     using Solver = typename TestFixture::Solver;

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -121,23 +121,23 @@ public:
     void set_krylov_dim(size_type other) { parameters_.krylov_dim = other; }
 
     /**
-     * Returns the restart tolerance.
+     * Returns the restart ratio.
      *
-     * @return the restart tolerance
+     * @return the restart ratio
      */
-    remove_complex<ValueType> get_restart_tol() const
+    remove_complex<ValueType> get_restart_ratio() const
     {
-        return parameters_.restart_tol;
+        return parameters_.restart_ratio;
     }
 
     /**
-     * Sets the restart tolerance.
+     * Sets the restart ratio.
      *
-     * @param other  the new restart tolerance
+     * @param other  the new restart ratio
      */
-    void set_restart_tol(remove_complex<ValueType> other)
+    void set_restart_ratio(remove_complex<ValueType> other)
     {
-        parameters_.restart_tol = other;
+        parameters_.restart_ratio = other;
     }
 
 
@@ -149,27 +149,30 @@ public:
         /**
          * Krylov subspace dimension/restart value.
          *
-         * With restart_tol positive this caps the basis size rather than
+         * With restart_ratio positive this caps the basis size rather than
          * setting the restart length, and a cycle ends at whichever criterion
          * is met first. It remains the memory bound.
          */
         size_type GKO_FACTORY_PARAMETER_SCALAR(krylov_dim, 0u);
 
         /**
-         * Restart tolerance.
+         * Restart ratio.
          *
-         * If positive, a cycle ends once
-         * \f$ \|r_i - A d_i\| \leq \text{restart\_tol} \cdot \|r_i\| \f$
-         * holds for every right-hand side still running, where \f$r_i\f$ is
-         * the residual at the start of the cycle and \f$d_i\f$ the correction
+         * A cycle ends once the residual has fallen to this fraction of its
+         * value at the start of the cycle, that is, once
+         * \f$ \|r_i - A d_i\| \leq \text{restart\_ratio} \cdot \|r_i\| \f$
+         * holds for every right-hand side still running, with \f$r_i\f$ the
+         * residual at the start of the cycle and \f$d_i\f$ the correction
          * built so far. This bounds the normwise backward error of the
-         * correction by restart_tol, which is what makes the restarted method
-         * analyzable as iterative refinement. A cycle cut short by krylov_dim
-         * carries no such bound.
+         * correction, which is what makes the restarted method analyzable as
+         * iterative refinement. A cycle cut short by krylov_dim carries no
+         * such bound.
          *
-         * Must lie in [0, 1), and must exceed the reduction a krylov_dim-step
-         * cycle achieves, or it never fires. Use 1e-3 to 1e-1 when a cycle
-         * gains orders of magnitude, and around 0.9 when it gains only a few
+         * It is a per-cycle reduction, not a convergence tolerance, so useful
+         * values are far larger than a stopping criterion's. It must lie in
+         * [0, 1) and must exceed the reduction a krylov_dim-step cycle
+         * achieves, or it never fires: use 1e-3 to 1e-1 when a cycle gains
+         * orders of magnitude, and around 0.9 when it gains only a few
          * percent.
          *
          * Zero, the default, disables the criterion.
@@ -178,7 +181,7 @@ public:
          * <a href="https://doi.org/10.1093/imanum/draf049">A Modular Framework
          * for the Backward Error Analysis of GMRES</a>.
          */
-        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(restart_tol,
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(restart_ratio,
                                                                0.0);
 
         /** Flexible GMRES */
@@ -234,10 +237,9 @@ protected:
             parameters_.krylov_dim = gmres_default_krylov_dim;
         }
         GKO_THROW_IF_INVALID(
-            parameters_.restart_tol >= zero<remove_complex<ValueType>>() &&
-                parameters_.restart_tol < one<remove_complex<ValueType>>(),
-            "restart_tol must lie in [0, 1); zero disables the criterion "
-            "and values close to but below one are the useful range");
+            parameters_.restart_ratio >= zero<remove_complex<ValueType>>() &&
+                parameters_.restart_ratio < one<remove_complex<ValueType>>(),
+            "restart_ratio must lie in [0, 1); zero disables the criterion");
     }
 };
 

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -120,14 +120,64 @@ public:
      */
     void set_krylov_dim(size_type other) { parameters_.krylov_dim = other; }
 
+    /**
+     * Returns the restart tolerance.
+     *
+     * @return the restart tolerance
+     */
+    remove_complex<ValueType> get_restart_tol() const
+    {
+        return parameters_.restart_tol;
+    }
+
+    /**
+     * Sets the restart tolerance.
+     *
+     * @param other  the new restart tolerance
+     */
+    void set_restart_tol(remove_complex<ValueType> other)
+    {
+        parameters_.restart_tol = other;
+    }
+
 
     class Factory;
 
     struct parameters_type
         : enable_preconditioned_iterative_solver_factory_parameters<
               parameters_type, Factory> {
-        /** Krylov subspace dimension/restart value. */
+        /**
+         * Krylov subspace dimension/restart value.
+         *
+         * With restart_tol positive this is a cap on the basis size rather than
+         * the restart length, and a cycle ends at whichever criterion is met
+         * first.
+         */
         size_type GKO_FACTORY_PARAMETER_SCALAR(krylov_dim, 0u);
+
+        /**
+         * Restart tolerance.
+         *
+         * If positive, a cycle ends as soon as
+         * \f$ \|r_i - A d_i\| \leq \text{restart\_tol} \cdot \|r_i\| \f$
+         * holds for every right-hand side that has not already stopped, where
+         * \f$r_i\f$ is the residual at the start of the cycle. Since
+         * \f$\|A\|_F \|d_i\| \geq 0\f$ enlarges the denominator of the
+         * backward error, this bounds the normwise backward error of the
+         * correction by restart_tol, which is what admits a backward error
+         * analysis of the restarted method.
+         *
+         * Must lie in [0, 1), with 0.9 to 0.95 the useful range. Well below one
+         * the test is only met after the cycle has done most of the work of a
+         * full solve, so krylov_dim governs the restart again. Close to one the
+         * cycles are too short for the subspace to make progress; at exactly
+         * one the non-increasing GMRES residual satisfies the test at every
+         * iteration, so values outside [0, 1) are rejected.
+         *
+         * Zero, the default, disables the criterion.
+         */
+        remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(restart_tol,
+                                                               0.0);
 
         /** Flexible GMRES */
         bool GKO_FACTORY_PARAMETER_SCALAR(flexible, false);
@@ -180,6 +230,12 @@ protected:
     {
         if (!parameters_.krylov_dim) {
             parameters_.krylov_dim = gmres_default_krylov_dim;
+        }
+        if (parameters_.restart_tol < zero<remove_complex<ValueType>>() ||
+            parameters_.restart_tol >= one<remove_complex<ValueType>>()) {
+            GKO_INVALID_STATE(
+                "restart_tol must lie in [0, 1); zero disables the criterion "
+                "and values close to but below one are the useful range");
         }
     }
 };

--- a/include/ginkgo/core/solver/gmres.hpp
+++ b/include/ginkgo/core/solver/gmres.hpp
@@ -149,32 +149,34 @@ public:
         /**
          * Krylov subspace dimension/restart value.
          *
-         * With restart_tol positive this is a cap on the basis size rather than
-         * the restart length, and a cycle ends at whichever criterion is met
-         * first.
+         * With restart_tol positive this caps the basis size rather than
+         * setting the restart length, and a cycle ends at whichever criterion
+         * is met first. It remains the memory bound.
          */
         size_type GKO_FACTORY_PARAMETER_SCALAR(krylov_dim, 0u);
 
         /**
          * Restart tolerance.
          *
-         * If positive, a cycle ends as soon as
+         * If positive, a cycle ends once
          * \f$ \|r_i - A d_i\| \leq \text{restart\_tol} \cdot \|r_i\| \f$
-         * holds for every right-hand side that has not already stopped, where
-         * \f$r_i\f$ is the residual at the start of the cycle. Since
-         * \f$\|A\|_F \|d_i\| \geq 0\f$ enlarges the denominator of the
-         * backward error, this bounds the normwise backward error of the
-         * correction by restart_tol, which is what admits a backward error
-         * analysis of the restarted method.
+         * holds for every right-hand side still running, where \f$r_i\f$ is
+         * the residual at the start of the cycle and \f$d_i\f$ the correction
+         * built so far. This bounds the normwise backward error of the
+         * correction by restart_tol, which is what makes the restarted method
+         * analyzable as iterative refinement. A cycle cut short by krylov_dim
+         * carries no such bound.
          *
-         * Must lie in [0, 1), with 0.9 to 0.95 the useful range. Well below one
-         * the test is only met after the cycle has done most of the work of a
-         * full solve, so krylov_dim governs the restart again. Close to one the
-         * cycles are too short for the subspace to make progress; at exactly
-         * one the non-increasing GMRES residual satisfies the test at every
-         * iteration, so values outside [0, 1) are rejected.
+         * Must lie in [0, 1), and must exceed the reduction a krylov_dim-step
+         * cycle achieves, or it never fires. Use 1e-3 to 1e-1 when a cycle
+         * gains orders of magnitude, and around 0.9 when it gains only a few
+         * percent.
          *
          * Zero, the default, disables the criterion.
+         *
+         * For the criterion and its analysis, see sec. 4.2 of
+         * <a href="https://doi.org/10.1093/imanum/draf049">A Modular Framework
+         * for the Backward Error Analysis of GMRES</a>.
          */
         remove_complex<ValueType> GKO_FACTORY_PARAMETER_SCALAR(restart_tol,
                                                                0.0);
@@ -231,12 +233,11 @@ protected:
         if (!parameters_.krylov_dim) {
             parameters_.krylov_dim = gmres_default_krylov_dim;
         }
-        if (parameters_.restart_tol < zero<remove_complex<ValueType>>() ||
-            parameters_.restart_tol >= one<remove_complex<ValueType>>()) {
-            GKO_INVALID_STATE(
-                "restart_tol must lie in [0, 1); zero disables the criterion "
-                "and values close to but below one are the useful range");
-        }
+        GKO_THROW_IF_INVALID(
+            parameters_.restart_tol >= zero<remove_complex<ValueType>>() &&
+                parameters_.restart_tol < one<remove_complex<ValueType>>(),
+            "restart_tol must lie in [0, 1); zero disables the criterion "
+            "and values close to but below one are the useful range");
     }
 };
 

--- a/reference/test/solver/gmres_kernels.cpp
+++ b/reference/test/solver/gmres_kernels.cpp
@@ -775,7 +775,7 @@ TYPED_TEST(Gmres, SolvesBigDenseSystem1WithRestart)
 }
 
 
-TYPED_TEST(Gmres, SolvesBigDenseSystem1WithRestartTol)
+TYPED_TEST(Gmres, SolvesBigDenseSystem1WithRestartRatio)
 {
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
@@ -787,7 +787,7 @@ TYPED_TEST(Gmres, SolvesBigDenseSystem1WithRestartTol)
     auto gmres_factory_restart =
         Solver::build()
             .with_krylov_dim(4u)
-            .with_restart_tol(rc_value_type{0.9})
+            .with_restart_ratio(rc_value_type{0.9})
             .with_criteria(gko::stop::Iteration::build().with_max_iters(200u),
                            gko::stop::ResidualNorm<value_type>::build()
                                .with_reduction_factor(r<value_type>::value))
@@ -840,7 +840,7 @@ private:
 };
 
 
-TYPED_TEST(Gmres, RestartTolRestartsBeforeKrylovDim)
+TYPED_TEST(Gmres, RestartRatioRestartsBeforeKrylovDim)
 {
     using Mtx = typename TestFixture::Mtx;
     using Solver = typename TestFixture::Solver;
@@ -850,10 +850,10 @@ TYPED_TEST(Gmres, RestartTolRestartsBeforeKrylovDim)
     SKIP_IF_HALF(value_type);
     auto half_tol = std::sqrt(r<value_type>::value);
     // krylov_dim is out of reach, so any restart comes from the tolerance.
-    auto build_factory = [this](rc_value_type restart_tol) {
+    auto build_factory = [this](rc_value_type restart_ratio) {
         return Solver::build()
             .with_krylov_dim(100u)
-            .with_restart_tol(restart_tol)
+            .with_restart_ratio(restart_ratio)
             .with_criteria(gko::stop::Iteration::build().with_max_iters(200u),
                            gko::stop::ResidualNorm<value_type>::build()
                                .with_reduction_factor(r<value_type>::value))

--- a/reference/test/solver/gmres_kernels.cpp
+++ b/reference/test/solver/gmres_kernels.cpp
@@ -12,6 +12,7 @@
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
 #include <ginkgo/core/base/math.hpp>
+#include <ginkgo/core/log/logger.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/preconditioner/jacobi.hpp>
 #include <ginkgo/core/solver/gmres.hpp>
@@ -770,6 +771,116 @@ TYPED_TEST(Gmres, SolvesBigDenseSystem1WithRestart)
     solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({-140.20, -142.20, 48.80, -17.70, -19.60}),
+                        half_tol * 1e2);
+}
+
+
+TYPED_TEST(Gmres, SolvesBigDenseSystem1WithRestartTol)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    using value_type = typename TestFixture::value_type;
+    using rc_value_type = typename TestFixture::rc_value_type;
+    // the system is already out of half precision range
+    SKIP_IF_HALF(value_type);
+    auto half_tol = std::sqrt(r<value_type>::value);
+    auto gmres_factory_restart =
+        Solver::build()
+            .with_krylov_dim(4u)
+            .with_restart_tol(rc_value_type{0.9})
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(200u),
+                           gko::stop::ResidualNorm<value_type>::build()
+                               .with_reduction_factor(r<value_type>::value))
+            .on(this->exec);
+    auto solver = gmres_factory_restart->generate(this->mtx_medium);
+    auto b = gko::initialize<Mtx>(
+        {-13945.16, 11205.66, 16132.96, 24342.18, -10910.98}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
+
+    solver->apply(b, x);
+
+    GKO_ASSERT_MTX_NEAR(x, l({-140.20, -142.20, 48.80, -17.70, -19.60}),
+                        half_tol * 1e2);
+}
+
+
+// Gmres only rewrites its residual vector on a restart, so a change in the
+// logged residual is exactly one restart.
+template <typename ValueType>
+class restart_counter : public gko::log::Logger {
+public:
+    restart_counter() : gko::log::Logger(Logger::iteration_complete_mask) {}
+
+    void on_iteration_complete(const gko::LinOp*, const gko::LinOp*,
+                               const gko::LinOp*, const gko::size_type&,
+                               const gko::LinOp* residual, const gko::LinOp*,
+                               const gko::LinOp*,
+                               const gko::array<gko::stopping_status>*,
+                               bool) const override
+    {
+        auto dense_residual = gko::as<gko::matrix::Dense<ValueType>>(residual);
+        if (previous_) {
+            const auto size = dense_residual->get_num_stored_elements();
+            for (gko::size_type i = 0; i < size; ++i) {
+                if (previous_->get_const_values()[i] !=
+                    dense_residual->get_const_values()[i]) {
+                    ++num_restarts_;
+                    break;
+                }
+            }
+        }
+        previous_ = dense_residual->clone();
+    }
+
+    int get_num_restarts() const { return num_restarts_; }
+
+private:
+    mutable std::unique_ptr<gko::matrix::Dense<ValueType>> previous_;
+    mutable int num_restarts_{};
+};
+
+
+TYPED_TEST(Gmres, RestartTolRestartsBeforeKrylovDim)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using Solver = typename TestFixture::Solver;
+    using value_type = typename TestFixture::value_type;
+    using rc_value_type = typename TestFixture::rc_value_type;
+    // the system is already out of half precision range
+    SKIP_IF_HALF(value_type);
+    auto half_tol = std::sqrt(r<value_type>::value);
+    // krylov_dim is out of reach, so any restart comes from the tolerance.
+    auto build_factory = [this](rc_value_type restart_tol) {
+        return Solver::build()
+            .with_krylov_dim(100u)
+            .with_restart_tol(restart_tol)
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(200u),
+                           gko::stop::ResidualNorm<value_type>::build()
+                               .with_reduction_factor(r<value_type>::value))
+            .on(this->exec);
+    };
+    auto b = gko::initialize<Mtx>(
+        {-13945.16, 11205.66, 16132.96, 24342.18, -10910.98}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0, 0.0, 0.0}, this->exec);
+    auto x_restarted = x->clone();
+    auto plain_counter = std::make_shared<restart_counter<value_type>>();
+    auto restarted_counter = std::make_shared<restart_counter<value_type>>();
+    auto plain_solver =
+        build_factory(rc_value_type{0})->generate(this->mtx_medium);
+    auto restarted_solver =
+        build_factory(rc_value_type{0.9})->generate(this->mtx_medium);
+    plain_solver->add_logger(plain_counter);
+    restarted_solver->add_logger(restarted_counter);
+
+    plain_solver->apply(b, x);
+    restarted_solver->apply(b, x_restarted);
+
+    ASSERT_EQ(plain_counter->get_num_restarts(), 0);
+    ASSERT_GT(restarted_counter->get_num_restarts(), 0);
+    GKO_ASSERT_MTX_NEAR(x, l({-140.20, -142.20, 48.80, -17.70, -19.60}),
+                        half_tol * 1e2);
+    GKO_ASSERT_MTX_NEAR(x_restarted,
+                        l({-140.20, -142.20, 48.80, -17.70, -19.60}),
                         half_tol * 1e2);
 }
 


### PR DESCRIPTION
This PR adds a ratio parameter in addition to restart iter (krylov_dim), which enables a cleaner backward error analysis and also makes restarted GMRES similar to GMRES-IR. See [Buttari et.al](https://doi.org/10.1093%2Fimanum%2Fdraf049).

In practice, it also seems to improve performance by reducing the overall time (when the basis size increases), but can increase the total number of restarts. 

An additional benefit of this was that when I tested this with CB-GMRES, it gave better convergence for FP32/FP16 than what was observed with fixed krylov_dim in our CBGMRES paper [Aliaga et.al](https://doi.org/10.1177/10943420221115140)