### PR TITLE
fix the unified col_reduction_2d on many cols

### DIFF
--- a/common/cuda_hip/base/kernel_launch_reduction.hpp
+++ b/common/cuda_hip/base/kernel_launch_reduction.hpp
@@ -493,7 +493,7 @@ void run_kernel_col_reduction_cached(
             syn::value_list<int>(), syn::type_list<>(), max_blocks, exec, fn,
             op, finalize, identity, result, size, tmp, map_to_device(args)...);
     } else {
-        // cuda only accept up to 65545 for grid's y-axix
+        // cuda only accept up to 65535 for grid's y-axis
         constexpr int64 max_grid_y = 65535;
         const auto col_blocks =
             std::min(ceildiv(cols, config::warp_size), max_grid_y);

--- a/common/cuda_hip/base/kernel_launch_reduction.hpp
+++ b/common/cuda_hip/base/kernel_launch_reduction.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -294,26 +294,31 @@ __launch_bounds__(default_block_size) void generic_kernel_col_reduction_2d_block
     const auto block = group::this_thread_block();
     const auto warp = group::tiled_partition<warp_size>(block);
     const auto warp_rank = warp.thread_rank();
-    const auto col = warp_rank + static_cast<int64>(blockIdx.y) * warp_size;
-    auto partial = identity;
-    // accumulate within a thread
-    if (col < cols) {
-        for (auto row = warp_id; row < rows; row += warp_num) {
-            partial = op(partial, fn(row, col, args...));
-        }
-    }
-    block_partial[threadIdx.x] = partial;
-    block.sync();
-    // in a single warp: accumulate the results
-    if (threadIdx.x < warp_size) {
-        partial = identity;
-        // accumulate the partial results within a thread
-#pragma unroll
-        for (int i = 0; i < default_block_size; i += warp_size) {
-            partial = op(partial, block_partial[i + warp_rank]);
-        }
+
+    for (auto block_col = static_cast<int64>(blockIdx.y) * warp_size;
+         block_col < cols;
+         block_col += static_cast<int64>(gridDim.y) * warp_size) {
+        const auto col = warp_rank + block_col;
+        auto partial = identity;
+        // accumulate within a thread
         if (col < cols) {
-            result[col + blockIdx.x * cols] = finalize(partial);
+            for (auto row = warp_id; row < rows; row += warp_num) {
+                partial = op(partial, fn(row, col, args...));
+            }
+        }
+        block_partial[threadIdx.x] = partial;
+        block.sync();
+        // in a single warp: accumulate the results
+        if (threadIdx.x < warp_size) {
+            partial = identity;
+            // accumulate the partial results within a thread
+#pragma unroll
+            for (int i = 0; i < default_block_size; i += warp_size) {
+                partial = op(partial, block_partial[i + warp_rank]);
+            }
+            if (col < cols) {
+                result[col + blockIdx.x * cols] = finalize(partial);
+            }
         }
     }
 }
@@ -488,7 +493,10 @@ void run_kernel_col_reduction_cached(
             syn::value_list<int>(), syn::type_list<>(), max_blocks, exec, fn,
             op, finalize, identity, result, size, tmp, map_to_device(args)...);
     } else {
-        const auto col_blocks = ceildiv(cols, config::warp_size);
+        // cuda only accept up to 65545 for grid's y-axix
+        constexpr int64 max_grid_y = 65535;
+        const auto col_blocks =
+            std::min(ceildiv(cols, config::warp_size), max_grid_y);
         const auto row_blocks =
             ceildiv(std::min<int64>(
                         ceildiv(rows * config::warp_size, default_block_size),

--- a/common/cuda_hip/base/kernel_launch_reduction.hpp
+++ b/common/cuda_hip/base/kernel_launch_reduction.hpp
@@ -294,10 +294,10 @@ __launch_bounds__(default_block_size) void generic_kernel_col_reduction_2d_block
     const auto block = group::this_thread_block();
     const auto warp = group::tiled_partition<warp_size>(block);
     const auto warp_rank = warp.thread_rank();
+    const auto col_step = static_cast<int64>(gridDim.y) * warp_size;
 
     for (auto block_col = static_cast<int64>(blockIdx.y) * warp_size;
-         block_col < cols;
-         block_col += static_cast<int64>(gridDim.y) * warp_size) {
+         block_col < cols; block_col += col_step) {
         const auto col = warp_rank + block_col;
         auto partial = identity;
         // accumulate within a thread
@@ -319,6 +319,10 @@ __launch_bounds__(default_block_size) void generic_kernel_col_reduction_2d_block
             if (col < cols) {
                 result[col + blockIdx.x * cols] = finalize(partial);
             }
+        }
+        // only sync if block_partial will be reused by another iteration
+        if (block_col + col_step < cols) {
+            block.sync();
         }
     }
 }

--- a/common/unified/multigrid/pgm_kernels.cpp
+++ b/common/unified/multigrid/pgm_kernels.cpp
@@ -251,7 +251,7 @@ void assign_to_exist_agg(
         // Copy the intermediate_agg to agg
         agg = intermediate_agg;
     } else {
-        // undeterminstic kernel
+        // undeterministic kernel
         run_kernel(
             exec,
             [] GKO_KERNEL(auto row, auto row_ptrs, auto col_idxs,

--- a/contributors.txt
+++ b/contributors.txt
@@ -28,3 +28,4 @@ Ribizel Tobias <mail@upsj.de> Karlsruhe Institute of Technology
 Riemer Lukas <lksriemer@gmail.com> Karlsruhe Institute of Technology
 Luka Stanisic <luka.stanisic@huawei.com> Huawei Technologies Duesseldorf GmbH
 Tsai Yu-Hsiang <yhmtsai@gmail.com> National Taiwan University
+Tschirpke Friedrich <friedrich.tschirpke@tum.de> Technical University of Munich

--- a/core/components/range_minimum_query.hpp
+++ b/core/components/range_minimum_query.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2024 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/test/base/kernel_launch_generic.cpp
+++ b/test/base/kernel_launch_generic.cpp
@@ -562,7 +562,9 @@ void run2d_col_reduction(std::shared_ptr<gko::EXEC_TYPE> exec)
     for (auto num_rows : {0, 10, 100, 1000, 10000}) {
         // check different edge cases: subwarp sizes, blocked mode
         for (auto num_cols :
-             {0, 1, 2, 3, 4, 5, 7, 8, 9, 16, 31, 32, 63, 127, 128, 129}) {
+             {0, 1, 2, 3, 4, 5, 7, 8, 9, 16, 31, 32, 63, 127, 128, 129,
+              65535 * 128 +
+                  1 /* check we do not exceed the gridDim.y limit */}) {
             SCOPED_TRACE(std::to_string(num_rows) + " rows, " +
                          std::to_string(num_cols) + " cols");
             gko::array<int64> host_ref{exec->get_master(),

--- a/test/base/kernel_launch_generic.cpp
+++ b/test/base/kernel_launch_generic.cpp
@@ -563,8 +563,7 @@ void run2d_col_reduction(std::shared_ptr<gko::EXEC_TYPE> exec)
         // check different edge cases: subwarp sizes, blocked mode
         for (auto num_cols :
              {0, 1, 2, 3, 4, 5, 7, 8, 9, 16, 31, 32, 63, 127, 128, 129,
-              65535 * 128 +
-                  1 /* check we do not exceed the gridDim.y limit */}) {
+              65535 * 128 + 1 /* check for exceeding the gridDim.y limit */}) {
             SCOPED_TRACE(std::to_string(num_rows) + " rows, " +
                          std::to_string(num_cols) + " cols");
             gko::array<int64> host_ref{exec->get_master(),


### PR DESCRIPTION
CUDA only support up to 65535 for y-axis of grid.
when col_reduction_2d on more than 65535 * 32 cols, it will lead invalid configuration for kernels.
Note. this currently contain the test to show the failure only. After some ci showing the error, I will push the fix

TODO:
- [x] link some failure test from CI https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/16061343095
- [x] push the fix