### PR TITLE
fix the deprecation warning 

### DIFF
--- a/include/ginkgo/core/factorization/ic.hpp
+++ b/include/ginkgo/core/factorization/ic.hpp
@@ -77,6 +77,8 @@ public:
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
@@ -92,6 +94,8 @@ public:
             }
             return *this;
         }
+
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the L matrix. The default value is

--- a/include/ginkgo/core/factorization/ilu.hpp
+++ b/include/ginkgo/core/factorization/ilu.hpp
@@ -72,6 +72,8 @@ public:
 
     GKO_CREATE_FACTORY_PARAMETERS(parameters, Factory)
     {
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
@@ -88,6 +90,8 @@ public:
             return *this;
         }
 
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value is
          * `classical`.
@@ -100,6 +104,8 @@ public:
 
         matrix::csr::spmv_strategy l_strategy{
             matrix::csr::spmv_strategy::classical};
+
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the U matrix. The default value
@@ -116,6 +122,8 @@ public:
             }
             return *this;
         }
+
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the U matrix. The default value is

--- a/include/ginkgo/core/factorization/par_ic.hpp
+++ b/include/ginkgo/core/factorization/par_ic.hpp
@@ -121,6 +121,8 @@ public:
          */
         bool GKO_FACTORY_PARAMETER_SCALAR(skip_sorting, false);
 
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
@@ -136,6 +138,8 @@ public:
             }
             return *this;
         }
+
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the L matrix. The default value is

--- a/include/ginkgo/core/factorization/par_ict.hpp
+++ b/include/ginkgo/core/factorization/par_ict.hpp
@@ -170,6 +170,8 @@ public:
          */
         double GKO_FACTORY_PARAMETER_SCALAR(fill_in_limit, 2.0);
 
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
@@ -185,6 +187,8 @@ public:
             }
             return *this;
         }
+
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the L matrix. The default value is

--- a/include/ginkgo/core/factorization/par_ilu.hpp
+++ b/include/ginkgo/core/factorization/par_ilu.hpp
@@ -119,6 +119,8 @@ public:
          */
         bool GKO_FACTORY_PARAMETER_SCALAR(skip_sorting, false);
 
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
@@ -135,6 +137,8 @@ public:
             return *this;
         }
 
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value is
          * `classical`.
@@ -147,6 +151,8 @@ public:
 
         matrix::csr::spmv_strategy l_strategy{
             matrix::csr::spmv_strategy::classical};
+
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the U matrix. The default value
@@ -163,6 +169,8 @@ public:
             }
             return *this;
         }
+
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the U matrix. The default value is

--- a/include/ginkgo/core/factorization/par_ilut.hpp
+++ b/include/ginkgo/core/factorization/par_ilut.hpp
@@ -176,6 +176,8 @@ public:
          */
         double GKO_FACTORY_PARAMETER_SCALAR(fill_in_limit, 2.0);
 
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value
          * `nullptr` will result in the strategy `classical`.
@@ -192,6 +194,8 @@ public:
             return *this;
         }
 
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
+
         /**
          * Strategy which will be used by the L matrix. The default value is
          * `classical`.
@@ -204,6 +208,8 @@ public:
 
         matrix::csr::spmv_strategy l_strategy{
             matrix::csr::spmv_strategy::classical};
+
+        GKO_BEGIN_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the U matrix. The default value
@@ -220,6 +226,8 @@ public:
             }
             return *this;
         }
+
+        GKO_END_DISABLE_DEPRECATION_WARNINGS
 
         /**
          * Strategy which will be used by the U matrix. The default value is


### PR DESCRIPTION
Providing deprecated interface using shared_ptr version of strategy_type also leads deprecation warning because we mark the class also deprecated.
This PR disables the warning when using it.