### PR TITLE
add precision in multigrid to control vector

### DIFF
--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -376,6 +376,40 @@ void MultigridState::generate(const LinOp* system_matrix_in,
 }
 
 
+template <template <typename> class VectorType, typename ValueType,
+          typename... Args>
+std::unique_ptr<LinOp> create_vector_on_precision(
+    precision p, std::shared_ptr<const Executor> exec, Args... args)
+{
+    GKO_THROW_IF_INVALID(p != precision::none, "precision must not be none.");
+    switch (p) {
+    case precision::any:
+        return VectorType<ValueType>::create(exec, args...);
+    case precision::fp32:
+        return VectorType<float>::create(exec, args...);
+    case precision::complex_fp32:
+        return VectorType<std::complex<float>>::create(exec, args...);
+    case precision::fp64:
+        return VectorType<double>::create(exec, args...);
+    case precision::complex_fp64:
+        return VectorType<std::complex<double>>::create(exec, args...);
+#if GINKGO_ENABLE_HALF
+    case precision::fp16:
+        return VectorType<half>::create(exec, args...);
+    case precision::complex_fp16:
+        return VectorType<std::complex<half>>::create(exec, args...);
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    case precision::bf16:
+        return VectorType<bfloat16>::create(exec, args...);
+    case precision::complex_bf16:
+        return VectorType<std::complex<bfloat16>>::create(exec, args...);
+#endif
+    default:
+        GKO_INVALID_STATE("unsupported precision");
+    }
+}
+
 template <class VectorType>
 void MultigridState::allocate_memory(int level, multigrid::cycle cycle,
                                      size_type current_nrows,
@@ -383,20 +417,32 @@ void MultigridState::allocate_memory(int level, multigrid::cycle cycle,
 {
     using value_type = typename VectorType::value_type;
     using vec = matrix::Dense<value_type>;
+    const auto& precision_list = multigrid->get_parameters().precision;
+    auto precision_index = (precision_list.size() == 1) ? 0 : level;
+    auto precision = precision_list.at(precision_index);
 
     auto exec =
         as<LinOp>(multigrid->get_mg_level_list().at(level))->get_executor();
-    r_list.emplace_back(vec::create(exec, dim<2>{current_nrows, nrhs}));
+    r_list.emplace_back(create_vector_on_precision<matrix::Dense, value_type>(
+        precision, exec, dim<2>{current_nrows, nrhs}));
     if (level != 0) {
         // allocate the previous level
-        g_list.emplace_back(vec::create(exec, dim<2>{current_nrows, nrhs}));
-        e_list.emplace_back(vec::create(exec, dim<2>{current_nrows, nrhs}));
+        g_list.emplace_back(
+            create_vector_on_precision<matrix::Dense, value_type>(
+                precision, exec, dim<2>{current_nrows, nrhs}));
+        e_list.emplace_back(
+            create_vector_on_precision<matrix::Dense, value_type>(
+                precision, exec, dim<2>{current_nrows, nrhs}));
         next_one_list.emplace_back(initialize<vec>({one<value_type>()}, exec));
     }
     if (level + 1 == multigrid->get_mg_level_list().size()) {
         // the last level allocate the g, e for coarsest solver
-        g_list.emplace_back(vec::create(exec, dim<2>{next_nrows, nrhs}));
-        e_list.emplace_back(vec::create(exec, dim<2>{next_nrows, nrhs}));
+        g_list.emplace_back(
+            create_vector_on_precision<matrix::Dense, value_type>(
+                precision, exec, dim<2>{next_nrows, nrhs}));
+        e_list.emplace_back(
+            create_vector_on_precision<matrix::Dense, value_type>(
+                precision, exec, dim<2>{next_nrows, nrhs}));
         next_one_list.emplace_back(initialize<vec>({one<value_type>()}, exec));
     }
     one_list.emplace_back(initialize<vec>({one<value_type>()}, exec));
@@ -418,31 +464,44 @@ void MultigridState::allocate_memory(
     using value_type = typename VectorType::value_type;
     using vec = VectorType;
     using dense_vec = matrix::Dense<value_type>;
+    const auto& precision_list = multigrid->get_parameters().precision;
+    auto precision_index = (precision_list.size() == 1) ? 0 : level;
+    auto precision = precision_list.at(precision_index);
 
     auto exec =
         as<LinOp>(multigrid->get_mg_level_list().at(level))->get_executor();
-    r_list.emplace_back(vec::create(exec, current_comm,
-                                    dim<2>{current_nrows, nrhs},
-                                    dim<2>{current_local_nrows, nrhs}));
+    r_list.emplace_back(
+        create_vector_on_precision<experimental::distributed::Vector,
+                                   value_type>(
+            precision, exec, current_comm, dim<2>{current_nrows, nrhs},
+            dim<2>{current_local_nrows, nrhs}));
     if (level != 0) {
         // allocate the previous level
-        g_list.emplace_back(vec::create(exec, current_comm,
-                                        dim<2>{current_nrows, nrhs},
-                                        dim<2>{current_local_nrows, nrhs}));
-        e_list.emplace_back(vec::create(exec, current_comm,
-                                        dim<2>{current_nrows, nrhs},
-                                        dim<2>{current_local_nrows, nrhs}));
+        g_list.emplace_back(
+            create_vector_on_precision<experimental::distributed::Vector,
+                                       value_type>(
+                precision, exec, current_comm, dim<2>{current_nrows, nrhs},
+                dim<2>{current_local_nrows, nrhs}));
+        e_list.emplace_back(
+            create_vector_on_precision<experimental::distributed::Vector,
+                                       value_type>(
+                precision, exec, current_comm, dim<2>{current_nrows, nrhs},
+                dim<2>{current_local_nrows, nrhs}));
         next_one_list.emplace_back(
             initialize<dense_vec>({one<value_type>()}, exec));
     }
     if (level + 1 == multigrid->get_mg_level_list().size()) {
         // the last level allocate the g, e for coarsest solver
-        g_list.emplace_back(vec::create(exec, next_comm,
-                                        dim<2>{next_nrows, nrhs},
-                                        dim<2>{next_local_nrows, nrhs}));
-        e_list.emplace_back(vec::create(exec, next_comm,
-                                        dim<2>{next_nrows, nrhs},
-                                        dim<2>{next_local_nrows, nrhs}));
+        g_list.emplace_back(
+            create_vector_on_precision<experimental::distributed::Vector,
+                                       value_type>(
+                precision, exec, next_comm, dim<2>{next_nrows, nrhs},
+                dim<2>{next_local_nrows, nrhs}));
+        e_list.emplace_back(
+            create_vector_on_precision<experimental::distributed::Vector,
+                                       value_type>(
+                precision, exec, next_comm, dim<2>{next_nrows, nrhs},
+                dim<2>{next_local_nrows, nrhs}));
         next_one_list.emplace_back(
             initialize<dense_vec>({one<value_type>()}, exec));
     }

--- a/core/solver/multigrid.cpp
+++ b/core/solver/multigrid.cpp
@@ -410,6 +410,41 @@ std::unique_ptr<LinOp> create_vector_on_precision(
     }
 }
 
+// This will cast the input scalar (float) to the precision of linop
+void fill_scalar(LinOp* linop, float scalar)
+{
+#if GINKGO_BUILD_MPI
+    if (dynamic_cast<DistributedBase*>(linop)) {
+        run<experimental::distributed::Vector,
+#if GINKGO_ENABLE_HALF
+            gko::float16, std::complex<gko::float16>,
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+            gko::bfloat16, std::complex<gko::bfloat16>,
+#endif
+            float, double, std::complex<float>, std::complex<double>>(
+            linop, [&](auto op) {
+                using value_type = typename decltype(*op)::value_type;
+                op->fill(static_cast<value_type>(scalar));
+            });
+        return;
+    }
+#endif
+    run<matrix::Dense,
+#if GINKGO_ENABLE_HALF
+        gko::float16, std::complex<gko::float16>,
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+        gko::bfloat16, std::complex<gko::bfloat16>,
+#endif
+        float, double, std::complex<float>, std::complex<double>>(
+        linop, [&](auto op) {
+            using value_type = typename std::decay_t<decltype(*op)>::value_type;
+            op->fill(static_cast<value_type>(scalar));
+        });
+}
+
+
 template <class VectorType>
 void MultigridState::allocate_memory(int level, multigrid::cycle cycle,
                                      size_type current_nrows,
@@ -433,7 +468,13 @@ void MultigridState::allocate_memory(int level, multigrid::cycle cycle,
         e_list.emplace_back(
             create_vector_on_precision<matrix::Dense, value_type>(
                 precision, exec, dim<2>{current_nrows, nrhs}));
-        next_one_list.emplace_back(initialize<vec>({one<value_type>()}, exec));
+        // Currently, next_one follow g, e when prolongation is RowGatherer
+        // if prolongation is usual matrix format supportting mixed precision,
+        // we need one follow prolongation precision and the other follow e.
+        auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+            precision, exec, dim<2>{1, 1}));
+        fill_scalar(tmp.get(), 1.0f);
+        next_one_list.emplace_back(tmp);
     }
     if (level + 1 == multigrid->get_mg_level_list().size()) {
         // the last level allocate the g, e for coarsest solver
@@ -443,10 +484,27 @@ void MultigridState::allocate_memory(int level, multigrid::cycle cycle,
         e_list.emplace_back(
             create_vector_on_precision<matrix::Dense, value_type>(
                 precision, exec, dim<2>{next_nrows, nrhs}));
-        next_one_list.emplace_back(initialize<vec>({one<value_type>()}, exec));
+        auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+            precision, exec, dim<2>{1, 1}));
+        fill_scalar(tmp.get(), 1.0f);
+        next_one_list.emplace_back(tmp);
     }
-    one_list.emplace_back(initialize<vec>({one<value_type>()}, exec));
-    neg_one_list.emplace_back(initialize<vec>({-one<value_type>()}, exec));
+    // follow r
+    auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+        precision, exec, dim<2>{1, 1}));
+    fill_scalar(tmp.get(), 1.0f);
+    one_list.emplace_back(tmp);
+    if (level == 0) {
+        // we take the first internal vector also here (but it is better to take
+        // matrix)
+        auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+            precision, exec, dim<2>{1, 1}));
+        fill_scalar(tmp.get(), -1.0f);
+        neg_one_list.emplace_back(tmp);
+    } else {
+        // follow matrix
+        neg_one_list.emplace_back(initialize<vec>({-one<value_type>()}, exec));
+    }
 }
 
 
@@ -487,8 +545,13 @@ void MultigridState::allocate_memory(
                                        value_type>(
                 precision, exec, current_comm, dim<2>{current_nrows, nrhs},
                 dim<2>{current_local_nrows, nrhs}));
-        next_one_list.emplace_back(
-            initialize<dense_vec>({one<value_type>()}, exec));
+        // Currently, next_one follow g, e when prolongation is RowGatherer
+        // if prolongation is usual matrix format supportting mixed precision,
+        // we need one follow prolongation precision and the other follow e.
+        auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+            precision, exec, dim<2>{1, 1}));
+        fill_scalar(tmp.get(), 1.0f);
+        next_one_list.emplace_back(tmp);
     }
     if (level + 1 == multigrid->get_mg_level_list().size()) {
         // the last level allocate the g, e for coarsest solver
@@ -502,12 +565,28 @@ void MultigridState::allocate_memory(
                                        value_type>(
                 precision, exec, next_comm, dim<2>{next_nrows, nrhs},
                 dim<2>{next_local_nrows, nrhs}));
-        next_one_list.emplace_back(
-            initialize<dense_vec>({one<value_type>()}, exec));
+        auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+            precision, exec, dim<2>{1, 1}));
+        fill_scalar(tmp.get(), 1.0f);
+        next_one_list.emplace_back(tmp);
     }
-    one_list.emplace_back(initialize<dense_vec>({one<value_type>()}, exec));
-    neg_one_list.emplace_back(
-        initialize<dense_vec>({-one<value_type>()}, exec));
+    // follow r
+    auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+        precision, exec, dim<2>{1, 1}));
+    fill_scalar(tmp.get(), 1.0f);
+    one_list.emplace_back(tmp);
+    if (level == 0) {
+        // we take the first internal vector also here (but it is better to take
+        // matrix)
+        auto tmp = share(create_vector_on_precision<matrix::Dense, value_type>(
+            precision, exec, dim<2>{1, 1}));
+        fill_scalar(tmp.get(), -1.0f);
+        neg_one_list.emplace_back(tmp);
+    } else {
+        // follow matrix
+        neg_one_list.emplace_back(
+            initialize<dense_vec>({-one<value_type>()}, exec));
+    }
 }
 
 
@@ -551,6 +630,7 @@ void MultigridState::run_mg_cycle(multigrid::cycle cycle, size_type level,
 }
 
 
+// Noneed template
 template <typename VectorType>
 void MultigridState::run_cycle(multigrid::cycle cycle, size_type level,
                                const std::shared_ptr<const LinOp>& matrix,
@@ -591,7 +671,7 @@ void MultigridState::run_cycle(multigrid::cycle cycle, size_type level,
             } else {
                 // x in first level is already filled by zero outside.
                 if (level != 0) {
-                    dynamic_cast<VectorType*>(x)->fill(zero<value_type>());
+                    fill_scalar(x, 0.0f);
                 }
                 pre_smoother->apply(b, x);
             }
@@ -612,7 +692,7 @@ void MultigridState::run_cycle(multigrid::cycle cycle, size_type level,
     // next level
     if (level + 1 == total_level) {
         // the coarsest solver use the last level valuetype
-        as<VectorType>(e)->fill(zero<value_type>());
+        fill_scalar(e.get(), 0.0f);
     }
     auto next_level_matrix =
         (level + 1 < total_level)
@@ -941,6 +1021,7 @@ void Multigrid::apply_with_initial_guess_impl(const LinOp* b, LinOp* x,
         return;
     }
 
+    // this may rely on b and x not mg_level anymore?
     auto lambda = [this, guess](auto mg_level, auto b, auto x) {
         using value_type =
             typename std::decay_t<decltype(*mg_level)>::value_type;

--- a/include/ginkgo/core/solver/multigrid.hpp
+++ b/include/ginkgo/core/solver/multigrid.hpp
@@ -43,6 +43,30 @@ namespace multigrid {
 
 
 /**
+ * A enum to specify the precision of stored data.
+ *
+ * follow the multivector, any means follows the multigridlevel precision
+ */
+enum struct precision {
+    none,  //!< no precision information is available, incompatible with all
+           //!< other precisions
+    any,   //!< compatible with all other precisions, including none
+    fp32,
+    complex_fp32,
+    fp64,
+    complex_fp64,
+#if GINKGO_ENABLE_HALF
+    fp16,
+    complex_fp16,
+#endif
+#if GINKGO_ENABLE_BFLOAT16
+    bf16,
+    complex_bf16,
+#endif
+};
+
+
+/**
  * cycle defines which kind of multigrid cycle can be used.
  * It contains V, W, and F cycle.
  * - V, W cycle uses the algorithm according to Briggs, Henson, and McCormick: A
@@ -199,6 +223,14 @@ public:
          */
         std::vector<std::shared_ptr<const LinOpFactory>>
             GKO_DEFERRED_FACTORY_VECTOR_PARAMETER(mg_level);
+
+
+        /**
+         * Multigrid working precision list, controlled by level_selector when
+         * size > 1
+         */
+        std::vector<multigrid::precision> GKO_FACTORY_PARAMETER_VECTOR(
+            precision, multigrid::precision::any);
 
         /**
          * Custom selector size_type (size_type level, const LinOp* fine_matrix)

--- a/reference/test/solver/multigrid_kernels.cpp
+++ b/reference/test/solver/multigrid_kernels.cpp
@@ -2,10 +2,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <string>
+#include <vector>
+
 #include <gtest/gtest.h>
 
 #include <ginkgo/core/base/exception.hpp>
 #include <ginkgo/core/base/executor.hpp>
+#include <ginkgo/core/log/profiler_hook.hpp>
 #include <ginkgo/core/matrix/csr.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
 #include <ginkgo/core/multigrid/pgm.hpp>
@@ -1296,6 +1300,42 @@ TYPED_TEST(Multigrid, SolvesStencilSystemByFCycle)
     solver->apply(b, x);
 
     GKO_ASSERT_MTX_NEAR(x, l({1.0, 3.0, 2.0}), r<value_type>::value);
+}
+
+std::pair<gko::log::ProfilerHook::hook_function,
+          gko::log::ProfilerHook::hook_function>
+make_hooks(std::vector<std::string>& output)
+{
+    return std::make_pair(
+        [&output](const char* msg, gko::log::profile_event_category) {
+            output.push_back(std::string{"begin:"} + msg);
+        },
+        [&output](const char* msg, gko::log::profile_event_category) {
+            output.push_back(std::string{"end:"} + msg);
+        });
+}
+
+TYPED_TEST(Multigrid, CheckApply)
+{
+    using Mtx = typename TestFixture::Mtx;
+    using value_type = typename TestFixture::value_type;
+    auto multigrid_factory =
+        this->get_multigrid_factory(gko::solver::multigrid::cycle::v);
+    auto solver = multigrid_factory->generate(this->mtx);
+    solver->set_stop_criterion_factory(
+        gko::stop::Iteration::build().with_max_iters(1u));
+    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
+    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+
+    std::vector<std::string> output;
+    auto hooks = make_hooks(output);
+    auto logger = gko::log::ProfilerHook::create_custom(
+        std::move(hooks.first), std::move(hooks.second));
+    this->exec->add_logger(logger);
+    solver->apply(b, x);
+    for (const auto& s : output) {
+        std::cout << s << std::endl;
+    }
 }
 
 

--- a/reference/test/solver/multigrid_kernels.cpp
+++ b/reference/test/solver/multigrid_kernels.cpp
@@ -37,7 +37,8 @@ namespace {
 int global_step = 0;
 
 
-void assert_same_vector(std::vector<int> v1, std::vector<int> v2)
+template <typename T>
+void assert_same_vector(const std::vector<T>& v1, std::vector<T> v2)
 {
     ASSERT_EQ(v1.size(), v2.size());
     for (gko::size_type i = 0; i < v1.size(); i++) {
@@ -400,7 +401,7 @@ protected:
                 .on(this->exec));
     }
 
-    std::shared_ptr<const gko::ReferenceExecutor> exec;
+    std::shared_ptr<gko::ReferenceExecutor> exec;
     std::shared_ptr<Csr> mtx;
     std::shared_ptr<Csr> mtx2;
     std::shared_ptr<typename Coarse::Factory> coarse_factory;
@@ -1308,34 +1309,190 @@ make_hooks(std::vector<std::string>& output)
 {
     return std::make_pair(
         [&output](const char* msg, gko::log::profile_event_category) {
-            output.push_back(std::string{"begin:"} + msg);
+            output.push_back(msg);
         },
-        [&output](const char* msg, gko::log::profile_event_category) {
-            output.push_back(std::string{"end:"} + msg);
-        });
+        [](const char* msg, gko::log::profile_event_category) {});
 }
 
-TYPED_TEST(Multigrid, CheckApply)
+std::vector<std::string> extract_info(const std::vector<std::string>& input)
 {
-    using Mtx = typename TestFixture::Mtx;
-    using value_type = typename TestFixture::value_type;
-    auto multigrid_factory =
-        this->get_multigrid_factory(gko::solver::multigrid::cycle::v);
-    auto solver = multigrid_factory->generate(this->mtx);
-    solver->set_stop_criterion_factory(
-        gko::stop::Iteration::build().with_max_iters(1u));
-    auto b = gko::initialize<Mtx>({-1.0, 3.0, 1.0}, this->exec);
-    auto x = gko::initialize<Mtx>({0.0, 0.0, 0.0}, this->exec);
+    std::vector<std::string> result;
+    for (const auto& s : input) {
+        if (s.find("apply") == std::string::npos) {
+            continue;
+        }
+        if (s.find("multigrid") != std::string::npos) {
+            continue;
+        }
+        // if (s.find("restrict") != std::string::npos || s.find("prolong") !=
+        // std::string::npos || s.find("coarse") != std::string::npos ||
+        // s.find("system") != std::string::npos) {
+        //     result.push_back(s);
+        // }
+        result.push_back(s);
+    }
+    return result;
+}
 
+void setup_name(std::shared_ptr<gko::log::ProfilerHook> logger,
+                gko::solver::Multigrid* mg)
+{
+    auto mg_list = mg->get_mg_level_list();
+    for (int i = 0; i < mg_list.size(); i++) {
+        // because we do not change the fine matrix from given one, coarse is
+        // equal to next fine
+        logger->set_object_name(mg_list.at(i)->get_coarse_op(),
+                                "coarse_" + std::to_string(i));
+        logger->set_object_name(mg_list.at(i)->get_restrict_op(),
+                                "restrict_" + std::to_string(i));
+        logger->set_object_name(mg_list.at(i)->get_prolong_op(),
+                                "prolong_" + std::to_string(i));
+    }
+    logger->set_object_name(mg->get_system_matrix(), "system");
+    logger->set_object_name(mg->get_coarsest_solver(), "coarsest_solver");
+    logger->set_object_name(mg, "multigrid");
+}
+
+
+TEST(MixedMultigrid, CheckApply)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    auto multigrid_factory =
+        gko::solver::Multigrid::build()
+            .with_max_levels(2u)
+            .with_pre_smoother(nullptr)
+            .with_mid_smoother(nullptr)
+            .with_mg_level(DummyMultigridLevelWithFactory<double>::build())
+            .with_coarsest_solver(DummyLinOpWithFactory<double>::build())
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(1u))
+            .with_min_coarse_rows(1u)
+            .on(exec);
+    auto mtx = gko::share(DummyLinOp::create(exec, gko::dim<2>{3, 3}));
+    auto solver = multigrid_factory->generate(mtx);
+    auto b =
+        gko::initialize<gko::matrix::Dense<double>>({-1.0, 3.0, 1.0}, exec);
+    auto x = gko::initialize<gko::matrix::Dense<double>>({0.0, 0.0, 0.0}, exec);
     std::vector<std::string> output;
     auto hooks = make_hooks(output);
     auto logger = gko::log::ProfilerHook::create_custom(
         std::move(hooks.first), std::move(hooks.second));
-    this->exec->add_logger(logger);
+    setup_name(logger, solver.get());
+
+    exec->add_logger(logger);
     solver->apply(b, x);
-    for (const auto& s : output) {
-        std::cout << s << std::endl;
-    }
+    exec->remove_logger(logger);
+
+    output = extract_info(output);
+    assert_same_vector(
+        output, {
+                    // clang-format off
+            "advanced_apply(gko::matrix::Dense<double> * system * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)",
+            "apply(restrict_0 * gko::matrix::Dense<double> = gko::matrix::Dense<double>)",
+            "advanced_apply(gko::matrix::Dense<double> * coarse_0 * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)",
+            "apply(restrict_1 * gko::matrix::Dense<double> = gko::matrix::Dense<double>)",
+            "apply(coarsest_solver * gko::matrix::Dense<double> = gko::matrix::Dense<double>)",
+            "advanced_apply(gko::matrix::Dense<double> * prolong_1 * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)",
+            "advanced_apply(gko::matrix::Dense<double> * prolong_0 * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)"
+                    // clang-format on
+                });
+}
+
+
+TEST(MixedMultigrid, CheckApplyMixed)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    auto multigrid_factory =
+        gko::solver::Multigrid::build()
+            .with_max_levels(2u)
+            .with_pre_smoother(nullptr)
+            .with_mid_smoother(nullptr)
+            .with_mg_level(DummyMultigridLevelWithFactory<double>::build(),
+                           DummyMultigridLevelWithFactory<float>::build())
+            .with_coarsest_solver(DummyLinOpWithFactory<float>::build())
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(1u))
+            .with_min_coarse_rows(1u)
+            .on(exec);
+    auto mtx = gko::share(DummyLinOp::create(exec, gko::dim<2>{3, 3}));
+    auto solver = multigrid_factory->generate(mtx);
+    auto b =
+        gko::initialize<gko::matrix::Dense<double>>({-1.0, 3.0, 1.0}, exec);
+    auto x = gko::initialize<gko::matrix::Dense<double>>({0.0, 0.0, 0.0}, exec);
+    std::vector<std::string> output;
+    auto hooks = make_hooks(output);
+    auto logger = gko::log::ProfilerHook::create_custom(
+        std::move(hooks.first), std::move(hooks.second));
+    setup_name(logger, solver.get());
+
+    exec->add_logger(logger);
+    solver->apply(b, x);
+    exec->remove_logger(logger);
+
+    output = extract_info(output);
+    assert_same_vector(
+        output,
+        {
+            // clang-format off
+            "advanced_apply(gko::matrix::Dense<double> * system * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)",
+            "apply(restrict_0 * gko::matrix::Dense<double> = gko::matrix::Dense<float>)",
+            "advanced_apply(gko::matrix::Dense<float> * coarse_0 * gko::matrix::Dense<float> + gko::matrix::Dense<float> * gko::matrix::Dense<float>)",
+            "apply(restrict_1 * gko::matrix::Dense<float> = gko::matrix::Dense<float>)",
+            "apply(coarsest_solver * gko::matrix::Dense<float> = gko::matrix::Dense<float>)",
+            "advanced_apply(gko::matrix::Dense<float> * prolong_1 * gko::matrix::Dense<float> + gko::matrix::Dense<float> * gko::matrix::Dense<float>)",
+            // beta is same as b, which is fine for prolongation as row_gatherer
+            "advanced_apply(gko::matrix::Dense<float> * prolong_0 * gko::matrix::Dense<float> + gko::matrix::Dense<float> * gko::matrix::Dense<double>)"
+            // clang-format on
+        });
+}
+
+
+TEST(MixedMultigrid, CheckApplyMixedInternal)
+{
+    auto exec = gko::ReferenceExecutor::create();
+    auto multigrid_factory =
+        gko::solver::Multigrid::build()
+            .with_max_levels(2u)
+            .with_pre_smoother(nullptr)
+            .with_mid_smoother(nullptr)
+            .with_mg_level(DummyMultigridLevelWithFactory<float>::build(),
+                           DummyMultigridLevelWithFactory<float>::build())
+            //    first vector need to be fp64 to keep matrix apply in the first
+            //    level because we do not use matrix to get precision yet
+            .with_precision(gko::solver::multigrid::precision::fp64,
+                            gko::solver::multigrid::precision::fp64)
+            .with_coarsest_solver(DummyLinOpWithFactory<float>::build())
+            .with_criteria(gko::stop::Iteration::build().with_max_iters(1u))
+            .with_min_coarse_rows(1u)
+            .on(exec);
+    auto mtx = gko::share(DummyLinOp::create(exec, gko::dim<2>{3, 3}));
+    auto solver = multigrid_factory->generate(mtx);
+    auto b =
+        gko::initialize<gko::matrix::Dense<double>>({-1.0, 3.0, 1.0}, exec);
+    auto x = gko::initialize<gko::matrix::Dense<double>>({0.0, 0.0, 0.0}, exec);
+    std::vector<std::string> output;
+    auto hooks = make_hooks(output);
+    auto logger = gko::log::ProfilerHook::create_custom(
+        std::move(hooks.first), std::move(hooks.second));
+    setup_name(logger, solver.get());
+
+    exec->add_logger(logger);
+    solver->apply(b, x);
+    exec->remove_logger(logger);
+
+    output = extract_info(output);
+    assert_same_vector(
+        output,
+        {
+            // clang-format off
+                    // the first one b is float because the apply_with_initial_guess use first mg_level precision (might need to change)
+            "advanced_apply(gko::matrix::Dense<double> * system * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)",
+            "apply(restrict_0 * gko::matrix::Dense<double> = gko::matrix::Dense<double>)",
+            "advanced_apply(gko::matrix::Dense<float> * coarse_0 * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)",
+            "apply(restrict_1 * gko::matrix::Dense<double> = gko::matrix::Dense<double>)",
+            "apply(coarsest_solver * gko::matrix::Dense<double> = gko::matrix::Dense<double>)",
+            "advanced_apply(gko::matrix::Dense<double> * prolong_1 * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<double>)",
+            "advanced_apply(gko::matrix::Dense<double> * prolong_0 * gko::matrix::Dense<double> + gko::matrix::Dense<double> * gko::matrix::Dense<float>)"
+            // clang-format on
+        });
 }
 
 


### PR DESCRIPTION
This provides different way to handle internal vector precision for different level.
This will enable more flexible setting and more performance benefit from mixed-precision by keeping the vector in higher precision than matrices' shown in my dissertation.

In https://github.com/ginkgo-project/ginkgo/tree/four_multigrid_exp, I have set the vector precision via `Pgm`.
In that branch, I also had separate precision for generation to keep the same generation even in mixed-precision. It leads three precision setup in Pgm class (coarse precision, working precision, multigrid precision). In the example, I feel it a bit hard to use. 

In this PR, use precision list from enum (if we use in multivector) to adjust these internal vector could be better to handle.
using any will follow the original MultigridLevel precision.

For generating in high precision, we can still handle in Pgm or adding convert_to to different precision

TODO:
- [ ] need to adjust one_list precision
- [x] test
