### PR TITLE
Force host stop status

### DIFF
--- a/core/stop/criterion.cpp
+++ b/core/stop/criterion.cpp
@@ -23,7 +23,7 @@ GKO_REGISTER_OPERATION(set_all_statuses, set_all_statuses::set_all_statuses);
 void Criterion::set_all_statuses(uint8 stoppingId, bool setFinalized,
                                  array<stopping_status>* stop_status)
 {
-    this->get_executor()->run(criterion::make_set_all_statuses(
+    stop_status->get_executor()->run(criterion::make_set_all_statuses(
         stoppingId, setFinalized, *stop_status));
 }
 

--- a/core/stop/residual_norm.cpp
+++ b/core/stop/residual_norm.cpp
@@ -158,6 +158,9 @@ ResidualNormBase<ValueType>::ResidualNormBase(
         GKO_NOT_SUPPORTED(nullptr);
     }
     this->u_dense_tau_ = NormVector::create_with_config_of(this->starting_tau_);
+    this->host_starting_tau_ = this->starting_tau_->clone(exec->get_master());
+    this->host_dense_tau_ =
+        NormVector::create_with_config_of(this->host_starting_tau_);
 }
 
 
@@ -196,11 +199,22 @@ bool ResidualNormBase<ValueType>::check_impl(
     }
     bool all_converged = true;
 
-    this->get_executor()->run(residual_norm::make_residual_norm(
-        dense_tau->get_const_device_view(),
-        starting_tau_->get_const_device_view(), reduction_factor_, stopping_id,
-        set_finalized, *stop_status, device_storage_, &all_converged,
-        one_changed));
+    if (this->get_executor() == stop_status->get_executor()) {
+        this->get_executor()->run(residual_norm::make_residual_norm(
+            dense_tau->get_const_device_view(),
+            starting_tau_->get_const_device_view(), reduction_factor_,
+            stopping_id, set_finalized, *stop_status, device_storage_,
+            &all_converged, one_changed));
+    } else {
+        host_dense_tau_->copy_from(dense_tau);
+        // device_storage is not used in omp/reference
+        stop_status->get_executor()->get_master()->run(
+            residual_norm::make_residual_norm(
+                host_dense_tau_->get_const_device_view(),
+                host_starting_tau_->get_const_device_view(), reduction_factor_,
+                stopping_id, set_finalized, *stop_status, device_storage_,
+                &all_converged, one_changed));
+    }
 
     return all_converged;
 }

--- a/core/stop/residual_norm.cpp
+++ b/core/stop/residual_norm.cpp
@@ -233,12 +233,26 @@ bool ImplicitResidualNorm<ValueType>::check_impl(
     }
     bool all_converged = true;
 
-    this->get_executor()->run(
-        implicit_residual_norm::make_implicit_residual_norm(
-            dense_tau->get_const_device_view(),
-            this->starting_tau_->get_const_device_view(),
-            this->reduction_factor_, stopping_id, set_finalized, *stop_status,
-            this->device_storage_, &all_converged, one_changed));
+    if (this->get_executor() == stop_status->get_executor()) {
+        this->get_executor()->run(
+            implicit_residual_norm::make_implicit_residual_norm(
+                dense_tau->get_const_device_view(),
+                this->starting_tau_->get_const_device_view(),
+                this->reduction_factor_, stopping_id, set_finalized,
+                *stop_status, this->device_storage_, &all_converged,
+                one_changed));
+    } else {
+        this->host_vector_dense_tau_->copy_from(dense_tau);
+        // device_storage is not used in omp/reference
+        stop_status->get_executor()->run(
+            implicit_residual_norm::make_implicit_residual_norm(
+                this->host_vector_dense_tau_->get_const_device_view(),
+                this->host_starting_tau_->get_const_device_view(),
+                this->reduction_factor_, stopping_id, set_finalized,
+                *stop_status, this->device_storage_, &all_converged,
+                one_changed));
+    }
+
 
     return all_converged;
 }

--- a/include/ginkgo/core/solver/workspace.hpp
+++ b/include/ginkgo/core/solver/workspace.hpp
@@ -132,28 +132,19 @@ public:
         GKO_ASSERT(array_id >= 0 && array_id < arrays_.size());
         auto& array = arrays_[array_id];
         if (array.empty()) {
-            auto& result =
-                array.template init<ValueType>(this->get_executor(), 0);
-            return result;
+            if constexpr (std::is_same_v<ValueType, stopping_status>) {
+                auto& result = array.template init<ValueType>(
+                    this->get_executor()->get_master(), 0);
+                return result;
+            } else {
+                auto& result =
+                    array.template init<ValueType>(this->get_executor(), 0);
+                return result;
+            }
         }
         // array types should not change!
         GKO_ASSERT(array.template contains<ValueType>());
         return array.template get<ValueType>();
-    }
-
-    template <>
-    array<stopping_status>& init_or_get_array<stopping_status>(int array_id)
-    {
-        GKO_ASSERT(array_id >= 0 && array_id < arrays_.size());
-        auto& array = arrays_[array_id];
-        if (array.empty()) {
-            auto& result = array.template init<stopping_status>(
-                this->get_executor()->get_master(), 0);
-            return result;
-        }
-        // array types should not change!
-        GKO_ASSERT(array.template contains<stopping_status>());
-        return array.template get<stopping_status>();
     }
 
     template <typename ValueType>

--- a/include/ginkgo/core/solver/workspace.hpp
+++ b/include/ginkgo/core/solver/workspace.hpp
@@ -132,15 +132,9 @@ public:
         GKO_ASSERT(array_id >= 0 && array_id < arrays_.size());
         auto& array = arrays_[array_id];
         if (array.empty()) {
-            if constexpr (std::is_same_v<ValueType, stopping_status>) {
-                auto& result = array.template init<ValueType>(
-                    this->get_executor()->get_master(), 0);
-                return result;
-            } else {
-                auto& result =
-                    array.template init<ValueType>(this->get_executor(), 0);
-                return result;
-            }
+            auto& result =
+                array.template init<ValueType>(this->get_executor(), 0);
+            return result;
         }
         // array types should not change!
         GKO_ASSERT(array.template contains<ValueType>());

--- a/include/ginkgo/core/solver/workspace.hpp
+++ b/include/ginkgo/core/solver/workspace.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -139,6 +139,21 @@ public:
         // array types should not change!
         GKO_ASSERT(array.template contains<ValueType>());
         return array.template get<ValueType>();
+    }
+
+    template <>
+    array<stopping_status>& init_or_get_array<stopping_status>(int array_id)
+    {
+        GKO_ASSERT(array_id >= 0 && array_id < arrays_.size());
+        auto& array = arrays_[array_id];
+        if (array.empty()) {
+            auto& result = array.template init<stopping_status>(
+                this->get_executor()->get_master(), 0);
+            return result;
+        }
+        // array types should not change!
+        GKO_ASSERT(array.template contains<stopping_status>());
+        return array.template get<stopping_status>();
     }
 
     template <typename ValueType>

--- a/include/ginkgo/core/stop/criterion.hpp
+++ b/include/ginkgo/core/stop/criterion.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -142,8 +142,16 @@ public:
             this, updater.num_iterations_, updater.residual_,
             updater.residual_norm_, updater.solution_, stopping_id,
             set_finalized);
-        auto all_converged = this->check_impl(
-            stopping_id, set_finalized, stop_status, one_changed, updater);
+        auto status_ptr = stop_status;
+        if (host_stop_status.get_executor() != stop_status->get_executor()) {
+            host_stop_status = *stop_status;
+            status_ptr = &host_stop_status;
+        }
+        auto all_converged = this->check_impl(stopping_id, set_finalized,
+                                              status_ptr, one_changed, updater);
+        if (host_stop_status.get_executor() != stop_status->get_executor()) {
+            *stop_status = host_stop_status;
+        }
         this->template log<log::Logger::criterion_check_completed>(
             this, updater.num_iterations_, updater.residual_,
             updater.residual_norm_, updater.implicit_sq_residual_norm_,
@@ -187,8 +195,12 @@ protected:
                           array<stopping_status>* stop_status);
 
     explicit Criterion(std::shared_ptr<const gko::Executor> exec)
-        : EnableAbstractPolymorphicObject<Criterion>(exec)
+        : EnableAbstractPolymorphicObject<Criterion>(exec),
+          host_stop_status(exec->get_master())
     {}
+
+private:
+    array<stopping_status> host_stop_status;
 };
 
 

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -221,8 +221,12 @@ protected:
               factory->get_executor(), args,
               factory->get_parameters().reduction_factor,
               factory->get_parameters().baseline),
-          parameters_{factory->get_parameters()}
+          parameters_{factory->get_parameters()},
+          host_vector_dense_tau_(
+              Vector::create(factory->get_executor()->get_master()))
     {}
+
+    std::unique_ptr<Vector> host_vector_dense_tau_{};
 };
 
 

--- a/include/ginkgo/core/stop/residual_norm.hpp
+++ b/include/ginkgo/core/stop/residual_norm.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -73,7 +73,9 @@ protected:
 
     remove_complex<ValueType> reduction_factor_{};
     std::unique_ptr<NormVector> starting_tau_{};
+    std::unique_ptr<NormVector> host_starting_tau_{};
     std::unique_ptr<NormVector> u_dense_tau_{};
+    std::unique_ptr<NormVector> host_dense_tau_{};
     /* Contains device side: all_converged and one_changed booleans */
     array<bool> device_storage_;
 


### PR DESCRIPTION
We can force the stop status on the host and make the check on host, which might be give some performance benefit. Originally, we have some tiny kernel call and tiny memory copy, but these tiny kernel calls do not utilize the GPU well.
Because we need to copy something back to CPU for iteration control, forcing stop status in host might reduce the kernel launch overhead.

This tries to sketch the experience from Petr. The current changes are not verified and performed in any experiments yet