### PR TITLE
Improve spmv (not fully and not keep in one kernel)

### DIFF
--- a/cuda/components/format_conversion.cuh
+++ b/cuda/components/format_conversion.cuh
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2024 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -78,13 +78,13 @@ __host__ size_type calculate_nwarps(std::shared_ptr<const CudaExecutor> exec,
     size_type nwarps_in_cuda = exec->get_num_multiprocessor() * warps_per_sm;
     size_type multiple = 8;
     if (nnz >= 2e8) {
-        multiple = 2048;
+        multiple = 1024;
     } else if (nnz >= 2e7) {
-        multiple = 512;
+        multiple = 256;
     } else if (nnz >= 2e6) {
-        multiple = 128;
+        multiple = 64;
     } else if (nnz >= 2e5) {
-        multiple = 32;
+        multiple = 16;
     }
 #ifdef GINKGO_BENCHMARK_ENABLE_TUNING
     if (_tuning_flag) {

--- a/include/ginkgo/core/matrix/csr.hpp
+++ b/include/ginkgo/core/matrix/csr.hpp
@@ -471,13 +471,13 @@ public:
             if (warp_size_ > 0) {
                 int multiple = 8;
                 if (nnz >= static_cast<int64_t>(2e8)) {
-                    multiple = 2048;
+                    multiple = 1024;
                 } else if (nnz >= static_cast<int64_t>(2e7)) {
-                    multiple = 512;
+                    multiple = 256;
                 } else if (nnz >= static_cast<int64_t>(2e6)) {
-                    multiple = 128;
+                    multiple = 64;
                 } else if (nnz >= static_cast<int64_t>(2e5)) {
-                    multiple = 32;
+                    multiple = 16;
                 }
                 if (strategy_name_ == "intel") {
                     multiple = 8;


### PR DESCRIPTION
The major of changes is to create a spmv kernel if all precision are the same.
When using the accessor, we always use int64 as index computation. Sometimes it leads not good performance. That's the reason behind #2050 . the pr should ensure all index computation not accidentally use int64 when we set to int32