### PR TITLE
Fix benchmark output parsing 

### DIFF
--- a/benchmark/spmv/spmv_common.hpp
+++ b/benchmark/spmv/spmv_common.hpp
@@ -1,10 +1,12 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef GINKGO_BENCHMARK_SPMV_SPMV_COMMON_HPP
 #define GINKGO_BENCHMARK_SPMV_SPMV_COMMON_HPP
 
+
+#include <sstream>
 
 #include "benchmark/utils/formats.hpp"
 #include "benchmark/utils/general.hpp"
@@ -89,9 +91,11 @@ struct SpmvBenchmark : Benchmark<spmv_benchmark_state<Generator>> {
             exec, gko::dim<2>{state.data.first.size[0], nrhs},
             gko::dim<2>{state.data.second[0], nrhs});
         if (do_print) {
-            std::cerr << "Matrix is of size (" << state.data.first.size[0]
-                      << ", " << state.data.first.size[1] << "), "
-                      << state.data.first.nonzeros.size() << std::endl;
+            std::ostringstream ss;
+            ss << "Matrix is of size (" << state.data.first.size[0] << ", "
+               << state.data.first.size[1] << "), "
+               << state.data.first.nonzeros.size();
+            print_line(ss.str());
         }
         test_case["rows"] = state.data.first.size[0];
         test_case["cols"] = state.data.first.size[1];

--- a/benchmark/utils/general.hpp
+++ b/benchmark/utils/general.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -163,6 +163,23 @@ void initialize_argument_parsing(int* argc, char** argv[], std::string& header,
     }
 }
 
+
+/**
+ * Writes a diagnostic message to stderr in a single write().
+ *
+ * std::cerr is unit-buffered, so each `<<` becomes its own write(). MPI
+ * launchers forward stderr through pipes and can misroute such fragments onto
+ * their stdout, corrupting the JSON that the benchmark tests parse from there.
+ *
+ * @param line  the message to print, without the trailing newline
+ */
+void print_line(std::string line)
+{
+    line += '\n';
+    std::cerr << line;
+}
+
+
 /**
  * Print general benchmark information using the common available parameters
  *
@@ -171,45 +188,20 @@ void initialize_argument_parsing(int* argc, char** argv[], std::string& header,
 void print_general_information(const std::string& extra,
                                std::shared_ptr<const gko::Executor> exec)
 {
-    std::cerr << gko::version_info::get() << std::endl
-              << "Running on " << exec->get_description() << std::endl
-              << "Running with " << FLAGS_warmup << " warm iterations and ";
+    std::ostringstream ss;
+    ss << gko::version_info::get() << '\n'
+       << "Running on " << exec->get_description() << '\n'
+       << "Running with " << FLAGS_warmup << " warm iterations and ";
     if (FLAGS_repetitions == "auto") {
-        std::cerr << "adaptively determined repetititions with "
-                  << FLAGS_min_repetitions
-                  << " <= rep <= " << FLAGS_max_repetitions
-                  << " and a minimal runtime of " << FLAGS_min_runtime << "s\n";
+        ss << "adaptively determined repetititions with "
+           << FLAGS_min_repetitions << " <= rep <= " << FLAGS_max_repetitions
+           << " and a minimal runtime of " << FLAGS_min_runtime << "s\n";
     } else {
-        std::cerr << FLAGS_repetitions << " running iterations\n";
+        ss << FLAGS_repetitions << " running iterations\n";
     }
-    std::cerr << "The random seed for right hand sides is " << FLAGS_seed
-              << '\n'
-              << extra << std::endl;
-}
-
-
-std::shared_ptr<gko::log::ProfilerHook> create_profiler_hook(
-    std::shared_ptr<const gko::Executor> exec)
-{
-    using gko::log::ProfilerHook;
-    std::map<std::string, std::function<std::shared_ptr<ProfilerHook>()>>
-        hook_map{
-            {"none", [] { return std::shared_ptr<ProfilerHook>{}; }},
-            {"auto", [&] { return ProfilerHook::create_for_executor(exec); }},
-            {"nvtx", [] { return ProfilerHook::create_nvtx(); }},
-            {"roctx", [] { return ProfilerHook::create_roctx(); }},
-            {"tau", [] { return ProfilerHook::create_tau(); }},
-            {"vtune", [] { return ProfilerHook::create_vtune(); }},
-            {"debug", [] {
-                 return ProfilerHook::create_custom(
-                     [](const char* name, gko::log::profile_event_category) {
-                         std::cerr << "DEBUG: begin " << name << '\n';
-                     },
-                     [](const char* name, gko::log::profile_event_category) {
-                         std::cerr << "DEBUG: end   " << name << '\n';
-                     });
-             }}};
-    return hook_map.at(FLAGS_profiler_hook)();
+    ss << "The random seed for right hand sides is " << FLAGS_seed << '\n'
+       << extra;
+    print_line(ss.str());
 }
 
 

--- a/benchmark/utils/runner.hpp
+++ b/benchmark/utils/runner.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2017 - 2025 The Ginkgo authors
+// SPDX-FileCopyrightText: 2017 - 2026 The Ginkgo authors
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
@@ -32,13 +32,13 @@ std::shared_ptr<gko::log::ProfilerHook> create_profiler_hook(
                      [do_print](const char* name,
                                 gko::log::profile_event_category) {
                          if (do_print) {
-                             std::cerr << "DEBUG: begin " << name << '\n';
+                             print_line("DEBUG: begin " + std::string{name});
                          }
                      },
                      [do_print](const char* name,
                                 gko::log::profile_event_category) {
                          if (do_print) {
-                             std::cerr << "DEBUG: end   " << name << '\n';
+                             print_line("DEBUG: end   " + std::string{name});
                          }
                      });
              }}};
@@ -119,8 +119,7 @@ void run_test_cases(const Benchmark<State>& benchmark,
             }
             auto test_case_desc = benchmark.describe_config(test_case);
             if (benchmark.should_print()) {
-                std::cerr << "Running test case " << test_case_desc
-                          << std::endl;
+                print_line("Running test case " + test_case_desc);
             }
             auto test_case_state = benchmark.setup(exec, test_case);
             auto test_case_range = annotate(test_case_desc.c_str());
@@ -132,8 +131,8 @@ void run_test_cases(const Benchmark<State>& benchmark,
                 }
                 benchmark_case[operation_name] = json::object();
                 if (benchmark.should_print()) {
-                    std::cerr << "\tRunning " << benchmark.get_name() << ": "
-                              << operation_name << std::endl;
+                    print_line("\tRunning " + benchmark.get_name() + ": " +
+                               operation_name);
                 }
                 auto& operation_case = benchmark_case[operation_name];
                 try {


### PR DESCRIPTION
Profiler hook benchmark logs each message to `std::cerr` in several unit-buffered << steps, and it seems that OpenMPI 5.0's IO forwarding occassionally splits these fragments causing parsing issues. [See CI failure](https://gitlab.com/ginkgo-project/ginkgo-public-ci/-/jobs/16262586321)

This PR assembles each diagnostic message into a string, and then writes it with a single << so every log line reaches stderr in one `write()` rather than three.  