### PR TITLE
Disable core dump for death tests

### DIFF
--- a/core/test/base/index_range.cpp
+++ b/core/test/base/index_range.cpp
@@ -105,7 +105,7 @@ TEST(DeathTest, Assertions)
 {
     // irange
     // end >= begin
-    EXPECT_EXIT((void)gko::irange<int>(1, 0), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)gko::irange<int>(1, 0));
 }
 
 

--- a/core/test/base/iterator_factory.cpp
+++ b/core/test/base/iterator_factory.cpp
@@ -231,13 +231,13 @@ TYPED_TEST(ZipIterator, IncompatibleIteratorDeathTest)
 
     // a set of operations that return inconsistent results for the two
     // different iterators
-    EXPECT_EXIT((void)(it2 - it1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(it2 == it1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(it2 != it1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(it1 < it2), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(it2 <= it1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(it2 > it1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(it1 >= it2), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(it2 - it1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(it2 == it1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(it2 != it1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(it1 < it2));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(it2 <= it1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(it2 > it1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(it1 >= it2));
 }
 
 

--- a/core/test/base/segmented_range.cpp
+++ b/core/test/base/segmented_range.cpp
@@ -212,33 +212,31 @@ TEST(DeathTest, Assertions)
                     static_cast<int>(ptrs.size() - 1)};
     vrange_t vrange2{ptrs.data(), values.data(), 0};
     // gko::segmented_index_range::iterator
-    EXPECT_EXIT((void)*(range_it_t{range, -1}), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)*(range_it_t{range, 1}), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(range_it_t{range, 0} == range_it_t{range2, 0}),
-                check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)*(range_it_t{range, -1}));
+    GKO_EXPECT_ASSERTION_FAILURE((void)*(range_it_t{range, 1}));
+    GKO_EXPECT_ASSERTION_FAILURE(
+        (void)(range_it_t{range, 0} == range_it_t{range2, 0}));
     // gko::segmented_index_range
-    EXPECT_EXIT((void)(range_t{nullptr, -1}), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)range[-1], check_assertion_exit_code, "");
-    EXPECT_EXIT((void)range[1], check_assertion_exit_code, "");
-    EXPECT_EXIT((void)range.begin_index(-1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)range.begin_index(1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)range.end_index(-1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)range.end_index(1), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(range_t{nullptr, -1}));
+    GKO_EXPECT_ASSERTION_FAILURE((void)range[-1]);
+    GKO_EXPECT_ASSERTION_FAILURE((void)range[1]);
+    GKO_EXPECT_ASSERTION_FAILURE((void)range.begin_index(-1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)range.begin_index(1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)range.end_index(-1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)range.end_index(1));
     // gko::segmented_value_range::iterator
-    EXPECT_EXIT((void)*(vrange_it_t{vrange, -1}), check_assertion_exit_code,
-                "");
-    EXPECT_EXIT((void)*(vrange_it_t{vrange, 1}), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(vrange_it_t{vrange, 0} == vrange_it_t{vrange2, 0}),
-                check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)*(vrange_it_t{vrange, -1}));
+    GKO_EXPECT_ASSERTION_FAILURE((void)*(vrange_it_t{vrange, 1}));
+    GKO_EXPECT_ASSERTION_FAILURE(
+        (void)(vrange_it_t{vrange, 0} == vrange_it_t{vrange2, 0}));
     // gko::segmented_value_range
-    EXPECT_EXIT((void)(vrange_t{nullptr, nullptr, -1}),
-                check_assertion_exit_code, "");
-    EXPECT_EXIT((void)vrange[-1], check_assertion_exit_code, "");
-    EXPECT_EXIT((void)vrange[1], check_assertion_exit_code, "");
-    EXPECT_EXIT((void)vrange.begin_index(-1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)vrange.begin_index(1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)vrange.end_index(-1), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)vrange.end_index(1), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(vrange_t{nullptr, nullptr, -1}));
+    GKO_EXPECT_ASSERTION_FAILURE((void)vrange[-1]);
+    GKO_EXPECT_ASSERTION_FAILURE((void)vrange[1]);
+    GKO_EXPECT_ASSERTION_FAILURE((void)vrange.begin_index(-1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)vrange.begin_index(1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)vrange.end_index(-1));
+    GKO_EXPECT_ASSERTION_FAILURE((void)vrange.end_index(1));
 }
 
 

--- a/core/test/matrix/device_views.cpp
+++ b/core/test/matrix/device_views.cpp
@@ -44,9 +44,9 @@ TYPED_TEST(DenseView, AssertTriggersInConstructorDeathTest)
     gko::matrix::view::dense<TypeParam> view{gko::dim<2>{2, 2}, 3,
                                              values.data()};
 
-    EXPECT_EXIT((void)(view(3, 0)), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view(0, 3)), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view(3, 3)), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view(3, 0)));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view(0, 3)));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view(3, 3)));
 }
 
 
@@ -56,9 +56,8 @@ TYPED_TEST(DenseView, AssertTriggersOnOutOfBoundsDeathTest)
     GTEST_SKIP() << "Assertion is only enabled in debug mode";
 #endif
 
-    EXPECT_EXIT((void)(gko::matrix::view::dense<TypeParam>{gko::dim<2>{2, 2}, 1,
-                                                           nullptr}),
-                check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(gko::matrix::view::dense<TypeParam>{
+        gko::dim<2>{2, 2}, 1, nullptr}));
 }
 
 
@@ -188,9 +187,9 @@ TYPED_TEST(EllView, AssertTriggersInConstructorDeathTest)
     using value_type = typename TestFixture::value_type;
     using index_type = typename TestFixture::index_type;
     // stride is smaller than dim[0]
-    EXPECT_EXIT((void)(gko::matrix::view::ell<value_type, index_type>{
-                    gko::dim<2>{2, 5}, 3, 1, nullptr, nullptr}),
-                check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE(
+        (void)(gko::matrix::view::ell<value_type, index_type>{
+            gko::dim<2>{2, 5}, 3, 1, nullptr, nullptr}));
 }
 
 
@@ -208,14 +207,14 @@ TYPED_TEST(EllView, AssertTriggersOnOutOfBoundsDeathTest)
         gko::dim<2>{2, 5}, 3, 4, values.data(), col_idxs.data()};
 
     // access exceed nonzero per row
-    EXPECT_EXIT((void)(view.val_at(1, 3)), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view.col_at(1, 3)), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.val_at(1, 3)));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.col_at(1, 3)));
     // access exceed the dimension
-    EXPECT_EXIT((void)(view.val_at(2, 0)), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view.col_at(2, 0)), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.val_at(2, 0)));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.col_at(2, 0)));
     // access exceed the stride
-    EXPECT_EXIT((void)(view.val_at(4, 0)), check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view.col_at(4, 0)), check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.val_at(4, 0)));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.col_at(4, 0)));
 }
 
 
@@ -303,13 +302,9 @@ TYPED_TEST(SellpView, AssertTriggersOnOutOfBoundsDeathTest)
                                                           slice_sets.data()};
 
     // access exceed row per slice
-    EXPECT_EXIT((void)(view.val_at(2, slice_sets.at(0), 0)),
-                check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view.col_at(2, slice_sets.at(0), 0)),
-                check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.val_at(2, slice_sets.at(0), 0)));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.col_at(2, slice_sets.at(0), 0)));
     // access exceed the total col
-    EXPECT_EXIT((void)(view.val_at(0, slice_sets.at(0), 7)),
-                check_assertion_exit_code, "");
-    EXPECT_EXIT((void)(view.col_at(0, slice_sets.at(0), 7)),
-                check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.val_at(0, slice_sets.at(0), 7)));
+    GKO_EXPECT_ASSERTION_FAILURE((void)(view.col_at(0, slice_sets.at(0), 7)));
 }

--- a/core/test/matrix/hybrid.cpp
+++ b/core/test/matrix/hybrid.cpp
@@ -502,6 +502,6 @@ TEST(HybridView, CreateFailsWithNonMatchingSizes)
         exec, gko::dim<2>(2, 1));
 
     using view_t = gko::matrix::view::hybrid<value_type, index_type>;
-    EXPECT_EXIT(view_t(ell->get_device_view(), coo->get_device_view()),
-                check_assertion_exit_code, "");
+    GKO_EXPECT_ASSERTION_FAILURE(
+        view_t(ell->get_device_view(), coo->get_device_view()));
 }

--- a/core/test/solver/workspace.cpp
+++ b/core/test/solver/workspace.cpp
@@ -181,8 +181,7 @@ TEST_F(Workspace, AbortsOnDifferentArrayTypes)
     ws.set_size(0, 1);
     ws.create_or_get_array<double>(0, 3);
 
-    EXPECT_EXIT(ws.create_or_get_array<int>(0, 4), check_assertion_exit_code,
-                "");
+    GKO_EXPECT_ASSERTION_FAILURE(ws.create_or_get_array<int>(0, 4));
 }
 
 

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -522,7 +522,7 @@ inline bool check_assertion_exit_code(int exit_code)
 inline void disable_core_dump()
 {
 #ifdef __linux__
-    prctl(PR_SET_DUMPABLE, 0, 0, 0, 0);
+    prctl(PR_SET_DUMPABLE, 0);
 #endif
 }
 

--- a/core/test/utils.hpp
+++ b/core/test/utils.hpp
@@ -13,6 +13,10 @@
 #include <tuple>
 #include <type_traits>
 
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
+
 #include <gtest/gtest.h>
 
 #include <ginkgo/core/base/math.hpp>
@@ -508,6 +512,30 @@ inline bool check_assertion_exit_code(int exit_code)
     return exit_code != 0;
 #endif
 }
+
+
+// Death tests abort the forked child, which hands it to the system core dump
+// collector. The kernel waits for that collector before reaping the child, and
+// on some machines it stalls for minutes per check. Note that `ulimit -c 0`
+// does not help: RLIMIT_CORE is ignored when core_pattern pipes core dumps to
+// a program, see `man 5 core`.
+inline void disable_core_dump()
+{
+#ifdef __linux__
+    prctl(PR_SET_DUMPABLE, 0, 0, 0, 0);
+#endif
+}
+
+
+// Checks that `_statement` aborts by failing a GKO_ASSERT. Preferred over a
+// bare EXPECT_EXIT, which leaves a core dump behind for every check.
+#define GKO_EXPECT_ASSERTION_FAILURE(_statement) \
+    EXPECT_EXIT(                                 \
+        {                                        \
+            disable_core_dump();                 \
+            _statement;                          \
+        },                                       \
+        check_assertion_exit_code, "")
 
 
 #endif  // GKO_CORE_TEST_UTILS_HPP_


### PR DESCRIPTION
This PR fixes the issue with timeouts for the death tests on debug builds.